### PR TITLE
Add execution node and wallet balance checks to process-redeemer startup

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -12,8 +12,16 @@ from web3.types import Gwei, Wei
 
 from src.common.clients import close_clients, execution_client, setup_clients
 from src.common.contracts import VaultContract
-from src.common.execution import check_gas_price, get_finalized_block_number
+from src.common.execution import (
+    check_gas_price,
+    check_wallet_balance,
+    get_finalized_block_number,
+)
 from src.common.logging import LOG_LEVELS, setup_logging
+from src.common.startup_check import (
+    check_execution_nodes_network,
+    wait_for_execution_node,
+)
 from src.common.utils import log_verbose
 from src.common.wallet import wallet
 from src.config.networks import AVAILABLE_NETWORKS, ZERO_CHECKSUM_ADDRESS
@@ -339,8 +347,18 @@ async def redeem_positions(
 
 
 async def _startup_check() -> None:
+    logger.info('Checking connection to execution nodes...')
+    await wait_for_execution_node()
+
+    logger.info('Checking execution nodes network...')
+    await check_execution_nodes_network()
+
+    logger.info('Checking Position Manager role...')
     positions_manager = await os_token_redeemer_contract.positions_manager()
     if positions_manager != wallet.account.address:
         raise RuntimeError(
             f'The Position Manager role must be assigned to the address {wallet.account.address}.'
         )
+
+    logger.info('Checking wallet balance %s...', wallet.address)
+    await check_wallet_balance()

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -197,6 +197,7 @@ class TestStartupCheck:
         mock_wallet = MagicMock()
         mock_wallet.account.address = wallet_address
         with (
+            _mock_startup_checks(),
             patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
             patch(f'{MODULE}.wallet', new=mock_wallet),
         ):
@@ -207,6 +208,7 @@ class TestStartupCheck:
         mock_wallet = MagicMock()
         mock_wallet.account.address = faker.eth_address()
         with (
+            _mock_startup_checks(),
             patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
             patch(f'{MODULE}.wallet', new=mock_wallet),
         ):
@@ -282,6 +284,18 @@ class TestProcess:
 
 
 # --- Helpers ---
+
+
+@contextmanager
+def _mock_startup_checks() -> Iterator[None]:
+    """Patch the execution-node, network and wallet-balance checks run by _startup_check,
+    leaving the Position Manager role check under test."""
+    with (
+        patch(f'{MODULE}.wait_for_execution_node', new=AsyncMock()),
+        patch(f'{MODULE}.check_execution_nodes_network', new=AsyncMock()),
+        patch(f'{MODULE}.check_wallet_balance', new=AsyncMock()),
+    ):
+        yield
 
 
 @contextmanager


### PR DESCRIPTION
Extends `_startup_check` in the `process-redeemer` command to mirror the `process-meta-vaults` startup checks, reusing the existing shared helpers.

Added checks:
- Execution node availability (`wait_for_execution_node`)
- Execution node network matches the `--network` param (`check_execution_nodes_network`)
- Wallet balance (`check_wallet_balance`)

Each check now logs a status line, including the existing Position Manager role check.