### PR TITLE
Add `--dappnode` flag to signer keystore upload

### DIFF
--- a/src/commands/remote_signer_setup.py
+++ b/src/commands/remote_signer_setup.py
@@ -175,7 +175,7 @@ async def main() -> None:
             # Only add tags and fee_recipient if --dappnode is set
             if settings.dappnode:
                 tags_array = ["stakewise"] * len(keystores_json_chunk)  # "stakewise" tag for each key
-                fee_recipient_array = [settings.fee_recipient] * len(keystores_json_chunk)  # Same FR for each key
+                fee_recipient_array = [fee_recipient] * len(keystores_json_chunk)  # Same FR for each key
                 data.update({
                     'tags': tags_array,
                     'feeRecipients': fee_recipient_array,

--- a/src/commands/remote_signer_setup.py
+++ b/src/commands/remote_signer_setup.py
@@ -77,7 +77,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     '--dappnode',
-    help='Add fields required by Dappnode Staking Brain to the import request (tags and fee recipients)',
+    help='Add fields required by Dappnode Staking Brain to the keystore import request',
     envvar='DAPPNODE',
     is_flag=True,
 )
@@ -85,12 +85,12 @@ logger = logging.getLogger(__name__)
     '--execution-endpoints',
     type=str,
     envvar='EXECUTION_ENDPOINTS',
-    help='Comma separated list of API endpoints for execution nodes. Used to retrieve vault validator fee recipient (only needed if flag --dappnode is set).',
+    help="""Comma separated list of API endpoints for execution nodes.
+Used to retrieve vault validator fee recipient (only needed if flag --dappnode is set).""",
     callback=validate_dappnode_execution_endpoints,
     default='',
 )
 @click.command(help='Uploads private keys to a remote signer.')
-
 # pylint: disable-next=too-many-arguments
 def remote_signer_setup(
     vault: HexAddress,

--- a/src/commands/remote_signer_setup.py
+++ b/src/commands/remote_signer_setup.py
@@ -81,8 +81,7 @@ logger = logging.getLogger(__name__)
     '--execution-endpoints',
     type=str,
     envvar='EXECUTION_ENDPOINTS',
-    prompt='Enter comma separated list of API endpoints for execution nodes. Used to retrieve vault validator fee recipient (only needed if flag --dappnode is set).',
-    help='Comma separated list of API endpoints for execution nodes.',
+    help='Comma separated list of API endpoints for execution nodes. Used to retrieve vault validator fee recipient (only needed if flag --dappnode is set).',
     required=False,
     callback=validate_dappnode_execution_endpoints
 )

--- a/src/common/validators.py
+++ b/src/common/validators.py
@@ -31,3 +31,9 @@ def validate_db_uri(ctx, param, value):
     if not pattern.match(value):
         raise click.BadParameter('Invalid database connection string')
     return value
+
+def validate_dappnode_execution_endpoints(ctx, param, value):
+    dappnode = ctx.params.get('dappnode')
+    if dappnode and not value:
+        raise click.MissingParameter(ctx=ctx, param=param, message="Execution endpoints are required when --dappnode is set.")
+    return value

--- a/src/common/validators.py
+++ b/src/common/validators.py
@@ -32,8 +32,12 @@ def validate_db_uri(ctx, param, value):
         raise click.BadParameter('Invalid database connection string')
     return value
 
+
 def validate_dappnode_execution_endpoints(ctx, param, value):
     dappnode = ctx.params.get('dappnode')
     if dappnode and not value:
-        raise click.MissingParameter(ctx=ctx, param=param, message="Execution endpoints are required when --dappnode is set.")
+        raise click.MissingParameter(
+            ctx=ctx, param=param, message='Execution endpoints are required when --dappnode is set.'
+        )
+
     return value

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -51,6 +51,8 @@ class Settings(metaclass=Singleton):
     keystores_password_dir: Path
     keystores_password_file: Path
     remote_signer_url: str | None
+    dappnode: bool = False
+    fee_recipient: ChecksumAddress | None = None
     hashi_vault_key_path: str | None
     hashi_vault_url: str | None
     hashi_vault_token: str | None
@@ -101,6 +103,8 @@ class Settings(metaclass=Singleton):
         keystores_dir: str | None = None,
         keystores_password_file: str | None = None,
         remote_signer_url: str | None = None,
+        dappnode: bool = False,
+        fee_recipient: str | None = None,
         hashi_vault_key_path: str | None = None,
         hashi_vault_url: str | None = None,
         hashi_vault_token: str | None = None,
@@ -147,6 +151,8 @@ class Settings(metaclass=Singleton):
 
         # remote signer configuration
         self.remote_signer_url = remote_signer_url
+        self.dappnode = dappnode
+        self.fee_recipient = Web3.to_checksum_address(fee_recipient) if fee_recipient else None
 
         # hashi vault configuration
         self.hashi_vault_url = hashi_vault_url

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -52,7 +52,6 @@ class Settings(metaclass=Singleton):
     keystores_password_file: Path
     remote_signer_url: str | None
     dappnode: bool = False
-    fee_recipient: ChecksumAddress | None = None
     hashi_vault_key_path: str | None
     hashi_vault_url: str | None
     hashi_vault_token: str | None
@@ -104,7 +103,6 @@ class Settings(metaclass=Singleton):
         keystores_password_file: str | None = None,
         remote_signer_url: str | None = None,
         dappnode: bool = False,
-        fee_recipient: str | None = None,
         hashi_vault_key_path: str | None = None,
         hashi_vault_url: str | None = None,
         hashi_vault_token: str | None = None,
@@ -152,7 +150,6 @@ class Settings(metaclass=Singleton):
         # remote signer configuration
         self.remote_signer_url = remote_signer_url
         self.dappnode = dappnode
-        self.fee_recipient = Web3.to_checksum_address(fee_recipient) if fee_recipient else None
 
         # hashi vault configuration
         self.hashi_vault_url = hashi_vault_url


### PR DESCRIPTION
This will allow the Stakewise operator to upload the validator keystores to the Dappnode Staking Brain, making the Stakewise Operator Dappnode package more resilient and simple.

The following flags were added to the `remote-signer-setup` command:
1. `--dappnode` will add the fields `tags` and `feeRecipients` to the data sent through the POST request to `/eth/v1/keystores` endpoint. This allows the Staking Brain to persist the desired staking configuration for the validator service and web3signer for a Dappnode user
2. `--execution-endpoints` will set the execution endpoint to use in order to get the correct validator fee recipient from the vault smart contract, ensuring Dappnode users cannot make any mistakes when setting the fee recipient for the keystores belonging to this vault. This flag is compulsory if `-dappnode` is set

Moreover, keystore removal option after import is skipped for Dappnode users

