### PR TITLE
Extract PositionsMerkleTree class

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 import click
 from eth_typing import BlockNumber, ChecksumAddress
-from multiproof import StandardMerkleTree
-from multiproof.standard import MultiProof
 from sw_utils import InterruptHandler
 from web3 import Web3
 from web3.exceptions import Web3Exception
@@ -34,6 +32,7 @@ from src.redemptions.fetch_positions import (
     update_positions_cache,
     update_processed_shares_cache,
 )
+from src.redemptions.merkle_tree import PositionsMerkleTree
 from src.redemptions.os_token_converter import (
     OsTokenConverter,
     create_os_token_converter,
@@ -265,22 +264,20 @@ async def _redeem_os_token_positions(
         logger.info('No redeemable positions found. Skipping to next interval.')
         return
 
+    tree = PositionsMerkleTree(all_positions, nonce)
     await redeem_positions(
-        all_positions=all_positions,
+        tree=tree,
         os_token_positions=os_token_positions,
         converter=os_token_converter,
-        nonce=nonce,
         block_number=block_number,
         dry_run=dry_run,
     )
 
 
-# pylint: disable-next=too-many-arguments
 async def redeem_positions(
-    all_positions: list[OsTokenPosition],
+    tree: PositionsMerkleTree,
     os_token_positions: list[OsTokenPosition],
     converter: OsTokenConverter,
-    nonce: int,
     block_number: BlockNumber,
     dry_run: bool = False,
 ) -> None:
@@ -329,8 +326,7 @@ async def redeem_positions(
         position_to_redeem = replace(position, shares_to_redeem=shares_to_redeem)
         redeemed = await _submit_redeem_position(
             position=position_to_redeem,
-            all_positions=all_positions,
-            nonce=nonce,
+            tree=tree,
             dry_run=dry_run,
         )
         if not redeemed:
@@ -366,8 +362,7 @@ async def _startup_check() -> None:
 
 async def _submit_redeem_position(
     position: OsTokenPosition,
-    all_positions: list[OsTokenPosition],
-    nonce: int,
+    tree: PositionsMerkleTree,
     dry_run: bool = False,
 ) -> bool:
     """Submit one redeemOsTokenPositions transaction for a single position.
@@ -375,11 +370,7 @@ async def _submit_redeem_position(
     Returns ``True`` on success, ``False`` otherwise. When ``dry_run`` is set,
     the call is simulated via ``.call()`` instead of being submitted.
     """
-    multiproof = _build_multi_proof(
-        nonce=nonce,
-        all_positions=all_positions,
-        positions_to_redeem=[position],
-    )
+    multiproof = tree.get_multi_proof([position])
     positions_arg = [
         (position.vault, position.owner, position.leaf_shares, position.shares_to_redeem)
     ]
@@ -445,18 +436,3 @@ async def _submit_redeem_position(
     # Barrier against fallback endpoints lagging behind the receipt block.
     await wait_for_execution_endpoints_synced(tx_receipt['blockNumber'])
     return True
-
-
-def _build_multi_proof(
-    nonce: int,
-    all_positions: list[OsTokenPosition],
-    positions_to_redeem: list[OsTokenPosition],
-) -> MultiProof[tuple[int, ChecksumAddress, Wei, ChecksumAddress]]:
-    """Build a merkle multiproof from all positions, proving the positions to redeem."""
-    all_leaves = [p.merkle_leaf(nonce - 1) for p in all_positions]
-    tree = StandardMerkleTree.of(
-        all_leaves,
-        ['uint256', 'address', 'uint256', 'address'],
-    )
-    redeem_leaves = [p.merkle_leaf(nonce - 1) for p in positions_to_redeem]
-    return tree.get_multi_proof(redeem_leaves)

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -12,13 +12,13 @@ from web3.exceptions import Web3Exception
 from web3.types import Gwei, Wei
 
 from src.redemptions.commands.process_redeemer import (
-    _build_multi_proof,
     _process_exit_queue,
     _startup_check,
     _submit_redeem_position,
     process,
     redeem_positions,
 )
+from src.redemptions.merkle_tree import PositionsMerkleTree
 from src.redemptions.os_token_converter import OsTokenConverter
 from src.redemptions.typings import OsTokenPosition
 
@@ -30,51 +30,13 @@ OWNER_1 = Web3.to_checksum_address('0x' + '33' * 20)
 OWNER_2 = Web3.to_checksum_address('0x' + '44' * 20)
 
 
-# --- Pure function tests (no mocks) ---
-
-
-class TestBuildMultiProof:
-    def test_single_position(self) -> None:
-        position = make_position(leaf_shares=1000, processed_shares=500)
-        result = _build_multi_proof(
-            nonce=5,
-            all_positions=[position],
-            positions_to_redeem=[position],
-        )
-        assert len(result.leaves) == 1
-
-    def test_partial_redeem(self) -> None:
-        pos1 = make_position(vault=VAULT_1, owner=OWNER_1, leaf_shares=1000, processed_shares=500)
-        pos2 = make_position(vault=VAULT_2, owner=OWNER_2, leaf_shares=2000, processed_shares=1000)
-
-        result = _build_multi_proof(
-            nonce=5,
-            all_positions=[pos1, pos2],
-            positions_to_redeem=[pos1],
-        )
-        assert len(result.leaves) == 1
-        assert len(result.proof) > 0
-
-    def test_all_positions_redeemed(self) -> None:
-        pos1 = make_position(vault=VAULT_1, owner=OWNER_1, leaf_shares=1000, processed_shares=500)
-        pos2 = make_position(vault=VAULT_2, owner=OWNER_2, leaf_shares=2000, processed_shares=1000)
-
-        result = _build_multi_proof(
-            nonce=5,
-            all_positions=[pos1, pos2],
-            positions_to_redeem=[pos1, pos2],
-        )
-        assert len(result.leaves) == 2
-
-
 class TestRedeemPositions:
     async def test_empty_positions(self) -> None:
         with _mock_redeem_positions() as mocks:
             await redeem_positions(
-                all_positions=[],
+                tree=make_tree(),
                 os_token_positions=[],
                 converter=make_converter(),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
         mocks['submit_mock'].assert_not_called()
@@ -84,10 +46,9 @@ class TestRedeemPositions:
 
         with _mock_redeem_positions(withdrawable=Wei(1000)) as mocks:
             await redeem_positions(
-                all_positions=[position],
+                tree=make_tree([position]),
                 os_token_positions=[position],
                 converter=make_converter(),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -99,10 +60,9 @@ class TestRedeemPositions:
 
         with _mock_redeem_positions(withdrawable=Wei(100)) as mocks:
             await redeem_positions(
-                all_positions=[position],
+                tree=make_tree([position]),
                 os_token_positions=[position],
                 converter=make_converter(100, 100),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -114,10 +74,9 @@ class TestRedeemPositions:
 
         with _mock_redeem_positions(withdrawable=Wei(0)) as mocks:
             await redeem_positions(
-                all_positions=[position],
+                tree=make_tree([position]),
                 os_token_positions=[position],
                 converter=make_converter(100, 100),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -131,10 +90,9 @@ class TestRedeemPositions:
         get_withdrawable = AsyncMock(return_value=Wei(700))
         with _mock_redeem_positions(withdrawable=get_withdrawable) as mocks:
             await redeem_positions(
-                all_positions=[pos1, pos2],
+                tree=make_tree([pos1, pos2]),
                 os_token_positions=[pos1, pos2],
                 converter=make_converter(100, 100),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -156,10 +114,9 @@ class TestRedeemPositions:
 
         with _mock_redeem_positions(withdrawable=Wei(10000)) as mocks:
             await redeem_positions(
-                all_positions=[pos],
+                tree=make_tree([pos]),
                 os_token_positions=[pos],
                 converter=make_converter(),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -171,10 +128,9 @@ class TestRedeemPositions:
 
         with _mock_redeem_positions(withdrawable=Wei(10000)) as mocks:
             await redeem_positions(
-                all_positions=[pos],
+                tree=make_tree([pos]),
                 os_token_positions=[pos],
                 converter=make_converter(),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -189,10 +145,9 @@ class TestRedeemPositions:
 
         with _mock_redeem_positions(withdrawable=get_withdrawable, is_meta_vault=True) as mocks:
             await redeem_positions(
-                all_positions=[pos],
+                tree=make_tree([pos]),
                 os_token_positions=[pos],
                 converter=make_converter(100, 100),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -208,10 +163,9 @@ class TestRedeemPositions:
             state_update_required=True,
         ) as mocks:
             await redeem_positions(
-                all_positions=[pos],
+                tree=make_tree([pos]),
                 os_token_positions=[pos],
                 converter=make_converter(100, 100),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -228,10 +182,9 @@ class TestRedeemPositions:
             submit_results=[False, True],
         ) as mocks:
             await redeem_positions(
-                all_positions=[pos1, pos2],
+                tree=make_tree([pos1, pos2]),
                 os_token_positions=[pos1, pos2],
                 converter=make_converter(100, 100),
-                nonce=5,
                 block_number=BlockNumber(100),
             )
 
@@ -248,8 +201,7 @@ class TestSubmitRedeemPosition:
         with _mock_submit_redeem_position(tx_status=1) as mocks:
             result = await _submit_redeem_position(
                 position=position,
-                all_positions=[position],
-                nonce=5,
+                tree=make_tree([position]),
             )
         assert result is True
         mocks['transaction_gas_wrapper'].assert_awaited_once()
@@ -262,8 +214,7 @@ class TestSubmitRedeemPosition:
         with _mock_submit_redeem_position(tx_status=0) as mocks:
             result = await _submit_redeem_position(
                 position=position,
-                all_positions=[position],
-                nonce=5,
+                tree=make_tree([position]),
             )
         assert result is False
         # No sync barrier when the tx reverted
@@ -276,8 +227,7 @@ class TestSubmitRedeemPosition:
         with _mock_submit_redeem_position(send_exception=exc_class('boom')) as mocks:
             result = await _submit_redeem_position(
                 position=position,
-                all_positions=[position],
-                nonce=5,
+                tree=make_tree([position]),
             )
         assert result is False
         # Receipt is never awaited when the build step raised
@@ -290,8 +240,7 @@ class TestSubmitRedeemPosition:
             with pytest.raises(KeyError):
                 await _submit_redeem_position(
                     position=position,
-                    all_positions=[position],
-                    nonce=5,
+                    tree=make_tree([position]),
                 )
 
 
@@ -404,8 +353,8 @@ class TestProcess:
 
         mocks['mock_redeem'].assert_awaited_once()
         redeem_call = mocks['mock_redeem'].await_args
-        # nonce is passed directly; _build_multi_proof uses nonce - 1 internally
-        assert redeem_call.kwargs['nonce'] == 5
+        # The merkle tree is built from the fetched nonce; leaves use nonce - 1 internally
+        assert redeem_call.kwargs['tree'].nonce == 5
 
 
 # --- Helpers ---
@@ -556,6 +505,14 @@ def _mock_process(
 
 def make_converter(total_assets: int = 110, total_shares: int = 100) -> OsTokenConverter:
     return OsTokenConverter(Wei(total_assets), Wei(total_shares))
+
+
+def make_tree(
+    positions: list[OsTokenPosition] | None = None, nonce: int = 5
+) -> PositionsMerkleTree:
+    """Build a positions merkle tree. Defaults to a single position so callers that
+    only need a valid tree (e.g. when _submit_redeem_position is mocked) can omit it."""
+    return PositionsMerkleTree(positions or [make_position()], nonce)
 
 
 def make_position(

--- a/src/redemptions/merkle_tree.py
+++ b/src/redemptions/merkle_tree.py
@@ -9,15 +9,10 @@ LEAF_TYPES = ['uint256', 'address', 'uint256', 'address']
 
 
 class PositionsMerkleTree:
-    """Merkle tree built from all OsToken positions for a given redemption nonce.
-
-    Building the tree from ALL positions makes its root match the on-chain
-    redemption root. Multiproofs for the subset of positions being redeemed are
-    generated via :meth:`get_multi_proof`.
-    """
-
     def __init__(self, all_positions: list[OsTokenPosition], nonce: int):
         self.nonce = nonce
+        # Leaves use `nonce - 1`: setting the positions root increments the
+        # on-chain nonce, leaving it one ahead of the nonce baked into the leaves.
         self._tree = StandardMerkleTree.of(
             [p.merkle_leaf(nonce - 1) for p in all_positions],
             LEAF_TYPES,

--- a/src/redemptions/merkle_tree.py
+++ b/src/redemptions/merkle_tree.py
@@ -1,0 +1,31 @@
+from eth_typing import ChecksumAddress
+from multiproof import StandardMerkleTree
+from multiproof.standard import MultiProof
+from web3.types import Wei
+
+from src.redemptions.typings import OsTokenPosition
+
+LEAF_TYPES = ['uint256', 'address', 'uint256', 'address']
+
+
+class PositionsMerkleTree:
+    """Merkle tree built from all OsToken positions for a given redemption nonce.
+
+    Building the tree from ALL positions makes its root match the on-chain
+    redemption root. Multiproofs for the subset of positions being redeemed are
+    generated via :meth:`get_multi_proof`.
+    """
+
+    def __init__(self, all_positions: list[OsTokenPosition], nonce: int):
+        self.nonce = nonce
+        self._tree = StandardMerkleTree.of(
+            [p.merkle_leaf(nonce - 1) for p in all_positions],
+            LEAF_TYPES,
+        )
+
+    def get_multi_proof(
+        self, positions_to_redeem: list[OsTokenPosition]
+    ) -> MultiProof[tuple[int, ChecksumAddress, Wei, ChecksumAddress]]:
+        """Build a merkle multiproof proving the given positions to redeem."""
+        redeem_leaves = [p.merkle_leaf(self.nonce - 1) for p in positions_to_redeem]
+        return self._tree.get_multi_proof(redeem_leaves)

--- a/src/redemptions/tests/test_merkle_tree.py
+++ b/src/redemptions/tests/test_merkle_tree.py
@@ -1,0 +1,24 @@
+from src.redemptions.merkle_tree import PositionsMerkleTree
+from src.redemptions.tests.factories import make_position
+
+
+class TestPositionsMerkleTree:
+    def test_single_position(self) -> None:
+        position = make_position(leaf_shares=1000, processed_shares=500)
+        result = PositionsMerkleTree([position], nonce=5).get_multi_proof([position])
+        assert len(result.leaves) == 1
+
+    def test_partial_redeem(self) -> None:
+        pos1 = make_position(leaf_shares=1000, processed_shares=500)
+        pos2 = make_position(leaf_shares=2000, processed_shares=1000)
+
+        result = PositionsMerkleTree([pos1, pos2], nonce=5).get_multi_proof([pos1])
+        assert len(result.leaves) == 1
+        assert len(result.proof) > 0
+
+    def test_all_positions_redeemed(self) -> None:
+        pos1 = make_position(leaf_shares=1000, processed_shares=500)
+        pos2 = make_position(leaf_shares=2000, processed_shares=1000)
+
+        result = PositionsMerkleTree([pos1, pos2], nonce=5).get_multi_proof([pos1, pos2])
+        assert len(result.leaves) == 2

--- a/src/redemptions/tests/test_merkle_tree.py
+++ b/src/redemptions/tests/test_merkle_tree.py
@@ -4,21 +4,21 @@ from src.redemptions.tests.factories import make_position
 
 class TestPositionsMerkleTree:
     def test_single_position(self) -> None:
-        position = make_position(leaf_shares=1000, processed_shares=500)
+        position = make_position(leaf_shares=1000)
         result = PositionsMerkleTree([position], nonce=5).get_multi_proof([position])
         assert len(result.leaves) == 1
 
     def test_partial_redeem(self) -> None:
-        pos1 = make_position(leaf_shares=1000, processed_shares=500)
-        pos2 = make_position(leaf_shares=2000, processed_shares=1000)
+        pos1 = make_position(leaf_shares=1000)
+        pos2 = make_position(leaf_shares=2000)
 
         result = PositionsMerkleTree([pos1, pos2], nonce=5).get_multi_proof([pos1])
         assert len(result.leaves) == 1
         assert len(result.proof) > 0
 
     def test_all_positions_redeemed(self) -> None:
-        pos1 = make_position(leaf_shares=1000, processed_shares=500)
-        pos2 = make_position(leaf_shares=2000, processed_shares=1000)
+        pos1 = make_position(leaf_shares=1000)
+        pos2 = make_position(leaf_shares=2000)
 
         result = PositionsMerkleTree([pos1, pos2], nonce=5).get_multi_proof([pos1, pos2])
         assert len(result.leaves) == 2


### PR DESCRIPTION
## Summary
Extracts the merkle-proof building logic out of `process_redeemer.py` into a dedicated `PositionsMerkleTree` class (`src/redemptions/merkle_tree.py`).

- `redeem_positions` / `_submit_redeem_position` now take a `tree: PositionsMerkleTree` instead of `all_positions` + `nonce`, building the tree once per round.
- Replaces the standalone `_build_multi_proof` helper.

## Tests
- New `src/redemptions/tests/test_merkle_tree.py` covering `PositionsMerkleTree.get_multi_proof`.
- Updated `test_process_redeemer.py` to the new tree-based API.
