### PR TITLE
Add --dry-run to process-redeemer command

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -109,6 +109,13 @@ DEFAULT_MIN_QUEUED_ASSETS_GWEI = Web3.from_wei(DEFAULT_MIN_QUEUED_ASSETS, 'gwei'
     is_flag=True,
 )
 @click.option(
+    '--dry-run',
+    help='Simulate redeemOsTokenPositions calls without submitting transactions. '
+    'Default is false.',
+    envvar='DRY_RUN',
+    is_flag=True,
+)
+@click.option(
     '--network',
     help='The network of the meta vaults.',
     prompt='Enter the network name',
@@ -125,6 +132,7 @@ def process_redeemer(
     execution_jwt_secret: str | None,
     network: str,
     verbose: bool,
+    dry_run: bool,
     log_level: str,
     interval: int,
     min_queued_assets_gwei: int,
@@ -148,6 +156,7 @@ def process_redeemer(
             main(
                 interval=interval,
                 min_queued_assets=Gwei(min_queued_assets_gwei),
+                dry_run=dry_run,
             )
         )
     except Exception as e:
@@ -158,10 +167,13 @@ def process_redeemer(
 async def main(
     interval: int,
     min_queued_assets: Gwei,
+    dry_run: bool = False,
 ) -> None:
     setup_logging()
     await setup_clients()
     await _startup_check()
+    if dry_run:
+        logger.info('Dry run enabled: redeemOsTokenPositions calls will be simulated only.')
     try:
         with InterruptHandler() as interrupt_handler:
             while not interrupt_handler.exit:
@@ -169,6 +181,7 @@ async def main(
                 await process(
                     block_number=block_number,
                     min_queued_assets=min_queued_assets,
+                    dry_run=dry_run,
                 )
                 await interrupt_handler.sleep(interval)
 
@@ -179,18 +192,23 @@ async def main(
 async def process(
     block_number: BlockNumber,
     min_queued_assets: Gwei,
+    dry_run: bool = False,
 ) -> None:
     try:
-        await _redeem_os_token_positions(min_queued_assets=min_queued_assets)
+        await _redeem_os_token_positions(min_queued_assets=min_queued_assets, dry_run=dry_run)
     finally:
-        # Re-fetch block number after redemption processing
-        # to ensure we read the latest on-chain state.
-        block_number = await execution_client.eth.block_number
-        await _process_exit_queue(block_number)
+        if dry_run:
+            logger.info('Dry run: skipping processExitQueue.')
+        else:
+            # Re-fetch block number after redemption processing
+            # to ensure we read the latest on-chain state.
+            block_number = await execution_client.eth.block_number
+            await _process_exit_queue(block_number)
 
 
 async def _redeem_os_token_positions(
     min_queued_assets: Gwei,
+    dry_run: bool = False,
 ) -> None:
     """Perform the OsToken redemption flow for a single iteration.
 
@@ -253,15 +271,18 @@ async def _redeem_os_token_positions(
         converter=os_token_converter,
         nonce=nonce,
         block_number=block_number,
+        dry_run=dry_run,
     )
 
 
+# pylint: disable-next=too-many-arguments
 async def redeem_positions(
     all_positions: list[OsTokenPosition],
     os_token_positions: list[OsTokenPosition],
     converter: OsTokenConverter,
     nonce: int,
     block_number: BlockNumber,
+    dry_run: bool = False,
 ) -> None:
     """Redeem positions one by one. Each position's shares_to_redeem is already set by
     assign_shares_to_redeem; this function further caps it by the vault's withdrawable assets.
@@ -278,10 +299,12 @@ async def redeem_positions(
         assets_to_redeem = converter.to_assets(shares_to_redeem)
 
         if await is_meta_vault(position.vault):
-            raise RuntimeError(
-                f'Unexpected meta vault position for {position.vault}; '
-                'redeemable positions should not include meta vaults.'
+            logger.warning(
+                'Unexpected meta vault position for %s; '
+                'redeemable positions should not include meta vaults.',
+                position.vault,
             )
+            continue
 
         if position.vault in unharvested_vaults:
             continue
@@ -304,15 +327,14 @@ async def redeem_positions(
             continue
 
         position_to_redeem = replace(position, shares_to_redeem=shares_to_redeem)
-        receipt_block = await _submit_redeem_position(
+        redeemed = await _submit_redeem_position(
             position=position_to_redeem,
             all_positions=all_positions,
             nonce=nonce,
+            dry_run=dry_run,
         )
-        if receipt_block is None:
+        if not redeemed:
             return
-
-        await wait_for_execution_endpoints_synced(receipt_block)
 
         vault_to_withdrawable[position.vault] = Wei(withdrawable - assets_to_redeem)
 
@@ -346,11 +368,12 @@ async def _submit_redeem_position(
     position: OsTokenPosition,
     all_positions: list[OsTokenPosition],
     nonce: int,
-) -> BlockNumber | None:
+    dry_run: bool = False,
+) -> bool:
     """Submit one redeemOsTokenPositions transaction for a single position.
 
-    Returns the receipt block on success (used as a sync barrier against
-    fallback endpoints lagging behind), ``None`` otherwise.
+    Returns ``True`` on success, ``False`` otherwise. When ``dry_run`` is set,
+    the call is simulated via ``.call()`` instead of being submitted.
     """
     multiproof = _build_multi_proof(
         nonce=nonce,
@@ -360,10 +383,30 @@ async def _submit_redeem_position(
     positions_arg = [
         (position.vault, position.owner, position.leaf_shares, position.shares_to_redeem)
     ]
-    try:
-        tx_function = os_token_redeemer_contract.contract.functions.redeemOsTokenPositions(
-            positions_arg, multiproof.proof, multiproof.proof_flags
+    tx_function = os_token_redeemer_contract.contract.functions.redeemOsTokenPositions(
+        positions_arg, multiproof.proof, multiproof.proof_flags
+    )
+
+    if dry_run:
+        try:
+            await tx_function.call()
+        except (Web3Exception, RuntimeError, ValueError) as e:
+            logger.error(
+                'Dry run: failed to simulate redeem position (vault %s, owner %s): %r',
+                position.vault,
+                position.owner,
+                e,
+            )
+            return False
+        logger.info(
+            'Dry run: simulated redeeming %s shares for position (vault %s, owner %s) successfully',
+            position.shares_to_redeem,
+            position.vault,
+            position.owner,
         )
+        return True
+
+    try:
         tx = await transaction_gas_wrapper(tx_function=tx_function)
     except (Web3Exception, RuntimeError, ValueError):
         logger.exception(
@@ -371,7 +414,7 @@ async def _submit_redeem_position(
             position.vault,
             position.owner,
         )
-        return None
+        return False
 
     tx_hash = Web3.to_hex(tx)
     logger.info(
@@ -390,7 +433,7 @@ async def _submit_redeem_position(
             position.owner,
             tx_hash,
         )
-        return None
+        return False
 
     logger.info(
         'Redeemed %s shares for position (vault %s, owner %s). Tx Hash: %s',
@@ -399,7 +442,9 @@ async def _submit_redeem_position(
         position.owner,
         tx_hash,
     )
-    return tx_receipt['blockNumber']
+    # Barrier against fallback endpoints lagging behind the receipt block.
+    await wait_for_execution_endpoints_synced(tx_receipt['blockNumber'])
+    return True
 
 
 def _build_multi_proof(

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -182,20 +182,19 @@ class TestRedeemPositions:
         assert submitted.leaf_shares == Wei(1000)
         assert submitted.shares_to_redeem == Wei(500)
 
-    async def test_meta_vault_position_raises(self) -> None:
-        """A meta-vault position is unexpected and must surface as a RuntimeError."""
+    async def test_meta_vault_position_skipped(self) -> None:
+        """A meta-vault position is unexpected and must be skipped without redeeming."""
         pos = make_position(processed_shares=500)
         get_withdrawable = AsyncMock(return_value=Wei(10000))
 
         with _mock_redeem_positions(withdrawable=get_withdrawable, is_meta_vault=True) as mocks:
-            with pytest.raises(RuntimeError, match='Unexpected meta vault position'):
-                await redeem_positions(
-                    all_positions=[pos],
-                    os_token_positions=[pos],
-                    converter=make_converter(100, 100),
-                    nonce=5,
-                    block_number=BlockNumber(100),
-                )
+            await redeem_positions(
+                all_positions=[pos],
+                os_token_positions=[pos],
+                converter=make_converter(100, 100),
+                nonce=5,
+                block_number=BlockNumber(100),
+            )
 
         mocks['submit_mock'].assert_not_called()
         get_withdrawable.assert_not_called()
@@ -226,7 +225,7 @@ class TestRedeemPositions:
 
         with _mock_redeem_positions(
             withdrawable=Wei(10000),
-            submit_results=[None, BlockNumber(123)],
+            submit_results=[False, True],
         ) as mocks:
             await redeem_positions(
                 all_positions=[pos1, pos2],
@@ -244,7 +243,7 @@ class TestRedeemPositions:
 
 
 class TestSubmitRedeemPosition:
-    async def test_success_returns_receipt_block(self) -> None:
+    async def test_success_returns_true(self) -> None:
         position = make_position(leaf_shares=1000, shares_to_redeem=500)
         with _mock_submit_redeem_position(tx_status=1) as mocks:
             result = await _submit_redeem_position(
@@ -252,24 +251,27 @@ class TestSubmitRedeemPosition:
                 all_positions=[position],
                 nonce=5,
             )
-        assert result == BlockNumber(456)
+        assert result is True
         mocks['transaction_gas_wrapper'].assert_awaited_once()
         mocks['client'].eth.wait_for_transaction_receipt.assert_awaited_once()
+        mocks['wait_for_execution_endpoints_synced'].assert_awaited_once_with(BlockNumber(456))
 
-    async def test_tx_status_zero_returns_none(self) -> None:
-        """A reverted on-chain tx returns None without raising."""
+    async def test_tx_status_zero_returns_false(self) -> None:
+        """A reverted on-chain tx returns False without raising."""
         position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_submit_redeem_position(tx_status=0):
+        with _mock_submit_redeem_position(tx_status=0) as mocks:
             result = await _submit_redeem_position(
                 position=position,
                 all_positions=[position],
                 nonce=5,
             )
-        assert result is None
+        assert result is False
+        # No sync barrier when the tx reverted
+        mocks['wait_for_execution_endpoints_synced'].assert_not_awaited()
 
     @pytest.mark.parametrize('exc_class', [Web3Exception, RuntimeError, ValueError])
-    async def test_tx_build_failure_returns_none(self, exc_class: type[Exception]) -> None:
-        """Each caught exception during tx build/send returns None."""
+    async def test_tx_build_failure_returns_false(self, exc_class: type[Exception]) -> None:
+        """Each caught exception during tx build/send returns False."""
         position = make_position(leaf_shares=1000, shares_to_redeem=500)
         with _mock_submit_redeem_position(send_exception=exc_class('boom')) as mocks:
             result = await _submit_redeem_position(
@@ -277,7 +279,7 @@ class TestSubmitRedeemPosition:
                 all_positions=[position],
                 nonce=5,
             )
-        assert result is None
+        assert result is False
         # Receipt is never awaited when the build step raised
         mocks['client'].eth.wait_for_transaction_receipt.assert_not_awaited()
 
@@ -414,7 +416,7 @@ def _mock_redeem_positions(
     withdrawable: Wei | AsyncMock | None = None,
     is_meta_vault: bool = False,
     state_update_required: bool = False,
-    submit_results: list[BlockNumber | None] | None = None,
+    submit_results: list[bool] | None = None,
 ) -> Iterator[dict[str, MagicMock]]:
     """Mock setup for redeem_positions tests.
 
@@ -422,7 +424,7 @@ def _mock_redeem_positions(
     AsyncMock for fine-grained control (e.g. ``side_effect=[...]`` for sequenced returns).
     ``state_update_required`` drives VaultContract.is_state_update_required, which gates
     the unharvested-vault skip. ``submit_results`` controls per-call return values of
-    _submit_redeem_position; a ``None`` entry models a failed submission that should
+    _submit_redeem_position; a ``False`` entry models a failed submission that should
     abort the round.
     """
     if isinstance(withdrawable, AsyncMock):
@@ -435,7 +437,7 @@ def _mock_redeem_positions(
     if submit_results is not None:
         submit_mock = AsyncMock(side_effect=submit_results)
     else:
-        submit_mock = AsyncMock(return_value=BlockNumber(123))
+        submit_mock = AsyncMock(return_value=True)
 
     vault_contract = MagicMock()
     vault_contract.is_state_update_required = AsyncMock(return_value=state_update_required)
@@ -483,10 +485,12 @@ def _mock_submit_redeem_position(
     else:
         gas_wrapper = AsyncMock(return_value=tx)
 
+    synced_mock = AsyncMock()
     with (
         patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
         patch(f'{MODULE}.transaction_gas_wrapper', new=gas_wrapper),
         patch(f'{MODULE}.execution_client', new=mock_client),
+        patch(f'{MODULE}.wait_for_execution_endpoints_synced', new=synced_mock),
         patch(f'{MODULE}.settings') as mock_settings,
     ):
         mock_settings.execution_transaction_timeout = 120
@@ -495,6 +499,7 @@ def _mock_submit_redeem_position(
             'redeemer': mock_redeemer,
             'transaction_gas_wrapper': gas_wrapper,
             'client': mock_client,
+            'wait_for_execution_endpoints_synced': synced_mock,
         }
 
 


### PR DESCRIPTION
## Summary
Adds a `--dry-run` flag (env `DRY_RUN`) to the `process-redeemer` command.

When enabled:
- Every `redeemOsTokenPositions` call is **simulated** via `.call()` instead of being submitted as a transaction.
- On-chain state is left untouched between positions (no withdrawable-assets decrement, no endpoint-sync wait).
- `processExitQueue` is skipped entirely.

## Notes
- Pure simulation per position against current chain state.
- Failures are logged with the exception instance (no traceback noise).
