### PR TITLE
Validate source_address on pending EL withdrawal/consolidation requests

### DIFF
--- a/src/common/consolidations.py
+++ b/src/common/consolidations.py
@@ -39,6 +39,9 @@ async def get_pending_consolidations(
 
     execution_consolidations = await get_execution_consolidations(chain_head.block_number)
     for cons in execution_consolidations:
+        if cons['source_address'] != settings.vault:
+            continue
+
         source_pubkey = cons['source_pubkey']
         target_pubkey = cons['target_pubkey']
 

--- a/src/common/withdrawals.py
+++ b/src/common/withdrawals.py
@@ -36,6 +36,9 @@ async def get_pending_partial_withdrawals(
 
     execution_withdrawals = await get_execution_partial_withdrawals(chain_head.block_number)
     for withdrawal in execution_withdrawals:
+        if withdrawal['source_address'] != settings.vault:
+            continue
+
         public_key = withdrawal['public_key']
         if public_key not in public_key_to_index:
             continue


### PR DESCRIPTION
## Issue

External bug report: https://gist.github.com/Leminkay/9e9a35d39ecc8359291a5cf3466fcc3c

When reading pending requests from the EIP-7002 withdrawal predeploy and the EIP-7251 consolidation predeploy, the operator matched queue entries purely by validator pubkey and ignored each entry's `source_address` field (the `msg.sender` that submitted the request).

Per EIP-7002 / EIP-7251, the consensus layer only honors a request whose `source_address` matches the validator's execution withdrawal address (i.e. the vault). Any other sender can spam the predeploy queue with arbitrary pubkeys: those entries will be discarded at the CL, but the operator counted them as legitimate pending operations.

## Impact (DoS)

- `get_pending_partial_withdrawals()` returned inflated entries, feeding `get_queued_assets()` and suppressing/delaying legitimate automated withdrawals.
- `get_pending_consolidations()` returned inflated entries, causing `ConsolidationManager` to mark validators as busy and skip valid consolidations.

## Fix

Filter execution-layer queue entries by `source_address == settings.vault` before the existing pubkey match, in both:

- `src/common/withdrawals.py` (`get_pending_partial_withdrawals`)
- `src/common/consolidations.py` (`get_pending_consolidations`)

The raw queue readers (`get_execution_partial_withdrawals` / `get_execution_consolidations`) are unchanged so the global queue length remains available for the EIP-7002/7251 fee computation, which correctly depends on the total network excess rather than per-vault counts.