### PR TITLE
adding support for jwt secret in upload keypairs

### DIFF
--- a/src/remote_db/commands.py
+++ b/src/remote_db/commands.py
@@ -150,7 +150,7 @@ def upload_keypairs(
     ctx: Context,
     encrypt_key: str,
     execution_endpoints: str,
-    execution_jwt_secret: str,
+    execution_jwt_secret: str | None,
     deposit_data_file: str | None,
     pool_size: int | None,
 ) -> None:

--- a/src/remote_db/commands.py
+++ b/src/remote_db/commands.py
@@ -138,11 +138,19 @@ def cleanup(ctx: Context) -> None:
     envvar='POOL_SIZE',
     type=int,
 )
+@click.option(
+    '--execution-jwt-secret',
+    type=str,
+    envvar='EXECUTION_JWT_SECRET',
+    help='JWT secret key used for signing and verifying JSON Web Tokens'
+    'when connecting to execution nodes.',
+)
 @click.pass_context
 def upload_keypairs(
     ctx: Context,
     encrypt_key: str,
     execution_endpoints: str,
+    execution_jwt_secret: str,
     deposit_data_file: str | None,
     pool_size: int | None,
 ) -> None:
@@ -154,6 +162,7 @@ def upload_keypairs(
         deposit_data_file=deposit_data_file,
         verbose=settings.verbose,
         execution_endpoints=execution_endpoints,
+        execution_jwt_secret=execution_jwt_secret,
         pool_size=pool_size,
     )
     try:

--- a/src/remote_db/commands.py
+++ b/src/remote_db/commands.py
@@ -146,6 +146,7 @@ def cleanup(ctx: Context) -> None:
     'when connecting to execution nodes.',
 )
 @click.pass_context
+# pylint: disable-next=too-many-arguments
 def upload_keypairs(
     ctx: Context,
     encrypt_key: str,


### PR DESCRIPTION
I'm still a bit new to stakewise (and ethereum in general, but lots of experience with Solana) however, I kept getting authentication errors hitting an execution endpoint with JWT enabled.

This PR allows a user to pass a JWT token to upload their keypairs, which worked for me after running