### PR TITLE
Remote signer setup improvements

### DIFF
--- a/src/commands/tests/test_remote_signer_setup.py
+++ b/src/commands/tests/test_remote_signer_setup.py
@@ -98,8 +98,9 @@ class TestOperatorRemoteSignerSetup:
             assert len(shares) == oracle_count
 
         async with aiohttp.ClientSession() as session:
-            resp = await session.get(f'{settings.remote_signer_url}/api/v1/eth2/publicKeys')
-            pubkeys_remote_signer = set(await resp.json())
+            resp = await session.get(f'{settings.remote_signer_url}/eth/v1/keystores')
+            data = (await resp.json())['data']
+            pubkeys_remote_signer = {pubkey_dict.get('validating_pubkey') for pubkey_dict in data}
             assert len(pubkeys_remote_signer) == key_count * oracle_count
 
     @pytest.mark.usefixtures('_init_vault', 'mocked_remote_signer', 'mock_scrypt_keystore')


### PR DESCRIPTION
Includes a few small changes that make the remote signer setup's UX a little better.

1. Fail fast - check if the remote signer's keymanager API is reachable before taking further time-consuming setup steps.
2. Override aiohttp's default ReadTimeout of 300 seconds. 300 seconds is not enough when importing a larger number of keystores (e.g. 50 validators * 11 oracles = 550 keystores to import , that can easily take longer than 300 seconds). Replace it with a connect timeout of (by default) 10 seconds and no read timeout.
3. Use the keymanager API endpoint for listing existing public keys (`eth/v1/keystores`) instead of the `/api/v1/eth2/publicKeys` endpoint. This change is mainly for consistency, I don't have a strong opinion which is better / more future-proof.