### PR TITLE
Skip reverting positions instead of aborting redemption round

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -287,7 +287,8 @@ async def redeem_positions(
 
     Meta-vault positions are skipped entirely. Vaults whose on-chain state is
     stale (unharvested) are skipped, since their withdrawable assets would be
-    outdated. Aborts the round if a single redemption tx fails.
+    outdated. A position that fails to simulate or submit is skipped, so the
+    remaining positions are still processed.
     """
     vault_to_withdrawable: dict[ChecksumAddress, Wei] = {}
     unharvested_vaults: set[ChecksumAddress] = set()
@@ -328,12 +329,12 @@ async def redeem_positions(
 
         # Always simulate first to catch reverts before broadcasting a real tx.
         if not await simulate_redeem_position(position=position_to_redeem, tree=tree):
-            return
+            continue
 
         # In dry-run mode we stop at simulation; otherwise submit the real tx.
         if not dry_run:
             if not await tx_redeem_position(position=position_to_redeem, tree=tree):
-                return
+                continue
 
         vault_to_withdrawable[position.vault] = Wei(withdrawable - assets_to_redeem)
 

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -168,8 +168,8 @@ class TestRedeemPositions:
         mocks['get_withdrawable'].assert_not_called()
         mocks['submit_mock'].assert_not_called()
 
-    async def test_submit_failure_aborts_iteration(self) -> None:
-        """A failed submission aborts the loop; subsequent positions are not attempted."""
+    async def test_submit_failure_skips_position(self) -> None:
+        """A failed submission skips that position; subsequent positions are still attempted."""
         pos1 = make_position(vault=VAULT_1, owner=OWNER_1, processed_shares=500)
         pos2 = make_position(vault=VAULT_2, owner=OWNER_2, processed_shares=500)
 
@@ -184,8 +184,8 @@ class TestRedeemPositions:
                 block_number=BlockNumber(100),
             )
 
-        # Only the first position is attempted; loop aborted
-        assert mocks['submit_mock'].await_count == 1
+        # The first position fails but the round continues to the second
+        assert mocks['submit_mock'].await_count == 2
 
 
 # --- Async function tests (with mocks) ---


### PR DESCRIPTION
Previously, if a single position failed to simulate or submit its redemption tx, `redeem_positions` returned early and aborted the entire round — leaving the remaining redeemable positions unprocessed until the next interval.

This changes the early `return` to `continue` so a failing position is skipped and the rest of the round proceeds. The function docstring is updated to match.