### PR TITLE
Clarify consolidate command help text

### DIFF
--- a/src/validators/commands/consolidate.py
+++ b/src/validators/commands/consolidate.py
@@ -175,11 +175,17 @@ logger = logging.getLogger(__name__)
     help='The block number where the vault was created. Used to optimize fetching vault events.',
 )
 @click.command(
-    help='Consolidates vault validators into 0x02 validators. '
-    'When no public keys are provided, automatically picks 0x01 validators '
-    'and consolidates them (a 0x01 validator with no separate target is '
-    'switched to 0x02). To consolidate 0x02 validators, or to choose specific validators, '
-    'pass explicit --source-public-keys and --target-public-key options.'
+    help='Consolidates vault validators into 0x02 (compounding) validators.\n'
+    '\n'
+    '\b\n'
+    'When no public keys are provided:\n'
+    '- automatically picks 0x01 validators eligible for consolidation\n'
+    '- a 0x01 validator with no separate target is switched to 0x02\n'
+    '\n'
+    '\b\n'
+    'To consolidate 0x02 validators or choose specific validators:\n'
+    '- pass explicit --source-public-keys and --target-public-key options\n'
+    '- auto-pick is not implemented for 0x02'
 )
 # pylint: disable-next=too-many-arguments,too-many-locals
 def consolidate(

--- a/src/validators/commands/consolidate.py
+++ b/src/validators/commands/consolidate.py
@@ -175,8 +175,11 @@ logger = logging.getLogger(__name__)
     help='The block number where the vault was created. Used to optimize fetching vault events.',
 )
 @click.command(
-    help='Performs a vault validators consolidation from 0x01 validators to 0x02 validator. '
-    'Switches a validator from 0x01 to 0x02 if the source and target keys are identical.'
+    help='Consolidates vault validators into 0x02 validators. '
+    'When no public keys are provided, automatically picks 0x01 validators '
+    'and consolidates them (a 0x01 validator with no separate target is '
+    'switched to 0x02). To consolidate 0x02 validators, or to choose specific validators, '
+    'pass explicit --source-public-keys and --target-public-key options.'
 )
 # pylint: disable-next=too-many-arguments,too-many-locals
 def consolidate(


### PR DESCRIPTION
Rewrites the `consolidate` command help text to accurately describe its behavior:

- The command consolidates validators into 0x02 (compounding) validators.
- When no public keys are provided, it automatically picks eligible 0x01 validators and consolidates them (a 0x01 validator with no separate target is switched to 0x02).
- To consolidate 0x02 validators, or to choose specific validators, explicit `--source-public-keys` and `--target-public-key` options must be passed (auto-pick is not implemented for 0x02).