### PR TITLE
Remind operator to upgrade when newer release is available

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4299,4 +4299,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "d1f9dc207cf5e8d49d7173561d08aadeb59d09f85cf34029166132336e25f533"
+content-hash = "5342b6cbd591adf46f4a2c9257a6b7244428734465b4a8b1e4b07b41a5a9a506"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ psycopg2 = "==2.9.9"
 pyyaml = "==6.0.1"
 python-json-logger = "==2.0.7"
 psutil = "==7.0.0"
+packaging = "==26.0"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "==3.3.3"

--- a/src/commands/start/startup_check.py
+++ b/src/commands/start/startup_check.py
@@ -11,6 +11,7 @@ from src.common.startup_check import (
     check_execution_nodes_network,
     check_ipfs_endpoints,
     check_metrics_port,
+    check_operator_version,
     check_relayer_endpoint,
     check_validators_manager,
     check_vault_address,
@@ -34,6 +35,9 @@ logger = logging.getLogger(__name__)
 # pylint: disable-next=too-many-statements
 async def startup_checks() -> None:
     validate_settings()
+
+    logger.info('Checking for newer operator version...')
+    await check_operator_version()
 
     logger.info('Checking connection to database...')
     db_client.create_db_dir()

--- a/src/common/clients.py
+++ b/src/common/clients.py
@@ -21,6 +21,7 @@ from src.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
+# Set an explicit user agent so Operator requests are easy to spot in EL/CL node logs
 OPERATOR_USER_AGENT = f'StakeWise Operator {src.__version__}'
 
 

--- a/src/common/startup_check.py
+++ b/src/common/startup_check.py
@@ -404,7 +404,7 @@ async def check_operator_version() -> None:
     try:
         async with ClientSession(
             timeout=ClientTimeout(30),
-            headers={'Accept': 'application/json', 'User-Agent': OPERATOR_USER_AGENT},
+            headers={'Accept': 'application/json'},
         ) as session:
             async with session.get(LATEST_RELEASE_URL) as response:
                 response.raise_for_status()

--- a/src/common/startup_check.py
+++ b/src/common/startup_check.py
@@ -10,6 +10,7 @@ import psutil
 from aiohttp import ClientSession, ClientTimeout
 from click import ClickException
 from eth_typing import BlockNumber
+from packaging.version import InvalidVersion, Version
 from sw_utils import (
     ChainHead,
     InterruptHandler,
@@ -22,6 +23,7 @@ from sw_utils.graph.client import GraphClient as SWGraphClient
 from web3 import Web3
 from web3.exceptions import BadFunctionCallOutput
 
+import src
 from src.common.clients import OPERATOR_USER_AGENT
 from src.common.clients import execution_client as default_execution_client
 from src.common.contracts import (
@@ -45,6 +47,11 @@ from src.validators.relayer import RelayerClient
 logger = logging.getLogger(__name__)
 
 IPFS_HASH_EXAMPLE = 'QmawUdo17Fvo7xa6ARCUSMV1eoVwPtVuzx8L8Crj2xozWm'
+
+# Used to remind the operator about newer stable releases on startup.
+# The `latest` endpoint always resolves to the most recent non-prerelease release.
+LATEST_RELEASE_URL = 'https://github.com/stakewise/v3-operator/releases/latest'
+RELEASES_URL = 'https://github.com/stakewise/v3-operator/releases'
 
 
 def validate_settings() -> None:
@@ -384,6 +391,38 @@ async def check_vault_version() -> None:
     vault_version = await vault_contract.version()
     if not is_vault_upgraded_to_pectra(settings.network, settings.vault, vault_version):
         raise RuntimeError(f'Please upgrade Vault {settings.vault} to the latest version.')
+
+
+async def check_operator_version() -> None:
+    """
+    Reminds the operator to upgrade when a newer stable release is available.
+
+    This check is best-effort: any failure to reach GitHub (network issues,
+    rate limiting, unexpected response) is logged as a warning and never aborts
+    startup.
+    """
+    try:
+        async with ClientSession(
+            timeout=ClientTimeout(30),
+            headers={'Accept': 'application/json', 'User-Agent': OPERATOR_USER_AGENT},
+        ) as session:
+            async with session.get(LATEST_RELEASE_URL) as response:
+                response.raise_for_status()
+                data = await response.json(content_type=None)
+
+        latest_version = data['tag_name']
+        if Version(src.__version__) < Version(latest_version):
+            logger.warning(
+                'A newer operator version %s is available (current version is %s). '
+                'Please consider upgrading: %s',
+                latest_version,
+                src.__version__,
+                RELEASES_URL,
+            )
+    except (InvalidVersion, KeyError, TypeError) as e:
+        logger.warning('Failed to parse the latest operator version: %s', format_error(e))
+    except Exception as e:
+        logger.warning('Failed to check for newer operator version: %s', format_error(e))
 
 
 async def check_events_logs() -> None:

--- a/src/common/startup_check.py
+++ b/src/common/startup_check.py
@@ -413,10 +413,9 @@ async def check_operator_version() -> None:
         latest_version = data['tag_name']
         if Version(src.__version__) < Version(latest_version):
             logger.warning(
-                'A newer operator version %s is available (current version is %s). '
-                'Please consider upgrading: %s',
+                'A newer Operator version is available: %s. '
+                'Upgrading to the latest release is recommended: %s',
                 latest_version,
-                src.__version__,
                 RELEASES_URL,
             )
     except (InvalidVersion, KeyError, TypeError) as e:

--- a/src/meta_vault/startup_check.py
+++ b/src/meta_vault/startup_check.py
@@ -6,6 +6,7 @@ from eth_typing import ChecksumAddress
 from src.common.execution import check_wallet_balance
 from src.common.startup_check import (
     check_execution_nodes_network,
+    check_operator_version,
     wait_for_execution_node,
     wait_for_graph_node_sync_to_chain_head,
 )
@@ -16,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 async def startup_checks(meta_vault_addresses: list[ChecksumAddress]) -> None:
+    logger.info('Checking for newer operator version...')
+    await check_operator_version()
+
     logger.info('Checking connection to execution nodes...')
     await wait_for_execution_node()
 


### PR DESCRIPTION
## Summary

Adds a best-effort **operator version reminder** to the startup checks. On startup the operator queries GitHub's `releases/latest` endpoint (the same approach used by `scripts/install.sh`), which always resolves to the most recent **stable** (non-prerelease) release, and warns if a newer version than the running one is available.

## Details

- New `check_operator_version()` in `src/common/startup_check.py`:
  - Fetches `https://github.com/stakewise/v3-operator/releases/latest` with `Accept: application/json`, parses `tag_name`.
  - Compares against the running `src.__version__` using `packaging.version.Version`.
  - Logs a warning recommending an upgrade when a newer release exists.
  - **Never aborts startup** — all failures (GitHub unreachable, rate limiting, malformed response, unparseable version) are caught and logged as a warning.
- Wired into both startup paths:
  - `start` / `start-local` → `src/commands/start/startup_check.py`
  - `process-meta-vaults` → `src/meta_vault/startup_check.py`
- Added `packaging = "==26.0"` as a pinned direct dependency (already resolved in the lock; `poetry.lock` change is limited to the content-hash via `--no-update`).

## Testing

- Smoke-tested all paths: newer-available → upgrade warning; up-to-date → silent; network failure → warning without raising.
- Full pre-commit lint suite (black, isort, mypy, pylint, flake8, bandit) passes.