### PR TITLE
Add position index for redemption logging

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -245,7 +245,7 @@ async def _redeem_os_token_positions(
         return
 
     logger.info(
-        'Process queued shares for Redemption: %s (~%s %s)',
+        'Process queued shares for redemption: %s (~%s %s)',
         queued_shares,
         Web3.from_wei(queued_assets, 'ether'),
         settings.network_config.VAULT_BALANCE_SYMBOL,
@@ -302,6 +302,7 @@ async def redeem_positions(
     unharvested_vaults: set[ChecksumAddress] = set()
 
     for position in os_token_positions:
+        logger.info('Processing position index=%d', position.index)
         shares_to_redeem = position.shares_to_redeem
         assets_to_redeem = converter.to_assets(shares_to_redeem)
 

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -438,6 +438,7 @@ def make_position(
         vault=vault,
         owner=owner,
         leaf_shares=Wei(leaf_shares),
+        index=0,
         processed_shares=Wei(processed_shares),
         shares_to_redeem=Wei(effective_shares_to_redeem),
     )

--- a/src/redemptions/fetch_positions.py
+++ b/src/redemptions/fetch_positions.py
@@ -128,6 +128,7 @@ async def fetch_positions_with_processed_shares(
                 owner=position.owner,
                 vault=position.vault,
                 leaf_shares=position.leaf_shares,
+                index=position.index,
                 processed_shares=processed_shares,
             )
         )
@@ -211,6 +212,7 @@ async def fetch_positions_from_ipfs(
             owner=Web3.to_checksum_address(item['owner']),
             vault=Web3.to_checksum_address(item['vault']),
             leaf_shares=Wei(int(item['leaf_shares'])),
+            index=index,
         )
-        for item in data
+        for index, item in enumerate(data)
     ]

--- a/src/redemptions/tests/factories.py
+++ b/src/redemptions/tests/factories.py
@@ -28,6 +28,7 @@ def make_position(
         vault=vault if vault is not None else faker.eth_address(),
         owner=owner if owner is not None else faker.eth_address(),
         leaf_shares=Wei(leaf_shares),
+        index=0,
         processed_shares=Wei(processed_shares),
         shares_to_redeem=Wei(shares_to_redeem),
     )

--- a/src/redemptions/tests/test_execution.py
+++ b/src/redemptions/tests/test_execution.py
@@ -199,6 +199,7 @@ def make_position(
         vault=vault,
         owner=owner,
         leaf_shares=Wei(leaf_shares),
+        index=0,
         processed_shares=Wei(processed_shares),
         shares_to_redeem=Wei(effective_shares_to_redeem),
     )

--- a/src/redemptions/typings.py
+++ b/src/redemptions/typings.py
@@ -65,6 +65,8 @@ class OsTokenPosition:
     owner: ChecksumAddress
     vault: ChecksumAddress
     leaf_shares: Wei
+    # Zero-based index of the position in the IPFS positions file. Used for logging only.
+    index: int = 0
     processed_shares: Wei = Wei(0)
     shares_to_redeem: Wei = Wei(0)
 


### PR DESCRIPTION
Add a zero-based `index` field to `OsTokenPosition`, determined by the position's order in the IPFS positions file. Used for logging only.

- Set `index` via `enumerate` in `fetch_positions_from_ipfs` and propagate it through `fetch_positions_with_processed_shares`.
- Log `Processing position index=<index>` at the start of the redemption loop.
- Tests mock `index` as 0.