### PR TITLE
Log metrics server address

### DIFF
--- a/src/commands/start/startup_check.py
+++ b/src/commands/start/startup_check.py
@@ -88,7 +88,7 @@ async def startup_checks() -> None:
     await check_vault_version()
 
     if settings.enable_metrics:
-        logger.info('Checking metrics server...')
+        logger.info('Checking whether metrics port is available...')
         check_metrics_port()
 
     if (

--- a/src/common/metrics.py
+++ b/src/common/metrics.py
@@ -110,5 +110,9 @@ logger = logging.getLogger(__name__)
 
 
 async def metrics_server() -> None:
-    logger.info('Starting metrics server')
+    logger.info(
+        'Starting metrics server at http://%s:%d',
+        settings.metrics_host,
+        settings.metrics_port,
+    )
     start_http_server(settings.metrics_port, settings.metrics_host)


### PR DESCRIPTION
## Summary
- Log the metrics server host and port on startup (e.g. `Starting metrics server at http://localhost:9100`)
- Clarify the pre-flight check message to make clear we're checking port availability, not probing a running server

## Why
The previous logs (`Checking metrics server...` / `Starting metrics server`) didn't show where the metrics server is exposed, and the "checking" message was ambiguous about what it actually verifies.