### PR TITLE
Add support for multiple --hashi-vault-key-path parameters

### DIFF
--- a/src/commands/start.py
+++ b/src/commands/start.py
@@ -13,6 +13,7 @@ from src.common.validators import validate_eth_address
 from src.common.vault_config import VaultConfig
 from src.config.networks import AVAILABLE_NETWORKS
 from src.config.settings import (
+    DEFAULT_HASHI_VAULT_PARALLELISM,
     DEFAULT_MAX_FEE_PER_GAS_GWEI,
     DEFAULT_METRICS_HOST,
     DEFAULT_METRICS_PORT,
@@ -179,7 +180,14 @@ logger = logging.getLogger(__name__)
 @click.option(
     '--hashi-vault-key-path',
     envvar='HASHI_VAULT_KEY_PATH',
-    help='Key path in the K/V secret engine where validator signing keys are stored.',
+    multiple=True,
+    help='Key path(s) in the K/V secret engine where validator signing keys are stored.',
+)
+@click.option(
+    '--hashi-vault-parallelism',
+    envvar='HASHI_VAULT_PARALLELISM',
+    help='How much requests to K/V secrets engine to do in parallel.',
+    default=DEFAULT_HASHI_VAULT_PARALLELISM,
 )
 @click.option(
     '--log-format',
@@ -235,9 +243,10 @@ def start(
     keystores_dir: str | None,
     keystores_password_file: str | None,
     remote_signer_url: str | None,
-    hashi_vault_key_path: str | None,
+    hashi_vault_key_path: list[str] | None,
     hashi_vault_token: str | None,
     hashi_vault_url: str | None,
+    hashi_vault_parallelism: int,
     hot_wallet_file: str | None,
     hot_wallet_password_file: str | None,
     max_fee_per_gas_gwei: int,
@@ -268,7 +277,8 @@ def start(
         keystores_password_file=keystores_password_file,
         remote_signer_url=remote_signer_url,
         hashi_vault_token=hashi_vault_token,
-        hashi_vault_key_path=hashi_vault_key_path,
+        hashi_vault_key_paths=hashi_vault_key_path,
+        hashi_vault_parallelism=hashi_vault_parallelism,
         hashi_vault_url=hashi_vault_url,
         hot_wallet_file=hot_wallet_file,
         hot_wallet_password_file=hot_wallet_password_file,

--- a/src/commands/validators_exit.py
+++ b/src/commands/validators_exit.py
@@ -17,7 +17,7 @@ from src.common.utils import format_error, log_verbose
 from src.common.validators import validate_eth_address
 from src.common.vault_config import VaultConfig
 from src.config.networks import AVAILABLE_NETWORKS
-from src.config.settings import settings
+from src.config.settings import DEFAULT_HASHI_VAULT_PARALLELISM, settings
 from src.validators.keystores.base import BaseKeystore
 from src.validators.keystores.load import load_keystore
 
@@ -84,8 +84,15 @@ EXITING_STATUSES = [ValidatorStatus.ACTIVE_EXITING] + EXITED_STATUSES
 )
 @click.option(
     '--hashi-vault-key-path',
+    multiple=True,
     envvar='HASHI_VAULT_KEY_PATH',
     help='Key path in the K/V secret engine where validator signing keys are stored.',
+)
+@click.option(
+    '--hashi-vault-parallelism',
+    envvar='HASHI_VAULT_PARALLELISM',
+    help='How much requests to K/V secrets engine to do in parallel.',
+    default=DEFAULT_HASHI_VAULT_PARALLELISM,
 )
 @click.option(
     '-v',
@@ -111,16 +118,17 @@ EXITING_STATUSES = [ValidatorStatus.ACTIVE_EXITING] + EXITED_STATUSES
     type=int,
 )
 @click.command(help='Performs a voluntary exit for active vault validators.')
-# pylint: disable-next=too-many-arguments
+# pylint: disable-next=too-many-arguments,too-many-locals
 def validators_exit(
     network: str,
     vault: HexAddress,
     count: int | None,
     consensus_endpoints: str,
     remote_signer_url: str,
-    hashi_vault_key_path: str | None,
+    hashi_vault_key_path: list[str] | None,
     hashi_vault_token: str | None,
     hashi_vault_url: str | None,
+    hashi_vault_parallelism: int,
     data_dir: str,
     verbose: bool,
     log_level: str,
@@ -139,8 +147,9 @@ def validators_exit(
         consensus_endpoints=consensus_endpoints,
         remote_signer_url=remote_signer_url,
         hashi_vault_token=hashi_vault_token,
-        hashi_vault_key_path=hashi_vault_key_path,
+        hashi_vault_key_paths=hashi_vault_key_path,
         hashi_vault_url=hashi_vault_url,
+        hashi_vault_parallelism=hashi_vault_parallelism,
         verbose=verbose,
         log_level=log_level,
         pool_size=pool_size,

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -163,7 +163,7 @@ class Settings(metaclass=Singleton):
 
         # hashi vault configuration
         if hashi_vault_key_paths is not None:
-            if sorted(list(set(hashi_vault_key_paths))) != sorted(hashi_vault_key_paths):
+            if len(set(hashi_vault_key_paths)) != len(hashi_vault_key_paths):
                 raise RuntimeError('Found duplicate addresses in hashi vault key paths')
 
         self.hashi_vault_url = hashi_vault_url

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -19,6 +19,8 @@ DEFAULT_METRICS_PREFIX = 'sw_operator'
 
 DEFAULT_MIN_VALIDATORS_REGISTRATION = 1
 
+DEFAULT_HASHI_VAULT_PARALLELISM = 8
+
 
 # pylint: disable-next=too-many-public-methods,too-many-instance-attributes
 class Settings(metaclass=Singleton):
@@ -46,9 +48,10 @@ class Settings(metaclass=Singleton):
     keystores_password_file: Path
     remote_signer_url: str | None
     dappnode: bool = False
-    hashi_vault_key_path: str | None
+    hashi_vault_key_paths: list[str] | None
     hashi_vault_url: str | None
     hashi_vault_token: str | None
+    hashi_vault_parallelism: int
     hot_wallet_file: Path
     hot_wallet_password_file: Path
     max_fee_per_gas_gwei: int
@@ -106,9 +109,10 @@ class Settings(metaclass=Singleton):
         keystores_password_file: str | None = None,
         remote_signer_url: str | None = None,
         dappnode: bool = False,
-        hashi_vault_key_path: str | None = None,
+        hashi_vault_key_paths: list[str] | None = None,
         hashi_vault_url: str | None = None,
         hashi_vault_token: str | None = None,
+        hashi_vault_parallelism: int = DEFAULT_HASHI_VAULT_PARALLELISM,
         hot_wallet_file: str | None = None,
         hot_wallet_password_file: str | None = None,
         database_dir: str | None = None,
@@ -158,9 +162,14 @@ class Settings(metaclass=Singleton):
         self.dappnode = dappnode
 
         # hashi vault configuration
+        if hashi_vault_key_paths is not None:
+            if sorted(list(set(hashi_vault_key_paths))) != sorted(hashi_vault_key_paths):
+                raise RuntimeError('Found duplicate addresses in hashi vault key paths')
+
         self.hashi_vault_url = hashi_vault_url
-        self.hashi_vault_key_path = hashi_vault_key_path
+        self.hashi_vault_key_paths = hashi_vault_key_paths
         self.hashi_vault_token = hashi_vault_token
+        self.hashi_vault_parallelism = hashi_vault_parallelism
 
         # hot wallet
         self.hot_wallet_file = (

--- a/src/test_fixtures/hashi_vault.py
+++ b/src/test_fixtures/hashi_vault.py
@@ -1,4 +1,5 @@
 import json
+from functools import partial
 from typing import Generator
 
 import pytest
@@ -16,21 +17,30 @@ def mocked_hashi_vault(
 ) -> Generator:
     # Generated via
     # eth-staking-smith existing-mnemonic \
-    #   --chain goerli \
+    #   --chain holesky \
     #   --num_validators 2 \
     #   --mnemonic 'provide iron update bronze session immense garage want round enhance artefact position make wash analyst skirt float jealous trend spread ginger rapid express tool'
-    _hashi_vault_pk_sk_mapping = {
+    _hashi_vault_pk_sk_mapping_1 = {
         'b05e93c4501233eeb7f1e7b0ee400caaa04608249c4aab61c18e04c675aaf2a0f03808d533c877fbbd57b04927c01ce0': '3eeedd7a6679d2e2036682b6f03ef16105a847321303aec163548aa3fa5e9eeb',
         'aa84894836cb3d897a1a11344920c41c472ed67667fd8a3453e557214442370ffc1d007ae7af67120de00afa068349be': '236f33410e6972a2db36ba3736099396768219b327e18eae49392f153007d468',
     }
+    # Generated via
+    # eth-staking-smith existing-mnemonic \
+    #   --chain holesky \
+    #   --num_validators 2 \
+    #   --mnemonic 'wheel treat brand feel motion atom card impose achieve rough shove bless glory wheel gold ensure maid despair turtle carry recall best outer fuel'
+    _hashi_vault_pk_sk_mapping_2 = {
+        '9548e46c8e3b11d686b11fe5c4aea53a6ffd6cef622920fe8d73b4b7bff71938d2a0652b607fa6d757e840f3ddc2d7a4': '2c7310981a6e12bef7f444860b450c70235acd3e9f74e0a3ee82da3fdbc657a5',
+        '8bc90a3110cf2b1ebaf8f5367bbfec1066797fca1f71ddbbf4f8f37ef74064404a78c31284c571656b7cb6efa29445ab': '56336628453e51cb9158da0651ea27dcb297eacdbd5cffdf0ea9d65fa154c327',
+    }
 
-    def _mocked_secret_path(url, **kwargs) -> CallbackResult:
+    def _mocked_secret_path(data, url, **kwargs) -> CallbackResult:
         return CallbackResult(
             status=200,
             body=json.dumps(
                 dict(
                     data=dict(
-                        data=_hashi_vault_pk_sk_mapping,
+                        data=data,
                     )
                 )
             ),  # type: ignore
@@ -42,10 +52,20 @@ def mocked_hashi_vault(
         )
 
     with aioresponses() as m:
-        # Mocked signing keys endpoint
+        # Mocked signing keys endpoints
         m.get(
             f'{hashi_vault_url}/v1/secret/data/ethereum/signing/keystores',
-            callback=_mocked_secret_path,
+            callback=partial(_mocked_secret_path, _hashi_vault_pk_sk_mapping_1),
+            repeat=True,
+        )
+        m.get(
+            f'{hashi_vault_url}/v1/secret/data/ethereum/signing/same/keystores',
+            callback=partial(_mocked_secret_path, _hashi_vault_pk_sk_mapping_1),
+            repeat=True,
+        )
+        m.get(
+            f'{hashi_vault_url}/v1/secret/data/ethereum/signing/other/keystores',
+            callback=partial(_mocked_secret_path, _hashi_vault_pk_sk_mapping_2),
             repeat=True,
         )
         # Mocked inacessible signing keys endpoint

--- a/src/validators/keystores/hashi_vault.py
+++ b/src/validators/keystores/hashi_vault.py
@@ -1,3 +1,5 @@
+import asyncio
+import itertools
 import logging
 import urllib.parse
 from dataclasses import dataclass
@@ -18,14 +20,15 @@ logger = logging.getLogger(__name__)
 class HashiVaultConfiguration:
     token: str
     url: str
-    key_path: str
+    key_paths: list[str]
+    parallelism: int
 
     @classmethod
     def from_settings(cls) -> 'HashiVaultConfiguration':
         if not (
             settings.hashi_vault_url is not None
             and settings.hashi_vault_token is not None
-            and settings.hashi_vault_key_path is not None
+            and settings.hashi_vault_key_paths is not None
         ):
             raise RuntimeError(
                 'All three of URL, token and key path must be specified for hashi vault'
@@ -33,13 +36,14 @@ class HashiVaultConfiguration:
         return cls(
             token=settings.hashi_vault_token,
             url=settings.hashi_vault_url,
-            key_path=settings.hashi_vault_key_path,
+            key_paths=settings.hashi_vault_key_paths,
+            parallelism=settings.hashi_vault_parallelism,
         )
 
-    def secret_url(self) -> str:
+    def secret_url(self, key_path: str) -> str:
         return urllib.parse.urljoin(
             self.url,
-            f'/v1/secret/data/{self.key_path}',
+            f'/v1/secret/data/{key_path}',
         )
 
 
@@ -48,11 +52,35 @@ class HashiVaultKeystore(LocalKeystore):
     async def load() -> 'HashiVaultKeystore':
         """Extracts private keys from the keystores."""
         hashi_vault_config = HashiVaultConfiguration.from_settings()
-        keys = await HashiVaultKeystore._load_hashi_vault_keys(hashi_vault_config)
-        return HashiVaultKeystore(keys)
+
+        parallelism = hashi_vault_config.parallelism
+        key_paths = hashi_vault_config.key_paths
+        merged_keys = Keys({})
+
+        key_paths_iter = iter(key_paths)
+        while key_chunk := list(itertools.islice(key_paths_iter, parallelism)):
+            async with ClientSession(
+                timeout=ClientTimeout(HASHI_VAULT_TIMEOUT),
+                headers={'X-Vault-Token': hashi_vault_config.token},
+            ) as session:
+                keys_responses = await asyncio.gather(
+                    *[
+                        HashiVaultKeystore._load_hashi_vault_keys(
+                            session=session, secret_url=hashi_vault_config.secret_url(key_path)
+                        )
+                        for key_path in key_chunk
+                    ]
+                )
+                for keys in keys_responses:
+                    for pk, sk in keys.items():
+                        if pk in merged_keys:
+                            logger.error('Duplicate validator key %s found in hashi vault', pk)
+                            raise RuntimeError('Found duplicate key in path')
+                        merged_keys[pk] = sk
+        return HashiVaultKeystore(merged_keys)
 
     @staticmethod
-    async def _load_hashi_vault_keys(config: HashiVaultConfiguration) -> Keys:
+    async def _load_hashi_vault_keys(session: ClientSession, secret_url: str) -> Keys:
         """
         Load public and private keys from hashi vault
         K/V secret engine.
@@ -60,15 +88,12 @@ class HashiVaultKeystore(LocalKeystore):
         All public and private keys must be stored as hex string  with or without 0x prefix.
         """
         keys = []
-        logger.info('Will load validator keys from %s', config.secret_url())
+        logger.info('Will load validator keys from %s', secret_url)
 
-        async with ClientSession(timeout=ClientTimeout(HASHI_VAULT_TIMEOUT)) as session:
-            response = await session.get(
-                config.secret_url(), headers={'X-Vault-Token': config.token}
-            )
-            response.raise_for_status()
+        response = await session.get(secret_url)
+        response.raise_for_status()
 
-            key_data = await response.json()
+        key_data = await response.json()
 
         if 'data' not in key_data:
             logger.error('Failed to retrieve keys from hashi vault')

--- a/src/validators/keystores/tests/test_hashi_vault.py
+++ b/src/validators/keystores/tests/test_hashi_vault.py
@@ -1,4 +1,5 @@
 import pytest
+from aiohttp.client import ClientSession
 
 from src.config.settings import settings
 from src.validators.keystores.hashi_vault import (
@@ -15,11 +16,15 @@ class TestHashiVault:
     ):
         settings.hashi_vault_url = hashi_vault_url
         settings.hashi_vault_token = 'Secret'
-        settings.hashi_vault_key_path = 'ethereum/signing/keystores'
+        settings.hashi_vault_key_paths = []
+        settings.hashi_vault_parallelism = 1
 
         config = HashiVaultConfiguration.from_settings()
 
-        keystore = await HashiVaultKeystore._load_hashi_vault_keys(config)
+        async with ClientSession() as session:
+            keystore = await HashiVaultKeystore._load_hashi_vault_keys(
+                session=session, secret_url=config.secret_url('ethereum/signing/keystores')
+            )
 
         assert len(keystore) == 2
 
@@ -31,6 +36,7 @@ class TestHashiVault:
         settings.hashi_vault_url = hashi_vault_url
         settings.hashi_vault_token = None
         settings.hashi_vault_key_path = None
+        settings.hashi_vault_parallelism = 1
 
         with pytest.raises(RuntimeError, match='URL, token and key path must be specified'):
             await HashiVaultConfiguration.from_settings()
@@ -42,10 +48,67 @@ class TestHashiVault:
     ):
         settings.hashi_vault_url = hashi_vault_url
         settings.hashi_vault_token = 'Secret'
-        settings.hashi_vault_key_path = 'ethereum/inaccessible/keystores'
+        settings.hashi_vault_key_path = []
+        settings.hashi_vault_parallelism = 1
 
         with pytest.raises(
             RuntimeError, match='Can not retrieve validator signing keys from hashi vault'
         ):
             config = HashiVaultConfiguration.from_settings()
-            await HashiVaultKeystore._load_hashi_vault_keys(config)
+            async with ClientSession() as session:
+                await HashiVaultKeystore._load_hashi_vault_keys(
+                    session=session, secret_url=config.secret_url('ethereum/inaccessible/keystores')
+                )
+
+    @pytest.mark.usefixtures('mocked_hashi_vault')
+    async def test_hashi_vault_keystores_parallel(
+        self,
+        hashi_vault_url: str,
+    ):
+        settings.hashi_vault_url = hashi_vault_url
+        settings.hashi_vault_token = 'Secret'
+        settings.hashi_vault_key_paths = [
+            'ethereum/signing/keystores',
+            'ethereum/signing/other/keystores',
+        ]
+        settings.hashi_vault_parallelism = 2
+
+        keystore = HashiVaultKeystore({})
+        keys = await keystore.load()
+
+        assert len(keys) == 4
+
+    @pytest.mark.usefixtures('mocked_hashi_vault')
+    async def test_hashi_vault_keystores_sequential(
+        self,
+        hashi_vault_url: str,
+    ):
+        settings.hashi_vault_url = hashi_vault_url
+        settings.hashi_vault_token = 'Secret'
+        settings.hashi_vault_key_paths = [
+            'ethereum/signing/keystores',
+            'ethereum/signing/other/keystores',
+        ]
+        settings.hashi_vault_parallelism = 1
+
+        keystore = HashiVaultKeystore({})
+        keys = await keystore.load()
+
+        assert len(keys) == 4
+
+    @pytest.mark.usefixtures('mocked_hashi_vault')
+    async def test_hashi_vault_duplicates_parallel(
+        self,
+        hashi_vault_url: str,
+    ):
+        settings.hashi_vault_url = hashi_vault_url
+        settings.hashi_vault_token = 'Secret'
+        settings.hashi_vault_key_paths = [
+            'ethereum/signing/keystores',
+            'ethereum/signing/same/keystores',
+        ]
+        settings.hashi_vault_parallelism = 2
+
+        keystore = HashiVaultKeystore({})
+        with pytest.raises(RuntimeError, match='Found duplicate key in path'):
+            await keystore.load()


### PR DESCRIPTION
- Allow passing multiple `--hashi-vault-key-path` parameters
- Fetch secrets from Hashicorp Vault in parallel, batched in chunks
- Verify no duplicate secrets are fetched from Hashicorp Vault
- Tests for new cases: parallel fetching of paths, sequential fetching of 2 chunks, duplicate secrets