### PR TITLE
Use latest release in install.sh instead of hardcoded version

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -288,7 +288,7 @@ http_copy() {
 github_release() {
   owner_repo=$1
   version=$2
-  test -z "$version" && version="v4.2.0"
+  test -z "$version" && version="latest"
   giturl="https://github.com/${owner_repo}/releases/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1


### PR DESCRIPTION
## Problem

When `scripts/install.sh` was run without a `[tag]` argument, `github_release()` defaulted to a hardcoded `version="v4.2.0"`. Since v4.2.0 is not released yet, `https://github.com/stakewise/v3-operator/releases/v4.2.0` returns **HTTP 404**, so the lookup returned empty and the install aborted with `unable to find ''`.

## Fix

Default to GitHub's `latest` endpoint, which always resolves to the most recent **stable** (non-prerelease) release. The existing parsing extracts `tag_name` from the JSON response — verified it resolves to the current latest release (`v4.1.14`).

This also means the default no longer needs a manual bump on every release.