### PR TITLE
Fix reporting unused_validators for DVT

### DIFF
--- a/src/commands/start_base.py
+++ b/src/commands/start_base.py
@@ -21,7 +21,7 @@ from src.validators.keystores.base import BaseKeystore
 from src.validators.keystores.load import load_keystore
 from src.validators.relayer import RelayerAdapter, create_relayer_adapter
 from src.validators.tasks import ValidatorsTask, load_genesis_validators
-from src.validators.typings import DepositData, ValidatorsRegistrationMode
+from src.validators.typings import DepositData, RelayerTypes, ValidatorsRegistrationMode
 from src.validators.utils import load_deposit_data
 
 logger = logging.getLogger(__name__)
@@ -48,6 +48,10 @@ async def start_base() -> None:
     keystore: BaseKeystore | None = None
     deposit_data: DepositData | None = None
     relayer_adapter: RelayerAdapter | None = None
+
+    # Override dvt setting for API setups running with DVT relayer
+    if settings.relayer_type == RelayerTypes.DVT:
+        settings.runs_dvt_setup = True
 
     # load keystore and deposit data
     if settings.validators_registration_mode == ValidatorsRegistrationMode.AUTO:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -92,6 +92,10 @@ class Settings(metaclass=Singleton):
         'DISABLE_DEPOSIT_DATA_WARNINGS', default=False, cast=bool
     )
 
+    runs_dvt_setup: bool = decouple_config(
+        'RUNS_DVT_SETUP', default=False, cast=bool,
+    )
+
     min_validators_registration: int
 
     # pylint: disable-next=too-many-arguments,too-many-locals,too-many-statements

--- a/src/validators/execution.py
+++ b/src/validators/execution.py
@@ -187,7 +187,9 @@ async def update_unused_validator_keys_metric(
 
     validators: int = 0
     for validator in deposit_data.validators:
-        if validator.public_key not in keystore:
+        # This check is skipped for DVT, since keystore contains
+        # key shares and not original public keys
+        if validator.public_key not in keystore and not settings.runs_dvt_setup:
             continue
 
         if NetworkValidatorCrud().is_validator_registered(validator.public_key):


### PR DESCRIPTION
We discovered that DVT enabled operator instances report `sw_operator_unused_validator_keys` incorrectly, always as zero ( https://github.com/stakewise/v3-operator/issues/421 ).

This happens because logic that determines number of unused keys, skips keys that are not in the keystore (regardless whether it's loaded from Hashicorp vault or local filesystem). Within DVT setup, the local keystore contains BLS key shares instead of validator full keys, and the key shares have their derived public key different from a validator key, which leads to all keys that are in deposit data, being skipped because they do not match any of key share public keys.

Because it is not possible to heuristically determine whether the keys loaded are full validator keys or key shares, we propose to add new parameter `RUNS_DVT_SETUP` which will signalize to the unused keys logic that keys not present in keystore should not be skipped. Also, added the logic to override this setting to `true` in relayer setups that are configured to use DVT via `--relayer-type` parameter.