### PR TITLE
Extract redemption execution into src/redemptions/execution.py

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -8,17 +8,11 @@ import click
 from eth_typing import BlockNumber, ChecksumAddress
 from sw_utils import InterruptHandler
 from web3 import Web3
-from web3.exceptions import Web3Exception
 from web3.types import Gwei, Wei
 
 from src.common.clients import close_clients, execution_client, setup_clients
 from src.common.contracts import VaultContract
-from src.common.execution import (
-    check_gas_price,
-    get_finalized_block_number,
-    transaction_gas_wrapper,
-    wait_for_execution_endpoints_synced,
-)
+from src.common.execution import check_gas_price, get_finalized_block_number
 from src.common.logging import LOG_LEVELS, setup_logging
 from src.common.utils import log_verbose
 from src.common.wallet import wallet
@@ -26,6 +20,11 @@ from src.config.networks import AVAILABLE_NETWORKS, ZERO_CHECKSUM_ADDRESS
 from src.config.settings import settings
 from src.meta_vault.service import is_meta_vault
 from src.redemptions.contracts import os_token_redeemer_contract
+from src.redemptions.execution import (
+    simulate_redeem_position,
+    tx_process_exit_queue,
+    tx_redeem_position,
+)
 from src.redemptions.fetch_positions import (
     cached_fetch_positions_from_ipfs,
     fetch_positions_with_processed_shares,
@@ -202,7 +201,9 @@ async def process(
             # Re-fetch block number after redemption processing
             # to ensure we read the latest on-chain state.
             block_number = await execution_client.eth.block_number
-            await _process_exit_queue(block_number)
+            if await os_token_redeemer_contract.can_process_exit_queue(block_number):
+                logger.info('Exit queue can be processed. Calling processExitQueue...')
+                await tx_process_exit_queue()
 
 
 async def _redeem_os_token_positions(
@@ -324,32 +325,17 @@ async def redeem_positions(
             continue
 
         position_to_redeem = replace(position, shares_to_redeem=shares_to_redeem)
-        redeemed = await _submit_redeem_position(
-            position=position_to_redeem,
-            tree=tree,
-            dry_run=dry_run,
-        )
-        if not redeemed:
+
+        # Always simulate first to catch reverts before broadcasting a real tx.
+        if not await simulate_redeem_position(position=position_to_redeem, tree=tree):
             return
 
+        # In dry-run mode we stop at simulation; otherwise submit the real tx.
+        if not dry_run:
+            if not await tx_redeem_position(position=position_to_redeem, tree=tree):
+                return
+
         vault_to_withdrawable[position.vault] = Wei(withdrawable - assets_to_redeem)
-
-
-async def _process_exit_queue(block_number: BlockNumber) -> None:
-    """Call processExitQueue() on the redeemer contract if canProcessExitQueue."""
-    can_process_exit_queue = await os_token_redeemer_contract.can_process_exit_queue(block_number)
-    if not can_process_exit_queue:
-        return
-    logger.info('Exit queue can be processed. Calling processExitQueue...')
-    tx_hash = await os_token_redeemer_contract.process_exit_queue()
-    logger.info('Waiting for processExitQueue transaction %s confirmation', tx_hash)
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx_hash, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
-        logger.error('processExitQueue transaction failed. Tx Hash: %s', tx_hash)
-    else:
-        logger.info('processExitQueue confirmed. Tx Hash: %s', tx_hash)
 
 
 async def _startup_check() -> None:
@@ -358,81 +344,3 @@ async def _startup_check() -> None:
         raise RuntimeError(
             f'The Position Manager role must be assigned to the address {wallet.account.address}.'
         )
-
-
-async def _submit_redeem_position(
-    position: OsTokenPosition,
-    tree: PositionsMerkleTree,
-    dry_run: bool = False,
-) -> bool:
-    """Submit one redeemOsTokenPositions transaction for a single position.
-
-    Returns ``True`` on success, ``False`` otherwise. When ``dry_run`` is set,
-    the call is simulated via ``.call()`` instead of being submitted.
-    """
-    multiproof = tree.get_multi_proof([position])
-    positions_arg = [
-        (position.vault, position.owner, position.leaf_shares, position.shares_to_redeem)
-    ]
-    tx_function = os_token_redeemer_contract.contract.functions.redeemOsTokenPositions(
-        positions_arg, multiproof.proof, multiproof.proof_flags
-    )
-
-    if dry_run:
-        try:
-            await tx_function.call()
-        except (Web3Exception, RuntimeError, ValueError) as e:
-            logger.error(
-                'Dry run: failed to simulate redeem position (vault %s, owner %s): %r',
-                position.vault,
-                position.owner,
-                e,
-            )
-            return False
-        logger.info(
-            'Dry run: simulated redeeming %s shares for position (vault %s, owner %s) successfully',
-            position.shares_to_redeem,
-            position.vault,
-            position.owner,
-        )
-        return True
-
-    try:
-        tx = await transaction_gas_wrapper(tx_function=tx_function)
-    except (Web3Exception, RuntimeError, ValueError):
-        logger.exception(
-            'Failed to redeem position (vault %s, owner %s)',
-            position.vault,
-            position.owner,
-        )
-        return False
-
-    tx_hash = Web3.to_hex(tx)
-    logger.info(
-        'Waiting for redeemOsTokenPositions tx %s (vault %s, owner %s) confirmation',
-        tx_hash,
-        position.vault,
-        position.owner,
-    )
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
-        logger.error(
-            'Failed to redeem position (vault %s, owner %s). Tx Hash: %s',
-            position.vault,
-            position.owner,
-            tx_hash,
-        )
-        return False
-
-    logger.info(
-        'Redeemed %s shares for position (vault %s, owner %s). Tx Hash: %s',
-        position.shares_to_redeem,
-        position.vault,
-        position.owner,
-        tx_hash,
-    )
-    # Barrier against fallback endpoints lagging behind the receipt block.
-    await wait_for_execution_endpoints_synced(tx_receipt['blockNumber'])
-    return True

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -5,16 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from eth_typing import BlockNumber, ChecksumAddress
-from hexbytes import HexBytes
 from sw_utils.tests import faker
 from web3 import Web3
-from web3.exceptions import Web3Exception
 from web3.types import Gwei, Wei
 
 from src.redemptions.commands.process_redeemer import (
-    _process_exit_queue,
     _startup_check,
-    _submit_redeem_position,
     process,
     redeem_positions,
 )
@@ -195,78 +191,6 @@ class TestRedeemPositions:
 # --- Async function tests (with mocks) ---
 
 
-class TestSubmitRedeemPosition:
-    async def test_success_returns_true(self) -> None:
-        position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_submit_redeem_position(tx_status=1) as mocks:
-            result = await _submit_redeem_position(
-                position=position,
-                tree=make_tree([position]),
-            )
-        assert result is True
-        mocks['transaction_gas_wrapper'].assert_awaited_once()
-        mocks['client'].eth.wait_for_transaction_receipt.assert_awaited_once()
-        mocks['wait_for_execution_endpoints_synced'].assert_awaited_once_with(BlockNumber(456))
-
-    async def test_tx_status_zero_returns_false(self) -> None:
-        """A reverted on-chain tx returns False without raising."""
-        position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_submit_redeem_position(tx_status=0) as mocks:
-            result = await _submit_redeem_position(
-                position=position,
-                tree=make_tree([position]),
-            )
-        assert result is False
-        # No sync barrier when the tx reverted
-        mocks['wait_for_execution_endpoints_synced'].assert_not_awaited()
-
-    @pytest.mark.parametrize('exc_class', [Web3Exception, RuntimeError, ValueError])
-    async def test_tx_build_failure_returns_false(self, exc_class: type[Exception]) -> None:
-        """Each caught exception during tx build/send returns False."""
-        position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_submit_redeem_position(send_exception=exc_class('boom')) as mocks:
-            result = await _submit_redeem_position(
-                position=position,
-                tree=make_tree([position]),
-            )
-        assert result is False
-        # Receipt is never awaited when the build step raised
-        mocks['client'].eth.wait_for_transaction_receipt.assert_not_awaited()
-
-    async def test_unexpected_exception_propagates(self) -> None:
-        """Exceptions outside the (Web3Exception, RuntimeError, ValueError) catch list propagate."""
-        position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_submit_redeem_position(send_exception=KeyError('boom')):
-            with pytest.raises(KeyError):
-                await _submit_redeem_position(
-                    position=position,
-                    tree=make_tree([position]),
-                )
-
-
-class TestProcessExitQueue:
-    async def test_cannot_process(self) -> None:
-        with patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer:
-            mock_redeemer.can_process_exit_queue = AsyncMock(return_value=False)
-            await _process_exit_queue(BlockNumber(100))
-            mock_redeemer.process_exit_queue.assert_not_called()
-
-    @pytest.mark.parametrize('tx_status', [1, 0])
-    async def test_process_exit_queue(self, tx_status: int) -> None:
-        mock_client = AsyncMock()
-        mock_client.eth.wait_for_transaction_receipt = AsyncMock(return_value={'status': tx_status})
-        with (
-            patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
-            patch(f'{MODULE}.execution_client', new=mock_client),
-            patch(f'{MODULE}.settings') as mock_settings,
-        ):
-            mock_settings.execution_transaction_timeout = 120
-            mock_redeemer.can_process_exit_queue = AsyncMock(return_value=True)
-            mock_redeemer.process_exit_queue = AsyncMock(return_value='0xabc')
-            await _process_exit_queue(BlockNumber(100))
-            mock_redeemer.process_exit_queue.assert_called_once()
-
-
 class TestStartupCheck:
     async def test_authorized(self) -> None:
         wallet_address = faker.eth_address()
@@ -373,8 +297,8 @@ def _mock_redeem_positions(
     AsyncMock for fine-grained control (e.g. ``side_effect=[...]`` for sequenced returns).
     ``state_update_required`` drives VaultContract.is_state_update_required, which gates
     the unharvested-vault skip. ``submit_results`` controls per-call return values of
-    _submit_redeem_position; a ``False`` entry models a failed submission that should
-    abort the round.
+    tx_redeem_position; a ``False`` entry models a failed submission that should
+    abort the round. Simulation always succeeds; each live position is simulated first.
     """
     if isinstance(withdrawable, AsyncMock):
         get_withdrawable = withdrawable
@@ -388,6 +312,8 @@ def _mock_redeem_positions(
     else:
         submit_mock = AsyncMock(return_value=True)
 
+    simulate_mock = AsyncMock(return_value=True)
+
     vault_contract = MagicMock()
     vault_contract.is_state_update_required = AsyncMock(return_value=state_update_required)
 
@@ -395,61 +321,19 @@ def _mock_redeem_positions(
         patch(f'{MODULE}.get_withdrawable_assets', new=get_withdrawable),
         patch(f'{MODULE}.is_meta_vault', new=AsyncMock(return_value=is_meta_vault)),
         patch(f'{MODULE}.VaultContract', return_value=vault_contract),
-        patch(f'{MODULE}._submit_redeem_position', new=submit_mock),
-        patch(
-            f'{MODULE}.wait_for_execution_endpoints_synced',
-            new=AsyncMock(),
-        ) as wait_synced_mock,
+        patch(f'{MODULE}.simulate_redeem_position', new=simulate_mock),
+        patch(f'{MODULE}.tx_redeem_position', new=submit_mock),
     ):
         yield {
             'submit_mock': submit_mock,
-            'wait_synced_mock': wait_synced_mock,
+            'simulate_mock': simulate_mock,
             'get_withdrawable': get_withdrawable,
         }
 
 
 def _submitted_position(mocks: dict[str, MagicMock], index: int = 0) -> OsTokenPosition:
-    """Return the position passed to the Nth _submit_redeem_position call."""
+    """Return the position passed to the Nth tx_redeem_position call."""
     return mocks['submit_mock'].call_args_list[index].kwargs['position']
-
-
-@contextmanager
-def _mock_submit_redeem_position(
-    tx_status: int = 1,
-    send_exception: BaseException | None = None,
-) -> Iterator[dict[str, MagicMock]]:
-    """Mock setup for _submit_redeem_position tests.
-
-    ``send_exception`` makes ``transaction_gas_wrapper`` raise; otherwise it returns
-    a fake tx that resolves to a receipt with the given ``tx_status``.
-    """
-    tx = HexBytes(b'\xab' * 32)
-    mock_client = AsyncMock()
-    mock_client.eth.wait_for_transaction_receipt = AsyncMock(
-        return_value={'status': tx_status, 'blockNumber': BlockNumber(456)},
-    )
-
-    if send_exception is not None:
-        gas_wrapper = AsyncMock(side_effect=send_exception)
-    else:
-        gas_wrapper = AsyncMock(return_value=tx)
-
-    synced_mock = AsyncMock()
-    with (
-        patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
-        patch(f'{MODULE}.transaction_gas_wrapper', new=gas_wrapper),
-        patch(f'{MODULE}.execution_client', new=mock_client),
-        patch(f'{MODULE}.wait_for_execution_endpoints_synced', new=synced_mock),
-        patch(f'{MODULE}.settings') as mock_settings,
-    ):
-        mock_settings.execution_transaction_timeout = 120
-        mock_redeemer.contract.functions.redeemOsTokenPositions = MagicMock()
-        yield {
-            'redeemer': mock_redeemer,
-            'transaction_gas_wrapper': gas_wrapper,
-            'client': mock_client,
-            'wait_for_execution_endpoints_synced': synced_mock,
-        }
 
 
 @contextmanager
@@ -465,7 +349,7 @@ def _mock_process(
 
     with (
         patch(f'{MODULE}.check_gas_price', new=AsyncMock(return_value=True)),
-        patch(f'{MODULE}._process_exit_queue', new=AsyncMock()),
+        patch(f'{MODULE}.tx_process_exit_queue', new=AsyncMock()),
         patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
         patch(
             f'{MODULE}.create_os_token_converter',
@@ -497,6 +381,7 @@ def _mock_process(
         patch(f'{MODULE}.execution_client', new=mock_client),
     ):
         mock_settings.network_config.VAULT_BALANCE_SYMBOL = 'ETH'
+        mock_redeemer.can_process_exit_queue = AsyncMock(return_value=False)
         yield {
             'mock_redeemer': mock_redeemer,
             'mock_redeem': mock_redeem,
@@ -511,7 +396,7 @@ def make_tree(
     positions: list[OsTokenPosition] | None = None, nonce: int = 5
 ) -> PositionsMerkleTree:
     """Build a positions merkle tree. Defaults to a single position so callers that
-    only need a valid tree (e.g. when _submit_redeem_position is mocked) can omit it."""
+    only need a valid tree (e.g. when tx_redeem_position is mocked) can omit it."""
     return PositionsMerkleTree(positions or [make_position()], nonce)
 
 

--- a/src/redemptions/execution.py
+++ b/src/redemptions/execution.py
@@ -1,0 +1,123 @@
+import logging
+
+from web3 import Web3
+from web3.contract.async_contract import AsyncContractFunction
+from web3.exceptions import Web3Exception
+
+from src.common.clients import execution_client
+from src.common.execution import (
+    transaction_gas_wrapper,
+    wait_for_execution_endpoints_synced,
+)
+from src.config.settings import settings
+from src.redemptions.contracts import os_token_redeemer_contract
+from src.redemptions.merkle_tree import PositionsMerkleTree
+from src.redemptions.typings import OsTokenPosition
+
+logger = logging.getLogger(__name__)
+
+
+async def tx_process_exit_queue() -> None:
+    """Call processExitQueue() on the redeemer contract."""
+    tx_hash = await os_token_redeemer_contract.process_exit_queue()
+    logger.info('Waiting for processExitQueue transaction %s confirmation', tx_hash)
+    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
+        tx_hash, timeout=settings.execution_transaction_timeout
+    )
+    if not tx_receipt['status']:
+        logger.error('processExitQueue transaction failed. Tx Hash: %s', tx_hash)
+    else:
+        logger.info('processExitQueue confirmed. Tx Hash: %s', tx_hash)
+
+
+async def simulate_redeem_position(
+    position: OsTokenPosition,
+    tree: PositionsMerkleTree,
+) -> bool:
+    """Simulate one redeemOsTokenPositions transaction via ``.call()`` without submitting.
+
+    Returns ``True`` when the call would succeed, ``False`` otherwise.
+    """
+    tx_function = _build_redeem_tx_function(position, tree)
+
+    try:
+        await tx_function.call()
+    except (Web3Exception, RuntimeError, ValueError) as e:
+        logger.error(
+            'Failed to simulate redeem position (vault %s, owner %s): %r',
+            position.vault,
+            position.owner,
+            e,
+        )
+        return False
+    logger.info(
+        'Simulated redeeming %s shares for position (vault %s, owner %s) successfully',
+        position.shares_to_redeem,
+        position.vault,
+        position.owner,
+    )
+    return True
+
+
+async def tx_redeem_position(
+    position: OsTokenPosition,
+    tree: PositionsMerkleTree,
+) -> bool:
+    """Submit one redeemOsTokenPositions transaction for a single position.
+
+    Returns ``True`` on success, ``False`` otherwise.
+    """
+    tx_function = _build_redeem_tx_function(position, tree)
+
+    try:
+        tx = await transaction_gas_wrapper(tx_function=tx_function)
+    except (Web3Exception, RuntimeError, ValueError):
+        logger.exception(
+            'Failed to redeem position (vault %s, owner %s)',
+            position.vault,
+            position.owner,
+        )
+        return False
+
+    tx_hash = Web3.to_hex(tx)
+    logger.info(
+        'Waiting for redeemOsTokenPositions tx %s (vault %s, owner %s) confirmation',
+        tx_hash,
+        position.vault,
+        position.owner,
+    )
+    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
+        tx, timeout=settings.execution_transaction_timeout
+    )
+    if not tx_receipt['status']:
+        logger.error(
+            'Failed to redeem position (vault %s, owner %s). Tx Hash: %s',
+            position.vault,
+            position.owner,
+            tx_hash,
+        )
+        return False
+
+    logger.info(
+        'Redeemed %s shares for position (vault %s, owner %s). Tx Hash: %s',
+        position.shares_to_redeem,
+        position.vault,
+        position.owner,
+        tx_hash,
+    )
+    # Barrier against fallback endpoints lagging behind the receipt block.
+    await wait_for_execution_endpoints_synced(tx_receipt['blockNumber'])
+    return True
+
+
+def _build_redeem_tx_function(
+    position: OsTokenPosition, tree: PositionsMerkleTree
+) -> AsyncContractFunction:
+    """Build the redeemOsTokenPositions contract function for a single position."""
+    multiproof = tree.get_multi_proof([position])
+    positions_arg = [
+        (position.vault, position.owner, position.leaf_shares, position.shares_to_redeem)
+    ]
+    return os_token_redeemer_contract.contract.functions.redeemOsTokenPositions(
+        positions_arg, multiproof.proof, multiproof.proof_flags
+    )

--- a/src/redemptions/tests/test_execution.py
+++ b/src/redemptions/tests/test_execution.py
@@ -1,0 +1,204 @@
+from contextlib import contextmanager
+from typing import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from eth_typing import BlockNumber, ChecksumAddress
+from hexbytes import HexBytes
+from web3 import Web3
+from web3.exceptions import Web3Exception
+from web3.types import Wei
+
+from src.redemptions.execution import (
+    simulate_redeem_position,
+    tx_process_exit_queue,
+    tx_redeem_position,
+)
+from src.redemptions.merkle_tree import PositionsMerkleTree
+from src.redemptions.typings import OsTokenPosition
+
+MODULE = 'src.redemptions.execution'
+
+VAULT_1 = Web3.to_checksum_address('0x' + '11' * 20)
+OWNER_1 = Web3.to_checksum_address('0x' + '33' * 20)
+
+
+class TestTxRedeemPosition:
+    async def test_success_returns_true(self) -> None:
+        position = make_position(leaf_shares=1000, shares_to_redeem=500)
+        with _mock_tx_redeem_position(tx_status=1) as mocks:
+            result = await tx_redeem_position(
+                position=position,
+                tree=make_tree([position]),
+            )
+        assert result is True
+        mocks['transaction_gas_wrapper'].assert_awaited_once()
+        mocks['client'].eth.wait_for_transaction_receipt.assert_awaited_once()
+        mocks['wait_for_execution_endpoints_synced'].assert_awaited_once_with(BlockNumber(456))
+
+    async def test_tx_status_zero_returns_false(self) -> None:
+        """A reverted on-chain tx returns False without raising."""
+        position = make_position(leaf_shares=1000, shares_to_redeem=500)
+        with _mock_tx_redeem_position(tx_status=0) as mocks:
+            result = await tx_redeem_position(
+                position=position,
+                tree=make_tree([position]),
+            )
+        assert result is False
+        # No sync barrier when the tx reverted
+        mocks['wait_for_execution_endpoints_synced'].assert_not_awaited()
+
+    @pytest.mark.parametrize('exc_class', [Web3Exception, RuntimeError, ValueError])
+    async def test_tx_build_failure_returns_false(self, exc_class: type[Exception]) -> None:
+        """Each caught exception during tx build/send returns False."""
+        position = make_position(leaf_shares=1000, shares_to_redeem=500)
+        with _mock_tx_redeem_position(send_exception=exc_class('boom')) as mocks:
+            result = await tx_redeem_position(
+                position=position,
+                tree=make_tree([position]),
+            )
+        assert result is False
+        # Receipt is never awaited when the build step raised
+        mocks['client'].eth.wait_for_transaction_receipt.assert_not_awaited()
+
+    async def test_unexpected_exception_propagates(self) -> None:
+        """Exceptions outside the (Web3Exception, RuntimeError, ValueError) catch list propagate."""
+        position = make_position(leaf_shares=1000, shares_to_redeem=500)
+        with _mock_tx_redeem_position(send_exception=KeyError('boom')):
+            with pytest.raises(KeyError):
+                await tx_redeem_position(
+                    position=position,
+                    tree=make_tree([position]),
+                )
+
+
+class TestSimulateRedeemPosition:
+    async def test_success_returns_true(self) -> None:
+        position = make_position(leaf_shares=1000, shares_to_redeem=500)
+        with _mock_simulate_redeem_position() as mocks:
+            result = await simulate_redeem_position(
+                position=position,
+                tree=make_tree([position]),
+            )
+        assert result is True
+        mocks['call'].assert_awaited_once()
+
+    @pytest.mark.parametrize('exc_class', [Web3Exception, RuntimeError, ValueError])
+    async def test_call_failure_returns_false(self, exc_class: type[Exception]) -> None:
+        """A failed simulation returns False without raising."""
+        position = make_position(leaf_shares=1000, shares_to_redeem=500)
+        with _mock_simulate_redeem_position(call_exception=exc_class('boom')):
+            result = await simulate_redeem_position(
+                position=position,
+                tree=make_tree([position]),
+            )
+        assert result is False
+
+
+class TestTxProcessExitQueue:
+    @pytest.mark.parametrize('tx_status', [1, 0])
+    async def test_process_exit_queue(self, tx_status: int) -> None:
+        mock_client = AsyncMock()
+        mock_client.eth.wait_for_transaction_receipt = AsyncMock(return_value={'status': tx_status})
+        with (
+            patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
+            patch(f'{MODULE}.execution_client', new=mock_client),
+            patch(f'{MODULE}.settings') as mock_settings,
+        ):
+            mock_settings.execution_transaction_timeout = 120
+            mock_redeemer.process_exit_queue = AsyncMock(return_value='0xabc')
+            await tx_process_exit_queue()
+            mock_redeemer.process_exit_queue.assert_called_once()
+
+
+# --- Helpers ---
+
+
+@contextmanager
+def _mock_tx_redeem_position(
+    tx_status: int = 1,
+    send_exception: BaseException | None = None,
+) -> Iterator[dict[str, MagicMock]]:
+    """Mock setup for tx_redeem_position tests.
+
+    ``send_exception`` makes ``transaction_gas_wrapper`` raise; otherwise it returns
+    a fake tx that resolves to a receipt with the given ``tx_status``.
+    """
+    tx = HexBytes(b'\xab' * 32)
+    mock_client = AsyncMock()
+    mock_client.eth.wait_for_transaction_receipt = AsyncMock(
+        return_value={'status': tx_status, 'blockNumber': BlockNumber(456)},
+    )
+
+    if send_exception is not None:
+        gas_wrapper = AsyncMock(side_effect=send_exception)
+    else:
+        gas_wrapper = AsyncMock(return_value=tx)
+
+    synced_mock = AsyncMock()
+    with (
+        patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
+        patch(f'{MODULE}.transaction_gas_wrapper', new=gas_wrapper),
+        patch(f'{MODULE}.execution_client', new=mock_client),
+        patch(f'{MODULE}.wait_for_execution_endpoints_synced', new=synced_mock),
+        patch(f'{MODULE}.settings') as mock_settings,
+    ):
+        mock_settings.execution_transaction_timeout = 120
+        mock_redeemer.contract.functions.redeemOsTokenPositions = MagicMock()
+        yield {
+            'redeemer': mock_redeemer,
+            'transaction_gas_wrapper': gas_wrapper,
+            'client': mock_client,
+            'wait_for_execution_endpoints_synced': synced_mock,
+        }
+
+
+@contextmanager
+def _mock_simulate_redeem_position(
+    call_exception: BaseException | None = None,
+) -> Iterator[dict[str, MagicMock]]:
+    """Mock setup for simulate_redeem_position tests.
+
+    ``call_exception`` makes the simulated ``.call()`` raise; otherwise it succeeds.
+    """
+    if call_exception is not None:
+        call_mock = AsyncMock(side_effect=call_exception)
+    else:
+        call_mock = AsyncMock(return_value=None)
+
+    tx_function = MagicMock()
+    tx_function.call = call_mock
+
+    with patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer:
+        mock_redeemer.contract.functions.redeemOsTokenPositions = MagicMock(
+            return_value=tx_function
+        )
+        yield {
+            'redeemer': mock_redeemer,
+            'call': call_mock,
+        }
+
+
+def make_tree(
+    positions: list[OsTokenPosition] | None = None, nonce: int = 5
+) -> PositionsMerkleTree:
+    return PositionsMerkleTree(positions or [make_position()], nonce)
+
+
+def make_position(
+    vault: ChecksumAddress = VAULT_1,
+    owner: ChecksumAddress = OWNER_1,
+    leaf_shares: int = 1000,
+    processed_shares: int = 500,
+    shares_to_redeem: int | None = None,
+) -> OsTokenPosition:
+    effective_shares_to_redeem = (
+        shares_to_redeem if shares_to_redeem is not None else leaf_shares - processed_shares
+    )
+    return OsTokenPosition(
+        vault=vault,
+        owner=owner,
+        leaf_shares=Wei(leaf_shares),
+        processed_shares=Wei(processed_shares),
+        shares_to_redeem=Wei(effective_shares_to_redeem),
+    )


### PR DESCRIPTION
Extracts the redemption transaction logic out of `process_redeemer.py` into a dedicated `src/redemptions/execution.py` module.

## Changes
- New `src/redemptions/execution.py` with:
  - `tx_process_exit_queue` — submits `processExitQueue()` (the `canProcessExitQueue` gate now lives at the call site).
  - `simulate_redeem_position` — simulates a redemption via `.call()`.
  - `tx_redeem_position` — submits a redemption tx and waits for the receipt.
  - `_build_redeem_tx_function` — shared helper building the `redeemOsTokenPositions` call.
- `redeem_positions` now always simulates a position first and only submits the live tx when not in dry-run mode.
- Tests for the execution functions moved to `src/redemptions/tests/test_execution.py`; `test_process_redeemer.py` now mocks those functions wholesale instead of their internals.