### PR TITLE
Support for loading validator signing keys from Hashi Vault

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,7 @@ CONSENSUS_ENDPOINTS=http://localhost:3500
 # Authentication token for Hashi vault. Since the token is used only once on
 # application start, it does not need to be long-lived, however application
 # need to be able to re-acquire it after restart
-# HASHI_VAULT_TOKEN=s.dcefaaead40095d748ab
+# HASHI_VAULT_TOKEN=<vault token>
 # A key path in the K/V secret engine that holds signing keys.
 # Internal structure of the secret must hold public validator keys in hex form without 0x as
 # secret keys, and signing keys in hex form without 0x prefix  as secret vault.

--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,17 @@ CONSENSUS_ENDPOINTS=http://localhost:3500
 # URL to the remote signer. Default is None - using local keystores.
 # REMOTE_SIGNER_URL=http://remote-signer:9000
 
+# URL to the hashi vault. Default is None - using local keystores or remote signer.
+# HASHI_VAULT_URL=http://vault:8200
+# Authentication token for Hashi vault. Since the token is used only once on
+# application start, it does not need to be long-lived, however application
+# need to be able to re-acquire it after restart
+# HASHI_VAULT_TOKEN=s.dcefaaead40095d748ab
+# A key path in the K/V secret engine that holds signing keys.
+# Internal structure of the secret must hold public validator keys in hex form without 0x as
+# secret keys, and signing keys in hex form without 0x prefix  as secret vault.
+# HASHI_VAULT_KEY_PATH=path/inside/hashi/vault/k/v/engine
+
 # Path to the deposit_data.json file
 # Default is ${DATA_DIR}/${VAULT_CONTRACT_ADDRESS}/deposit_data.json
 # DEPOSIT_DATA_FILE=/home/user/.stakewise/${VAULT_CONTRACT_ADDRESS}/deposit_data.json

--- a/README.md
+++ b/README.md
@@ -344,6 +344,45 @@ You should see a message similar to this one after starting the operator:
 Using remote signer at http://remote-signer:9000 for 10 public keys
 ```
 
+## Hashi Vault
+
+Operator supports loading signing keys from remote [Hashi Vault](https://github.com/hashicorp/vault)
+instance, avoiding storage of keystores on the filesystem. This approach is best suited for
+node operators who already have most of Stakewise Operator functionality implemented
+in their systems, and only need integration for validator registration or pooling support.
+Regular users should only employ this functionality on their own risk, if they already
+manage a deployment of hashi vault.
+
+Currently there are two commands that support loading signing keys: `start` and `vaidators-exit`,
+user must provide hashi vault instance URL, authentication token, and secret path
+in K/V engine. Internal structure of the secret must resemble following json:
+
+```json
+{
+  "pubkey1": "privkey1",
+  "pubkey2": "privkey2",
+  ...
+}
+```
+
+Note that public and private signing keys must be stored in hex form, but without
+0x prefix.
+
+After loading keys from hashi vault, operator behaves in the same way as if it
+had loaded them from keystores, no additional operations needed to support
+the integration.
+
+## `start` options for hashi vault
+
+Passing following options to `start` command will enable loading validator signing
+keys from remote [Hashi Vault](https://github.com/hashicorp/vault). Make sure
+keystores directory is empty before running this command, otherwise operator
+will prefer local keystores.
+
+- `--hashi-vault-url` - URL to the remote hashi vault instance
+- `--hashi-vault-token` - Token for use when authenticating with hashi vault
+- `--hashi-vault-key-path` - Key path in hashi vault K/V engine holding signing secrets
+
 ## Misc commands
 
 ### Validators voluntary exit
@@ -369,6 +408,9 @@ Validators 513571, 513572, 513861 exits successfully initiated
 - `--count` - The number of validators to exit. By default, command will force exit all active vault validators.
 - `--data-dir` - Path where the vault data is stored. Default is ~/.stakewise.
 - `--remote-signer-url` - URL to the remote signer instance.
+- `--hashi-vault-url` - URL to the remote hashi vault instance
+- `--hashi-vault-token` - Token for use when authenticating with hashi vault
+- `--hashi-vault-key-path` - Key path in hashi vault K/V engine holding signing secrets
 - `--verbose` - Enable debug mode. Default is false.
 
 ### Update vault deposit data

--- a/README.md
+++ b/README.md
@@ -365,8 +365,8 @@ in K/V engine. Internal structure of the secret must resemble following json:
 }
 ```
 
-Note that public and private signing keys must be stored in hex form, but without
-0x prefix.
+Note that public and private signing keys must be stored in hex form, with or
+without 0x prefix.
 
 After loading keys from hashi vault, operator behaves in the same way as if it
 had loaded them from keystores, no additional operations needed to support

--- a/src/commands/start.py
+++ b/src/commands/start.py
@@ -261,16 +261,13 @@ async def main() -> None:
     remote_signer_config = None
 
     if len(keystores) == 0:
-        if not settings.remote_signer_url and not settings.hashi_vault_url:
-            raise RuntimeError('No keystores, no remote signer or hashi vault URL provided')
-
         if settings.hashi_vault_url:
             # No keystores loaded but hashi vault configuration specified
             hashi_vault_config = HashiVaultConfiguration.from_settings()
             logger.info('Using hashi vault at %s for loading public keys')
             keystores = await load_hashi_vault_keys(hashi_vault_config)
 
-        else:
+        elif settings.remote_signer_url:
             # No keystores loaded but remote signer URL provided
             remote_signer_config = RemoteSignerConfiguration.from_file(
                 settings.remote_signer_config_file
@@ -280,6 +277,8 @@ async def main() -> None:
                 settings.remote_signer_url,
                 len(remote_signer_config.pubkeys_to_shares.keys()),
             )
+        else:
+            raise RuntimeError('No keystores, no remote signer or hashi vault URL provided')
 
     # load deposit data
     deposit_data = load_deposit_data(settings.vault, settings.deposit_data_file)

--- a/src/commands/validators_exit.py
+++ b/src/commands/validators_exit.py
@@ -145,9 +145,6 @@ async def main(count: int | None) -> None:
     if len(keystores) > 0:
         all_validator_pubkeys = list(keystores.keys())  # pylint: disable=no-member
     else:
-        if not settings.remote_signer_url and not settings.hashi_vault_url:
-            raise RuntimeError('No keystores, no remote signer or hashi vault URL provided')
-
         if settings.hashi_vault_url:
             # No keystores loaded but hashi vault configuration specified
             hashi_vault_config = HashiVaultConfiguration.from_settings()
@@ -155,7 +152,7 @@ async def main(count: int | None) -> None:
             keystores = await load_hashi_vault_keys(hashi_vault_config)
             all_validator_pubkeys = list(keystores.keys())
 
-        else:
+        elif settings.remote_signer_url:
             # No keystores loaded but remote signer URL provided
             remote_signer_config = RemoteSignerConfiguration.from_file(
                 settings.remote_signer_config_file
@@ -165,6 +162,8 @@ async def main(count: int | None) -> None:
                 f'Using remote signer at {settings.remote_signer_url}'
                 f' for {len(all_validator_pubkeys)} public keys',
             )
+        else:
+            raise RuntimeError('No keystores, no remote signer or hashi vault URL provided')
 
     exit_keystores = await _get_exit_keystores(
         keystores=keystores, public_keys=all_validator_pubkeys

--- a/src/commands/validators_exit.py
+++ b/src/commands/validators_exit.py
@@ -17,6 +17,10 @@ from src.common.utils import log_verbose
 from src.common.validators import validate_eth_address
 from src.common.vault_config import VaultConfig
 from src.config.settings import AVAILABLE_NETWORKS, NETWORKS, settings
+from src.validators.signing.hashi_vault import (
+    HashiVaultConfiguration,
+    load_hashi_vault_keys,
+)
 from src.validators.signing.key_shares import reconstruct_shared_bls_signature
 from src.validators.signing.remote import RemoteSignerConfiguration, get_signature_shard
 from src.validators.typings import BLSPrivkey, Keystores
@@ -75,6 +79,21 @@ EXITING_STATUSES = [ValidatorStatus.ACTIVE_EXITING] + EXITED_STATUSES
     help='The base URL of the remote signer, e.g. http://signer:9000',
 )
 @click.option(
+    '--hashi-vault-url',
+    envvar='HASHI_VAULT_URL',
+    help='The base URL of the vault service, e.g. http://vault:8200.',
+)
+@click.option(
+    '--hashi-vault-token',
+    envvar='HASHI_VAULT_TOKEN',
+    help='Authentication token for accessing Hashi vault.',
+)
+@click.option(
+    '--hashi-vault-key-path',
+    envvar='HASHI_VAULT_KEY_PATH',
+    help='Key path in the K/V secret engine where validator signing keys are stored.',
+)
+@click.option(
     '-v',
     '--verbose',
     help='Enable debug mode. Default is false.',
@@ -89,6 +108,9 @@ def validators_exit(
     count: int | None,
     consensus_endpoints: str,
     remote_signer_url: str,
+    hashi_vault_key_path: str | None,
+    hashi_vault_token: str | None,
+    hashi_vault_url: str | None,
     data_dir: str,
     verbose: bool,
 ) -> None:
@@ -104,6 +126,9 @@ def validators_exit(
         vault_dir=vault_config.vault_dir,
         consensus_endpoints=consensus_endpoints,
         remote_signer_url=remote_signer_url,
+        hashi_vault_token=hashi_vault_token,
+        hashi_vault_key_path=hashi_vault_key_path,
+        hashi_vault_url=hashi_vault_url,
         verbose=verbose,
     )
     try:
@@ -115,24 +140,31 @@ def validators_exit(
 async def main(count: int | None) -> None:
     keystores = load_keystores()
     remote_signer_config = None
-
     fork = await consensus_client.get_consensus_fork()
 
     if len(keystores) > 0:
         all_validator_pubkeys = list(keystores.keys())  # pylint: disable=no-member
     else:
-        if not settings.remote_signer_url:
-            raise RuntimeError('No keystores and no remote signer URL provided')
+        if not settings.remote_signer_url and not settings.hashi_vault_url:
+            raise RuntimeError('No keystores, no remote signer or hashi vault URL provided')
 
-        # No keystores loaded but remote signer URL provided
-        remote_signer_config = RemoteSignerConfiguration.from_file(
-            settings.remote_signer_config_file
-        )
-        all_validator_pubkeys = list(remote_signer_config.pubkeys_to_shares.keys())
-        click.echo(
-            f'Using remote signer at {settings.remote_signer_url}'
-            f' for {len(all_validator_pubkeys)} public keys',
-        )
+        if settings.hashi_vault_url:
+            # No keystores loaded but hashi vault configuration specified
+            hashi_vault_config = HashiVaultConfiguration.from_settings()
+            click.echo('Using hashi vault at %s for loading public keys')
+            keystores = await load_hashi_vault_keys(hashi_vault_config)
+            all_validator_pubkeys = list(keystores.keys())
+
+        else:
+            # No keystores loaded but remote signer URL provided
+            remote_signer_config = RemoteSignerConfiguration.from_file(
+                settings.remote_signer_config_file
+            )
+            all_validator_pubkeys = list(remote_signer_config.pubkeys_to_shares.keys())
+            click.echo(
+                f'Using remote signer at {settings.remote_signer_url}'
+                f' for {len(all_validator_pubkeys)} public keys',
+            )
 
     exit_keystores = await _get_exit_keystores(
         keystores=keystores, public_keys=all_validator_pubkeys

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -42,6 +42,9 @@ class Settings(metaclass=Singleton):
     keystores_password_file: Path
     remote_signer_config_file: Path
     remote_signer_url: str | None
+    hashi_vault_key_path: str | None
+    hashi_vault_url: str | None
+    hashi_vault_token: str | None
     hot_wallet_file: Path
     hot_wallet_password_file: Path
     max_fee_per_gas_gwei: int
@@ -71,6 +74,9 @@ class Settings(metaclass=Singleton):
         keystores_password_file: str | None = None,
         remote_signer_config_file: str | None = None,
         remote_signer_url: str | None = None,
+        hashi_vault_key_path: str | None = None,
+        hashi_vault_url: str | None = None,
+        hashi_vault_token: str | None = None,
         hot_wallet_file: str | None = None,
         hot_wallet_password_file: str | None = None,
         database_dir: str | None = None,
@@ -113,6 +119,11 @@ class Settings(metaclass=Singleton):
             else vault_dir / 'remote_signer_config.json'
         )
         self.remote_signer_url = remote_signer_url
+
+        # hashi vault configuration
+        self.hashi_vault_url = hashi_vault_url
+        self.hashi_vault_key_path = hashi_vault_key_path
+        self.hashi_vault_token = hashi_vault_token
 
         # hot wallet
         self.hot_wallet_file = (
@@ -168,6 +179,9 @@ DEFAULT_RETRY_TIME = 60
 
 # Remote signer timeout
 REMOTE_SIGNER_TIMEOUT = 10
+
+# Hashi vault timeout
+HASHI_VAULT_TIMEOUT = 10
 
 # Oracles signature update sync (10 minutes)
 ORACLES_SIGNATURE_UPDATE_SYNC_TIMEOUT = 600

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -19,6 +19,7 @@ from src.common.typings import Oracles
 from src.common.vault_config import VaultConfig
 from src.config.networks import GOERLI
 from src.config.settings import settings
+from src.test_fixtures.hashi_vault import hashi_vault_url, mocked_hashi_vault
 from src.test_fixtures.remote_signer import mocked_remote_signer, remote_signer_url
 from src.validators.signing.remote import RemoteSignerConfiguration
 from src.validators.signing.tests.oracle_functions import OracleCommittee

--- a/src/test_fixtures/hashi_vault.py
+++ b/src/test_fixtures/hashi_vault.py
@@ -1,0 +1,57 @@
+import json
+from typing import Generator
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+
+@pytest.fixture
+def hashi_vault_url() -> str:
+    return 'http://vault:8200'
+
+
+@pytest.fixture
+def mocked_hashi_vault(
+    hashi_vault_url: str,
+) -> Generator:
+    # Generated via
+    # eth-staking-smith existing-mnemonic \
+    #   --chain goerli \
+    #   --num_validators 2 \
+    #   --mnemonic 'provide iron update bronze session immense garage want round enhance artefact position make wash analyst skirt float jealous trend spread ginger rapid express tool'
+    _hashi_vault_pk_sk_mapping = {
+        'b05e93c4501233eeb7f1e7b0ee400caaa04608249c4aab61c18e04c675aaf2a0f03808d533c877fbbd57b04927c01ce0': '3eeedd7a6679d2e2036682b6f03ef16105a847321303aec163548aa3fa5e9eeb',
+        'aa84894836cb3d897a1a11344920c41c472ed67667fd8a3453e557214442370ffc1d007ae7af67120de00afa068349be': '236f33410e6972a2db36ba3736099396768219b327e18eae49392f153007d468',
+    }
+
+    def _mocked_secret_path(url, **kwargs) -> CallbackResult:
+        return CallbackResult(
+            status=200,
+            body=json.dumps(
+                dict(
+                    data=dict(
+                        data=_hashi_vault_pk_sk_mapping,
+                    )
+                )
+            ),  # type: ignore
+        )
+
+    def _mocked_error_path(url, **kwargs) -> CallbackResult:
+        return CallbackResult(
+            status=200, body=json.dumps(dict(errors=list('token not provided')))  # type: ignore
+        )
+
+    with aioresponses() as m:
+        # Mocked signing keys endpoint
+        m.get(
+            f'{hashi_vault_url}/v1/secret/data/ethereum/signing/keystores',
+            callback=_mocked_secret_path,
+            repeat=True,
+        )
+        # Mocked inacessible signing keys endpoint
+        m.get(
+            f'{hashi_vault_url}/v1/secret/data/ethereum/inaccessible/keystores',
+            callback=_mocked_error_path,
+            repeat=True,
+        )
+        yield

--- a/src/validators/signing/hashi_vault.py
+++ b/src/validators/signing/hashi_vault.py
@@ -1,0 +1,70 @@
+import logging
+import urllib.parse
+from dataclasses import dataclass
+
+from aiohttp import ClientSession, ClientTimeout
+from eth_typing import HexStr
+from web3 import Web3
+
+from src.config.settings import HASHI_VAULT_TIMEOUT, settings
+from src.validators.typings import BLSPrivkey, Keystores
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HashiVaultConfiguration:
+    token: str
+    url: str
+    key_path: str
+
+    @classmethod
+    def from_settings(cls):
+        if not (
+            settings.hashi_vault_url is not None
+            and settings.hashi_vault_token is not None
+            and settings.hashi_vault_key_path is not None
+        ):
+            raise RuntimeError(
+                'All three of URL, token and key path must be specified for hashi vault'
+            )
+        return cls(
+            token=settings.hashi_vault_token,
+            url=settings.hashi_vault_url,
+            key_path=settings.hashi_vault_key_path,
+        )
+
+    def secret_url(self):
+        return urllib.parse.urljoin(
+            self.url,
+            f'/v1/secret/data/{self.key_path}',
+        )
+
+
+async def load_hashi_vault_keys(config: HashiVaultConfiguration) -> Keystores:
+    """
+    Load public and private keys from hashi vault
+    K/V secret engine.
+
+    All public and private keys must be stored as hex string without 0x prefix.
+    """
+    keys = []
+    logger.info('Will load validator keys from %s', config.secret_url())
+
+    async with ClientSession(timeout=ClientTimeout(HASHI_VAULT_TIMEOUT)) as session:
+        response = await session.get(config.secret_url(), headers={'X-Vault-Token': config.token})
+        response.raise_for_status()
+
+        key_data = await response.json()
+
+    if 'data' not in key_data:
+        logger.error('Failed to retrieve keys from hashi vault')
+        for error in key_data.get('errors', []):
+            logger.error('hashi vault error: %s', error)
+        raise RuntimeError('Can not retrieve validator signing keys from hashi vault')
+
+    for pk, sk in key_data['data']['data'].items():
+        sk_bytes = Web3.to_bytes(hexstr=sk)
+        keys.append((HexStr(f'0x{pk}'), BLSPrivkey(sk_bytes)))
+    validator_keys = Keystores(dict(keys))
+    return validator_keys

--- a/src/validators/signing/hashi_vault.py
+++ b/src/validators/signing/hashi_vault.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from aiohttp import ClientSession, ClientTimeout
 from eth_typing import HexStr
+from eth_utils import add_0x_prefix
 from web3 import Web3
 
 from src.config.settings import HASHI_VAULT_TIMEOUT, settings
@@ -46,7 +47,7 @@ async def load_hashi_vault_keys(config: HashiVaultConfiguration) -> Keystores:
     Load public and private keys from hashi vault
     K/V secret engine.
 
-    All public and private keys must be stored as hex string without 0x prefix.
+    All public and private keys must be stored as hex string  with or without 0x prefix.
     """
     keys = []
     logger.info('Will load validator keys from %s', config.secret_url())
@@ -65,6 +66,6 @@ async def load_hashi_vault_keys(config: HashiVaultConfiguration) -> Keystores:
 
     for pk, sk in key_data['data']['data'].items():
         sk_bytes = Web3.to_bytes(hexstr=sk)
-        keys.append((HexStr(f'0x{pk}'), BLSPrivkey(sk_bytes)))
+        keys.append((add_0x_prefix(HexStr(pk)), BLSPrivkey(sk_bytes)))
     validator_keys = Keystores(dict(keys))
     return validator_keys


### PR DESCRIPTION
This PR adds support for loading validator signing keys from remote [Vault](https://github.com/hashicorp/vault) instance.

The signing keys still reside in validator memory, but keystores and passwords are not written to filesystem.
