### PR TITLE
Add TransactionManager to handle stalled tx

### DIFF
--- a/src/common/contracts.py
+++ b/src/common/contracts.py
@@ -14,10 +14,10 @@ from web3.contract.async_contract import (
     AsyncContractEvents,
     AsyncContractFunctions,
 )
-from web3.types import BlockNumber, ChecksumAddress, EventData, Wei
+from web3.types import BlockNumber, ChecksumAddress, EventData, TxReceipt, Wei
 
 from src.common.clients import execution_client as default_execution_client
-from src.common.execution import transaction_gas_wrapper
+from src.common.transaction import tx_manager
 from src.common.typings import (
     ExitQueueMissingAssetsParams,
     HarvestParams,
@@ -411,10 +411,9 @@ class MulticallContract(ContractWrapper):
     async def tx_aggregate(
         self,
         data: list[tuple[ChecksumAddress, HexStr]],
-    ) -> HexStr:
+    ) -> TxReceipt | None:
         tx_function = self.contract.functions.aggregate(data)
-        tx_hash = await transaction_gas_wrapper(tx_function)
-        return Web3.to_hex(tx_hash)
+        return await tx_manager.transact(tx_function)
 
 
 class ValidatorsCheckerContract(ContractWrapper):

--- a/src/common/execution.py
+++ b/src/common/execution.py
@@ -1,19 +1,16 @@
-import asyncio
 import logging
 from urllib.parse import urlparse
 
-from hexbytes import HexBytes
 from sw_utils import GasManager, InterruptHandler
 from web3 import Web3
-from web3.contract.async_contract import AsyncContractFunction
-from web3.types import TxParams, Wei
+from web3.types import Wei
 
 from src.common.clients import execution_client
 from src.common.metrics import metrics
 from src.common.tasks import BaseTask
 from src.common.wallet import wallet
 from src.config.networks import HOODI
-from src.config.settings import ATTEMPTS_WITH_DEFAULT_GAS, settings
+from src.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -49,40 +46,10 @@ async def get_wallet_balance() -> Wei:
     return await execution_client.eth.get_balance(wallet.address)
 
 
-async def transaction_gas_wrapper(
-    tx_function: AsyncContractFunction, tx_params: TxParams | None = None
-) -> HexBytes:
-    """Handles periods with high gas in the network."""
-    if not tx_params:
-        tx_params = {}
-
-    # trying to submit with basic gas
-    attempts_with_default_gas = ATTEMPTS_WITH_DEFAULT_GAS
-
-    # Alchemy does not support eth_maxPriorityFeePerGas for Hoodi
-    if settings.network == HOODI and _is_alchemy_used():
-        attempts_with_default_gas = 0
-
-    for i in range(attempts_with_default_gas):
-        try:
-            return await tx_function.transact(tx_params)
-        except ValueError as e:
-            # Handle only FeeTooLow error
-            if not _is_fee_too_low_error(e):
-                raise e
-            if i < attempts_with_default_gas - 1:  # skip last sleep
-                await asyncio.sleep(settings.network_config.SECONDS_PER_BLOCK)
-
-    # use high priority fee
-    gas_manager = build_gas_manager()
-    tx_params = tx_params | await gas_manager.get_high_priority_tx_params()
-    return await tx_function.transact(tx_params)
-
-
 async def check_gas_price(high_priority: bool = False) -> bool:
     gas_manager = build_gas_manager()
     # Alchemy does not support eth_maxPriorityFeePerGas for Hoodi, skip
-    if settings.network == HOODI and _is_alchemy_used():
+    if settings.network == HOODI and is_alchemy_used():
         return True
 
     return await gas_manager.check_gas_price(high_priority)
@@ -99,14 +66,7 @@ def build_gas_manager() -> GasManager:
     )
 
 
-def _is_fee_too_low_error(e: ValueError) -> bool:
-    code = None
-    if e.args and isinstance(e.args[0], dict):
-        code = e.args[0].get('code')
-    return code == -32010
-
-
-def _is_alchemy_used() -> bool:
+def is_alchemy_used() -> bool:
     for endpoint in settings.execution_endpoints:
         domain = urlparse(endpoint).netloc
         if domain.lower().endswith(ALCHEMY_DOMAIN):

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -8,9 +8,102 @@ from web3 import Web3
 from web3.exceptions import TimeExhausted
 from web3.types import Wei
 
-from src.common.transaction import REPLACEMENT_GAS_BUMP, TransactionManager
+from src.common.transaction import REPLACEMENT_GAS_BUMP, Fees, TransactionManager
 
 GWEI = Web3.to_wei(1, 'gwei')
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestFees:
+    def test_bump_returns_new_capped_instance(self):
+        fees = Fees(
+            fee_per_gas=Web3.to_wei(4, 'gwei'),
+            priority_fee_per_gas=Web3.to_wei(2, 'gwei'),
+            max_fee_per_gas=Web3.to_wei(10, 'gwei'),
+        )
+
+        bumped = fees.bump()
+
+        # the original instance is left untouched
+        assert fees.fee_per_gas == Web3.to_wei(4, 'gwei')
+        assert fees.priority_fee_per_gas == Web3.to_wei(2, 'gwei')
+        # bump returns a new instance with both fees raised by 12.5%
+        assert bumped is not fees
+        assert bumped.fee_per_gas == Web3.to_wei(4.5, 'gwei')
+        assert bumped.priority_fee_per_gas == Web3.to_wei(2.25, 'gwei')
+
+    def test_bump_caps_at_max_fee_per_gas(self):
+        cap = Web3.to_wei(10, 'gwei')
+        fees = Fees(fee_per_gas=cap, priority_fee_per_gas=cap, max_fee_per_gas=cap)
+
+        bumped = fees.bump()
+
+        # already at the ceiling - the bump cannot raise either fee
+        assert bumped.fee_per_gas == cap
+        assert bumped.priority_fee_per_gas == cap
+
+    def test_replaces_true_when_both_fees_rise_enough(self):
+        cap = Web3.to_wei(1000, 'gwei')
+        prev = Fees(
+            fee_per_gas=Web3.to_wei(10, 'gwei'),
+            priority_fee_per_gas=Web3.to_wei(5, 'gwei'),
+            max_fee_per_gas=cap,
+        )
+        # both fees exactly at the +10% threshold
+        new = Fees(
+            fee_per_gas=Web3.to_wei(11, 'gwei'),
+            priority_fee_per_gas=Web3.to_wei(5.5, 'gwei'),
+            max_fee_per_gas=cap,
+        )
+
+        assert new.replaces(prev) is True
+
+    def test_replaces_false_when_fee_rise_too_small(self):
+        cap = Web3.to_wei(1000, 'gwei')
+        prev = Fees(
+            fee_per_gas=Web3.to_wei(10, 'gwei'),
+            priority_fee_per_gas=Web3.to_wei(5, 'gwei'),
+            max_fee_per_gas=cap,
+        )
+        # maxFeePerGas rises only 9%, below the +10% threshold
+        new = Fees(
+            fee_per_gas=Web3.to_wei(10.9, 'gwei'),
+            priority_fee_per_gas=Web3.to_wei(5.5, 'gwei'),
+            max_fee_per_gas=cap,
+        )
+
+        assert new.replaces(prev) is False
+
+    def test_replaces_false_when_priority_rise_too_small(self):
+        cap = Web3.to_wei(1000, 'gwei')
+        prev = Fees(
+            fee_per_gas=Web3.to_wei(10, 'gwei'),
+            priority_fee_per_gas=Web3.to_wei(5, 'gwei'),
+            max_fee_per_gas=cap,
+        )
+        # maxFeePerGas clears the threshold but maxPriorityFeePerGas rises only 8%
+        new = Fees(
+            fee_per_gas=Web3.to_wei(11, 'gwei'),
+            priority_fee_per_gas=Web3.to_wei(5.4, 'gwei'),
+            max_fee_per_gas=cap,
+        )
+
+        assert new.replaces(prev) is False
+
+    def test_from_tx_params_then_to_tx_params_round_trips(self):
+        # below the ceiling, so capping does not alter the values
+        params = {'maxFeePerGas': Wei(2 * GWEI), 'maxPriorityFeePerGas': Wei(GWEI)}
+
+        assert Fees.from_tx_params(params).to_tx_params() == params
+
+    def test_to_tx_params_then_from_tx_params_round_trips(self):
+        cap = Web3.to_wei(1000, 'gwei')
+        fees = Fees(fee_per_gas=2 * GWEI, priority_fee_per_gas=GWEI, max_fee_per_gas=cap)
+
+        restored = Fees.from_tx_params(fees.to_tx_params(), max_fee_per_gas=cap)
+
+        assert restored.fee_per_gas == fees.fee_per_gas
+        assert restored.priority_fee_per_gas == fees.priority_fee_per_gas
 
 
 @pytest.mark.usefixtures('fake_settings')

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -1,9 +1,11 @@
+import contextlib
 from math import ceil
 from unittest import mock
 
 import pytest
 from hexbytes import HexBytes
 from web3 import Web3
+from web3.exceptions import TimeExhausted
 from web3.types import Wei
 
 from src.common.transaction import REPLACEMENT_GAS_BUMP, TransactionManager
@@ -15,10 +17,7 @@ GWEI = Web3.to_wei(1, 'gwei')
 class TestTransactionManager:
     async def test_no_pending_high_priority_uses_latest_nonce(self):
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm, al = _patch(
-            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
-        )
-        with ec, w, gm, al:
+        with _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)):
             manager = TransactionManager()
             receipt = await manager.transact(_tx_function(transact), high_priority=True)
 
@@ -31,10 +30,7 @@ class TestTransactionManager:
     async def test_default_gas_skips_fee_fields(self):
         # high_priority=False with no pending tx submits with the node's default gas
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm, al = _patch(
-            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
-        )
-        with ec, w, gm, al:
+        with _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)):
             manager = TransactionManager()
             await manager.transact(_tx_function(transact))
 
@@ -49,12 +45,11 @@ class TestTransactionManager:
         transact = mock.AsyncMock(
             side_effect=[fee_too_low, fee_too_low, fee_too_low, HexBytes('0x02')]
         )
-        ec, w, gm, al = _patch(
+        with _patch(
             latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
-        )
-        with ec, w, gm, al, mock.patch(
-            'src.common.transaction.ATTEMPTS_WITH_DEFAULT_GAS', 3
-        ), mock.patch('src.common.transaction.asyncio.sleep', mock.AsyncMock()):
+        ), mock.patch('src.common.transaction.ATTEMPTS_WITH_DEFAULT_GAS', 3), mock.patch(
+            'src.common.transaction.asyncio.sleep', mock.AsyncMock()
+        ):
             manager = TransactionManager()
             receipt = await manager.transact(_tx_function(transact))
 
@@ -70,18 +65,12 @@ class TestTransactionManager:
 
         # first submission records the gas used for nonce 5
         transact1 = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm, al = _patch(
-            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
-        )
-        with ec, w, gm, al:
+        with _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)):
             await manager.transact(_tx_function(transact1), high_priority=True)
 
         # second submission sees a pending tx at nonce 5 -> replace it, bumped
         transact2 = mock.AsyncMock(return_value=HexBytes('0x02'))
-        ec, w, gm, al = _patch(
-            latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)
-        )
-        with ec, w, gm, al:
+        with _patch(latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)):
             await manager.transact(_tx_function(transact2))
 
         params = transact2.call_args.args[0]
@@ -92,10 +81,7 @@ class TestTransactionManager:
     async def test_pending_skips_default_gas(self):
         # even without high_priority, a pending tx forces the high-priority path
         transact = mock.AsyncMock(return_value=HexBytes('0x02'))
-        ec, w, gm, al = _patch(
-            latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)
-        )
-        with ec, w, gm, al:
+        with _patch(latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)):
             manager = TransactionManager()
             await manager.transact(_tx_function(transact))
 
@@ -106,27 +92,40 @@ class TestTransactionManager:
 
     async def test_reverted_receipt_returns_none(self):
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm, al = _patch(
+        with _patch(
             latest_nonce=5,
             pending_nonce=5,
             gas_manager=_gas_manager(GWEI, GWEI // 2),
             status=0,
-        )
-        with ec, w, gm, al:
+        ):
             manager = TransactionManager()
             receipt = await manager.transact(_tx_function(transact), high_priority=True)
 
         assert receipt is None
+
+    async def test_receipt_timeout_returns_none(self):
+        # the receipt wait times out -> the tx is left pending and transact returns None
+        # so the next run can detect and replace it
+        transact = mock.AsyncMock(return_value=HexBytes('0x01'))
+        with _patch(
+            latest_nonce=5,
+            pending_nonce=5,
+            gas_manager=_gas_manager(GWEI, GWEI // 2),
+            receipt_side_effect=TimeExhausted(),
+        ):
+            manager = TransactionManager()
+            receipt = await manager.transact(_tx_function(transact), high_priority=True)
+
+        assert receipt is None
+        # the transaction was broadcast even though no receipt arrived
+        transact.assert_awaited_once()
 
     async def test_gas_capped_at_max_fee_per_gas(self):
         # high-priority returns far above the HOODI ceiling (10 gwei)
         huge = Web3.to_wei(100, 'gwei')
         cap = Web3.to_wei(10, 'gwei')
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm, al = _patch(
-            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(huge, huge)
-        )
-        with ec, w, gm, al:
+        with _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(huge, huge)):
             manager = TransactionManager()
             await manager.transact(_tx_function(transact), high_priority=True)
 
@@ -143,26 +142,38 @@ def _gas_manager(max_fee: int, priority_fee: int) -> mock.Mock:
     return manager
 
 
-def _patch(latest_nonce: int, pending_nonce: int, gas_manager: mock.Mock, status: int = 1):
+@contextlib.contextmanager
+def _patch(
+    latest_nonce: int,
+    pending_nonce: int,
+    gas_manager: mock.Mock,
+    status: int = 1,
+    receipt_side_effect: Exception | None = None,
+):
     execution_client = mock.Mock()
     execution_client.eth.get_transaction_count = mock.AsyncMock(
         side_effect=[latest_nonce, pending_nonce]
     )
-    execution_client.eth.wait_for_transaction_receipt = mock.AsyncMock(
-        return_value={
-            'status': status,
-            'transactionHash': HexBytes('0xab'),
-            'blockNumber': 1,
-        }
-    )
+    if receipt_side_effect is not None:
+        execution_client.eth.wait_for_transaction_receipt = mock.AsyncMock(
+            side_effect=receipt_side_effect
+        )
+    else:
+        execution_client.eth.wait_for_transaction_receipt = mock.AsyncMock(
+            return_value={
+                'status': status,
+                'transactionHash': HexBytes('0xab'),
+                'blockNumber': 1,
+            }
+        )
     wallet = mock.Mock()
     wallet.address = '0x' + '11' * 20
-    return (
-        mock.patch('src.common.transaction.execution_client', execution_client),
-        mock.patch('src.common.transaction.wallet', wallet),
-        mock.patch('src.common.transaction.build_gas_manager', return_value=gas_manager),
-        mock.patch('src.common.transaction.is_alchemy_used', return_value=False),
-    )
+    with mock.patch('src.common.transaction.execution_client', execution_client), mock.patch(
+        'src.common.transaction.wallet', wallet
+    ), mock.patch('src.common.transaction.build_gas_manager', return_value=gas_manager), mock.patch(
+        'src.common.transaction.is_alchemy_used', return_value=False
+    ):
+        yield
 
 
 def _tx_function(transact_mock: mock.AsyncMock) -> mock.Mock:

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -90,6 +90,25 @@ class TestTransactionManager:
         assert params['nonce'] == 5
         assert params['maxFeePerGas'] == GWEI
 
+    async def test_pending_at_fee_ceiling_skips_replacement(self):
+        # HOODI max_fee_per_gas ceiling (10 gwei)
+        cap = Web3.to_wei(10, 'gwei')
+        manager = TransactionManager()
+
+        # first submission lands at the fee ceiling and records it for nonce 5
+        transact1 = mock.AsyncMock(return_value=HexBytes('0x01'))
+        with _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(cap, cap)):
+            await manager.transact(_tx_function(transact1), high_priority=True)
+
+        # second submission sees the pending tx still at the ceiling - it cannot bump,
+        # so it must not broadcast a doomed replacement
+        transact2 = mock.AsyncMock(return_value=HexBytes('0x02'))
+        with _patch(latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(cap, cap)):
+            receipt = await manager.transact(_tx_function(transact2))
+
+        assert receipt is None
+        transact2.assert_not_awaited()
+
     async def test_reverted_receipt_returns_none(self):
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
         with _patch(

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -109,6 +109,31 @@ class TestTransactionManager:
         assert receipt is None
         transact2.assert_not_awaited()
 
+    async def test_pending_near_fee_ceiling_skips_replacement(self):
+        # pending tx sits just below the ceiling: the 12.5% bump clamps to the 10 gwei
+        # ceiling, which is < the 10% rise the node requires, so it cannot be replaced
+        near_ceiling = Web3.to_wei(9.5, 'gwei')
+        manager = TransactionManager()
+
+        transact1 = mock.AsyncMock(return_value=HexBytes('0x01'))
+        with _patch(
+            latest_nonce=5,
+            pending_nonce=5,
+            gas_manager=_gas_manager(near_ceiling, near_ceiling),
+        ):
+            await manager.transact(_tx_function(transact1), high_priority=True)
+
+        transact2 = mock.AsyncMock(return_value=HexBytes('0x02'))
+        with _patch(
+            latest_nonce=5,
+            pending_nonce=6,
+            gas_manager=_gas_manager(near_ceiling, near_ceiling),
+        ):
+            receipt = await manager.transact(_tx_function(transact2))
+
+        assert receipt is None
+        transact2.assert_not_awaited()
+
     async def test_reverted_receipt_returns_none(self):
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
         with _patch(

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -1,0 +1,113 @@
+from math import ceil
+from unittest import mock
+
+import pytest
+from hexbytes import HexBytes
+from web3 import Web3
+from web3.types import Wei
+
+from src.common.transaction import REPLACEMENT_GAS_BUMP, TransactionManager
+
+GWEI = Web3.to_wei(1, 'gwei')
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestTransactionManager:
+    async def test_no_pending_uses_latest_nonce(self):
+        transact = mock.AsyncMock(return_value=HexBytes('0x01'))
+        ec, w, gm = _patch(
+            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
+        )
+        with ec, w, gm:
+            manager = TransactionManager()
+            tx_hash = await manager.transact(_tx_function(transact))
+
+        assert tx_hash == HexBytes('0x01')
+        params = transact.call_args.args[0]
+        assert params['nonce'] == 5
+        assert params['maxFeePerGas'] == GWEI
+        assert params['maxPriorityFeePerGas'] == GWEI // 2
+
+    async def test_pending_reuses_nonce_and_bumps_gas(self):
+        manager = TransactionManager()
+
+        # first submission records the gas used for nonce 5
+        transact1 = mock.AsyncMock(return_value=HexBytes('0x01'))
+        ec, w, gm = _patch(
+            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
+        )
+        with ec, w, gm:
+            await manager.transact(_tx_function(transact1))
+
+        # second submission sees a pending tx at nonce 5 -> replace it, bumped
+        transact2 = mock.AsyncMock(return_value=HexBytes('0x02'))
+        ec, w, gm = _patch(
+            latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)
+        )
+        with ec, w, gm:
+            await manager.transact(_tx_function(transact2))
+
+        params = transact2.call_args.args[0]
+        assert params['nonce'] == 5  # same nonce, not 6
+        assert params['maxFeePerGas'] == ceil(GWEI * REPLACEMENT_GAS_BUMP)
+        assert params['maxPriorityFeePerGas'] == ceil((GWEI // 2) * REPLACEMENT_GAS_BUMP)
+
+    async def test_retries_on_replacement_underpriced(self):
+        underpriced = ValueError({'code': -32000, 'message': 'replacement transaction underpriced'})
+        transact = mock.AsyncMock(side_effect=[underpriced, HexBytes('0x02')])
+        ec, w, gm = _patch(
+            latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)
+        )
+        with ec, w, gm:
+            manager = TransactionManager()
+            tx_hash = await manager.transact(_tx_function(transact))
+
+        assert tx_hash == HexBytes('0x02')
+        assert transact.await_count == 2
+        first = transact.call_args_list[0].args[0]
+        second = transact.call_args_list[1].args[0]
+        assert second['nonce'] == first['nonce'] == 5
+        assert second['maxFeePerGas'] > first['maxFeePerGas']
+        assert second['maxPriorityFeePerGas'] > first['maxPriorityFeePerGas']
+
+    async def test_gas_capped_at_max_fee_per_gas(self):
+        # high-priority returns far above the HOODI ceiling (10 gwei)
+        huge = Web3.to_wei(100, 'gwei')
+        cap = Web3.to_wei(10, 'gwei')
+        transact = mock.AsyncMock(return_value=HexBytes('0x01'))
+        ec, w, gm = _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(huge, huge))
+        with ec, w, gm:
+            manager = TransactionManager()
+            await manager.transact(_tx_function(transact))
+
+        params = transact.call_args.args[0]
+        assert params['maxFeePerGas'] == cap
+        assert params['maxPriorityFeePerGas'] <= params['maxFeePerGas']
+
+
+def _gas_manager(max_fee: int, priority_fee: int) -> mock.Mock:
+    manager = mock.Mock()
+    manager.get_high_priority_tx_params = mock.AsyncMock(
+        return_value={'maxFeePerGas': Wei(max_fee), 'maxPriorityFeePerGas': Wei(priority_fee)}
+    )
+    return manager
+
+
+def _patch(latest_nonce: int, pending_nonce: int, gas_manager: mock.Mock):
+    execution_client = mock.Mock()
+    execution_client.eth.get_transaction_count = mock.AsyncMock(
+        side_effect=[latest_nonce, pending_nonce]
+    )
+    wallet = mock.Mock()
+    wallet.address = '0x' + '11' * 20
+    return (
+        mock.patch('src.common.transaction.execution_client', execution_client),
+        mock.patch('src.common.transaction.wallet', wallet),
+        mock.patch('src.common.transaction.build_gas_manager', return_value=gas_manager),
+    )
+
+
+def _tx_function(transact_mock: mock.AsyncMock) -> mock.Mock:
+    tx_function = mock.Mock()
+    tx_function.transact = transact_mock
+    return tx_function

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -13,38 +13,75 @@ GWEI = Web3.to_wei(1, 'gwei')
 
 @pytest.mark.usefixtures('fake_settings')
 class TestTransactionManager:
-    async def test_no_pending_uses_latest_nonce(self):
+    async def test_no_pending_high_priority_uses_latest_nonce(self):
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm = _patch(
+        ec, w, gm, al = _patch(
             latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
         )
-        with ec, w, gm:
+        with ec, w, gm, al:
             manager = TransactionManager()
-            tx_hash = await manager.transact(_tx_function(transact))
+            receipt = await manager.transact(_tx_function(transact), high_priority=True)
 
-        assert tx_hash == HexBytes('0x01')
+        assert receipt is not None
         params = transact.call_args.args[0]
         assert params['nonce'] == 5
         assert params['maxFeePerGas'] == GWEI
         assert params['maxPriorityFeePerGas'] == GWEI // 2
+
+    async def test_default_gas_skips_fee_fields(self):
+        # high_priority=False with no pending tx submits with the node's default gas
+        transact = mock.AsyncMock(return_value=HexBytes('0x01'))
+        ec, w, gm, al = _patch(
+            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
+        )
+        with ec, w, gm, al:
+            manager = TransactionManager()
+            await manager.transact(_tx_function(transact))
+
+        params = transact.call_args.args[0]
+        assert params['nonce'] == 5
+        assert 'maxFeePerGas' not in params
+        assert 'maxPriorityFeePerGas' not in params
+
+    async def test_default_gas_escalates_on_fee_too_low(self):
+        fee_too_low = ValueError({'code': -32010})
+        # every default-gas attempt is rejected, the final escalation succeeds
+        transact = mock.AsyncMock(
+            side_effect=[fee_too_low, fee_too_low, fee_too_low, HexBytes('0x02')]
+        )
+        ec, w, gm, al = _patch(
+            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
+        )
+        with ec, w, gm, al, mock.patch(
+            'src.common.transaction.ATTEMPTS_WITH_DEFAULT_GAS', 3
+        ), mock.patch('src.common.transaction.asyncio.sleep', mock.AsyncMock()):
+            manager = TransactionManager()
+            receipt = await manager.transact(_tx_function(transact))
+
+        assert receipt is not None
+        # 3 default-gas attempts + 1 high-priority escalation
+        assert transact.await_count == 4
+        escalated = transact.call_args_list[-1].args[0]
+        assert escalated['maxFeePerGas'] == GWEI
+        assert escalated['maxPriorityFeePerGas'] == GWEI // 2
 
     async def test_pending_reuses_nonce_and_bumps_gas(self):
         manager = TransactionManager()
 
         # first submission records the gas used for nonce 5
         transact1 = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm = _patch(
+        ec, w, gm, al = _patch(
             latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)
         )
-        with ec, w, gm:
-            await manager.transact(_tx_function(transact1))
+        with ec, w, gm, al:
+            await manager.transact(_tx_function(transact1), high_priority=True)
 
         # second submission sees a pending tx at nonce 5 -> replace it, bumped
         transact2 = mock.AsyncMock(return_value=HexBytes('0x02'))
-        ec, w, gm = _patch(
+        ec, w, gm, al = _patch(
             latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)
         )
-        with ec, w, gm:
+        with ec, w, gm, al:
             await manager.transact(_tx_function(transact2))
 
         params = transact2.call_args.args[0]
@@ -52,33 +89,46 @@ class TestTransactionManager:
         assert params['maxFeePerGas'] == ceil(GWEI * REPLACEMENT_GAS_BUMP)
         assert params['maxPriorityFeePerGas'] == ceil((GWEI // 2) * REPLACEMENT_GAS_BUMP)
 
-    async def test_retries_on_replacement_underpriced(self):
-        underpriced = ValueError({'code': -32000, 'message': 'replacement transaction underpriced'})
-        transact = mock.AsyncMock(side_effect=[underpriced, HexBytes('0x02')])
-        ec, w, gm = _patch(
+    async def test_pending_skips_default_gas(self):
+        # even without high_priority, a pending tx forces the high-priority path
+        transact = mock.AsyncMock(return_value=HexBytes('0x02'))
+        ec, w, gm, al = _patch(
             latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)
         )
-        with ec, w, gm:
+        with ec, w, gm, al:
             manager = TransactionManager()
-            tx_hash = await manager.transact(_tx_function(transact))
+            await manager.transact(_tx_function(transact))
 
-        assert tx_hash == HexBytes('0x02')
-        assert transact.await_count == 2
-        first = transact.call_args_list[0].args[0]
-        second = transact.call_args_list[1].args[0]
-        assert second['nonce'] == first['nonce'] == 5
-        assert second['maxFeePerGas'] > first['maxFeePerGas']
-        assert second['maxPriorityFeePerGas'] > first['maxPriorityFeePerGas']
+        assert transact.await_count == 1
+        params = transact.call_args.args[0]
+        assert params['nonce'] == 5
+        assert params['maxFeePerGas'] == GWEI
+
+    async def test_reverted_receipt_returns_none(self):
+        transact = mock.AsyncMock(return_value=HexBytes('0x01'))
+        ec, w, gm, al = _patch(
+            latest_nonce=5,
+            pending_nonce=5,
+            gas_manager=_gas_manager(GWEI, GWEI // 2),
+            status=0,
+        )
+        with ec, w, gm, al:
+            manager = TransactionManager()
+            receipt = await manager.transact(_tx_function(transact), high_priority=True)
+
+        assert receipt is None
 
     async def test_gas_capped_at_max_fee_per_gas(self):
         # high-priority returns far above the HOODI ceiling (10 gwei)
         huge = Web3.to_wei(100, 'gwei')
         cap = Web3.to_wei(10, 'gwei')
         transact = mock.AsyncMock(return_value=HexBytes('0x01'))
-        ec, w, gm = _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(huge, huge))
-        with ec, w, gm:
+        ec, w, gm, al = _patch(
+            latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(huge, huge)
+        )
+        with ec, w, gm, al:
             manager = TransactionManager()
-            await manager.transact(_tx_function(transact))
+            await manager.transact(_tx_function(transact), high_priority=True)
 
         params = transact.call_args.args[0]
         assert params['maxFeePerGas'] == cap
@@ -93,10 +143,17 @@ def _gas_manager(max_fee: int, priority_fee: int) -> mock.Mock:
     return manager
 
 
-def _patch(latest_nonce: int, pending_nonce: int, gas_manager: mock.Mock):
+def _patch(latest_nonce: int, pending_nonce: int, gas_manager: mock.Mock, status: int = 1):
     execution_client = mock.Mock()
     execution_client.eth.get_transaction_count = mock.AsyncMock(
         side_effect=[latest_nonce, pending_nonce]
+    )
+    execution_client.eth.wait_for_transaction_receipt = mock.AsyncMock(
+        return_value={
+            'status': status,
+            'transactionHash': HexBytes('0xab'),
+            'blockNumber': 1,
+        }
     )
     wallet = mock.Mock()
     wallet.address = '0x' + '11' * 20
@@ -104,6 +161,7 @@ def _patch(latest_nonce: int, pending_nonce: int, gas_manager: mock.Mock):
         mock.patch('src.common.transaction.execution_client', execution_client),
         mock.patch('src.common.transaction.wallet', wallet),
         mock.patch('src.common.transaction.build_gas_manager', return_value=gas_manager),
+        mock.patch('src.common.transaction.is_alchemy_used', return_value=False),
     )
 
 

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -311,11 +311,15 @@ class TestTransactionManager:
 @pytest.mark.parametrize(
     'message',
     [
-        'FeeTooLow',
+        # Nethermind (mainnet full pool / Gnosis min-priority)
         'FeeTooLowToCompete',
+        'FeeTooLow, EffectivePriorityFeePerGas too low 0 < 1, BaseFee: 1221551',
         'ReplacementNotAllowed',
+        # Geth / Reth / Besu
         'transaction underpriced',
         'replacement transaction underpriced',
+        # Erigon
+        'INTERNAL_ERROR: could not replace existing tx',
     ],
 )
 def test_is_fee_too_low_error_matches_fee_rejections(message):

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -5,10 +5,15 @@ from unittest import mock
 import pytest
 from hexbytes import HexBytes
 from web3 import Web3
-from web3.exceptions import TimeExhausted
+from web3.exceptions import TimeExhausted, Web3RPCError
 from web3.types import Wei
 
-from src.common.transaction import REPLACEMENT_GAS_BUMP, Fees, TransactionManager
+from src.common.transaction import (
+    REPLACEMENT_GAS_BUMP,
+    Fees,
+    TransactionManager,
+    _is_fee_too_low_error,
+)
 
 GWEI = Web3.to_wei(1, 'gwei')
 
@@ -133,7 +138,7 @@ class TestTransactionManager:
         assert 'maxPriorityFeePerGas' not in params
 
     async def test_default_gas_escalates_on_fee_too_low(self):
-        fee_too_low = ValueError({'code': -32010})
+        fee_too_low = _rpc_error('FeeTooLowToCompete')
         # every default-gas attempt is rejected, the final escalation succeeds
         transact = mock.AsyncMock(
             side_effect=[fee_too_low, fee_too_low, fee_too_low, HexBytes('0x02')]
@@ -170,6 +175,38 @@ class TestTransactionManager:
         assert params['nonce'] == 5  # same nonce, not 6
         assert params['maxFeePerGas'] == ceil(GWEI * REPLACEMENT_GAS_BUMP)
         assert params['maxPriorityFeePerGas'] == ceil((GWEI // 2) * REPLACEMENT_GAS_BUMP)
+
+    async def test_high_priority_records_fees_and_bumps_after_underpriced_rejection(self):
+        # after a restart there is no in-memory record, so the freshly built fees may
+        # not clear the stuck tx's replacement threshold and the node rejects them.
+        manager = TransactionManager()
+
+        rejected = mock.AsyncMock(side_effect=_rpc_error('ReplacementNotAllowed'))
+        with _patch(latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)):
+            receipt = await manager.transact(_tx_function(rejected), high_priority=True)
+
+        # the rejection is swallowed and the attempted fees are recorded for nonce 5
+        assert receipt is None
+        rejected.assert_awaited_once()
+
+        # next run bumps from the recorded fees instead of resubmitting the same ones
+        accepted = mock.AsyncMock(return_value=HexBytes('0x02'))
+        with _patch(latest_nonce=5, pending_nonce=6, gas_manager=_gas_manager(GWEI, GWEI // 2)):
+            receipt = await manager.transact(_tx_function(accepted), high_priority=True)
+
+        assert receipt is not None
+        params = accepted.call_args.args[0]
+        assert params['nonce'] == 5
+        assert params['maxFeePerGas'] == ceil(GWEI * REPLACEMENT_GAS_BUMP)
+        assert params['maxPriorityFeePerGas'] == ceil((GWEI // 2) * REPLACEMENT_GAS_BUMP)
+
+    async def test_high_priority_reraises_non_fee_rpc_error(self):
+        # a rejection unrelated to fees (e.g. a revert) must not be swallowed
+        reverted = mock.AsyncMock(side_effect=_rpc_error('execution reverted', code=3))
+        with _patch(latest_nonce=5, pending_nonce=5, gas_manager=_gas_manager(GWEI, GWEI // 2)):
+            manager = TransactionManager()
+            with pytest.raises(Web3RPCError):
+                await manager.transact(_tx_function(reverted), high_priority=True)
 
     async def test_pending_skips_default_gas(self):
         # even without high_priority, a pending tx forces the high-priority path
@@ -269,6 +306,34 @@ class TestTransactionManager:
         params = transact.call_args.args[0]
         assert params['maxFeePerGas'] == cap
         assert params['maxPriorityFeePerGas'] <= params['maxFeePerGas']
+
+
+@pytest.mark.parametrize(
+    'message',
+    [
+        'FeeTooLow',
+        'FeeTooLowToCompete',
+        'ReplacementNotAllowed',
+        'transaction underpriced',
+        'replacement transaction underpriced',
+    ],
+)
+def test_is_fee_too_low_error_matches_fee_rejections(message):
+    assert _is_fee_too_low_error(_rpc_error(message)) is True
+
+
+@pytest.mark.parametrize(
+    'message',
+    ['execution reverted', 'nonce too low', 'insufficient funds for gas', 'AlreadyKnown'],
+)
+def test_is_fee_too_low_error_ignores_other_rejections(message):
+    assert _is_fee_too_low_error(_rpc_error(message)) is False
+
+
+def _rpc_error(message: str, code: int = -32000) -> Web3RPCError:
+    # mirrors what web3 7.x raises: args[0] is repr(error), the dict is in rpc_response
+    error = {'code': code, 'message': message}
+    return Web3RPCError(repr(error), rpc_response={'jsonrpc': '2.0', 'error': error, 'id': 1})
 
 
 def _gas_manager(max_fee: int, priority_fee: int) -> mock.Mock:

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -16,9 +16,14 @@ from src.config.settings import ATTEMPTS_WITH_DEFAULT_GAS, settings
 
 logger = logging.getLogger(__name__)
 
-# geth requires both `maxFeePerGas` and `maxPriorityFeePerGas` to increase by at
+# the node requires both `maxFeePerGas` and `maxPriorityFeePerGas` to increase by at
 # least 10% to replace a pending transaction. Use a bit more for headroom.
 REPLACEMENT_GAS_BUMP = 1.125
+
+# Minimum ratio the node enforces for a replacement: both fees must rise by at least
+# its price bump (10% by default). A bump clamped to the ceiling below this ratio
+# would be rejected as underpriced.
+MIN_REPLACEMENT_RATIO = 1.1
 
 
 class Fees:
@@ -56,6 +61,14 @@ class Fees:
             priority_fee_per_gas=max(self.priority_fee_per_gas, other.priority_fee_per_gas),
             max_fee_per_gas=self.max_fee_per_gas,
         )
+
+    def replaces(self, prev: 'Fees') -> bool:
+        # the node accepts a replacement only when BOTH fees rise by at least its price
+        # bump. Near the ceiling the bump clamps below that, making replacement
+        # impossible even though the capped fee is still above the previous one.
+        return self.fee_per_gas >= ceil(
+            prev.fee_per_gas * MIN_REPLACEMENT_RATIO
+        ) and self.priority_fee_per_gas >= ceil(prev.priority_fee_per_gas * MIN_REPLACEMENT_RATIO)
 
     @property
     def tx_params(self) -> TxParams:
@@ -172,17 +185,17 @@ class TransactionManager:
         if prev is not None:
             # a transaction we sent for this nonce is still pending - bump from its fees
             prev_fees = Fees.from_tx_params(prev)
-            prev_fee_per_gas = prev_fees.fee_per_gas
-            prev_fees.bump()
-            fees = fees.max_with(prev_fees)
-            if fees.fee_per_gas <= prev_fee_per_gas:
-                # already at the max_fee_per_gas ceiling - the bump is a no-op, so the node
-                # would reject the replacement as underpriced. Leave the pending tx in place;
-                # it will mine once the base fee drops.
+            bumped_prev = Fees.from_tx_params(prev)
+            bumped_prev.bump()
+            fees = fees.max_with(bumped_prev)
+            if not fees.replaces(prev_fees):
+                # the bump got clamped to the max_fee_per_gas ceiling and no longer clears
+                # the node's replacement threshold, so it would reject it as underpriced.
+                # Leave the pending tx in place; it will mine once the base fee drops.
                 logger.warning(
-                    'Pending transaction at nonce %d is at the max_fee_per_gas_gwei ceiling '
-                    '(%s gwei); cannot bump fees to replace it. Waiting for it to mine or for '
-                    'the base fee to drop. Consider raising max_fee_per_gas_gwei.',
+                    'Pending transaction at nonce %d is at or near the max_fee_per_gas_gwei '
+                    'ceiling (%s gwei); cannot bump fees enough to replace it. Waiting for it '
+                    'to mine or for the base fee to drop. Consider raising max_fee_per_gas_gwei.',
                     nonce,
                     settings.max_fee_per_gas_gwei,
                 )

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -1,0 +1,127 @@
+import asyncio
+import logging
+from math import ceil
+
+from hexbytes import HexBytes
+from web3 import Web3
+from web3.contract.async_contract import AsyncContractFunction
+from web3.types import TxParams, Wei
+
+from src.common.clients import execution_client
+from src.common.execution import build_gas_manager
+from src.common.wallet import wallet
+from src.config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# geth requires both `maxFeePerGas` and `maxPriorityFeePerGas` to increase by at
+# least 10% to replace a pending transaction. Use a bit more for headroom.
+REPLACEMENT_GAS_BUMP = 1.125
+
+# how many times to bump the gas when a replacement is rejected as underpriced
+REPLACEMENT_ATTEMPTS = 5
+
+
+class TransactionManager:
+    """
+    Submits transactions while keeping at most one in-flight transaction per nonce.
+
+    Instead of spending a new nonce while an earlier one is pending, this manager
+    re-uses the lowest unconfirmed nonce and bumps its gas price so the new
+    transaction *replaces* the stuck one in the mempool. As a bonus the replacing
+    transaction carries freshly built calldata, so it does not inherit the stale
+    state that doomed the original.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        # nonce -> gas params last broadcast for it, used to size the replacement bump
+        self._pending_gas: dict[int, TxParams] = {}
+
+    async def transact(
+        self, tx_function: AsyncContractFunction, tx_params: TxParams | None = None
+    ) -> HexBytes:
+        # serialize submissions so concurrent tasks do not grab the same nonce
+        async with self._lock:
+            return await self._transact(tx_function, dict(tx_params or {}))  # type: ignore
+
+    async def _transact(self, tx_function: AsyncContractFunction, tx_params: TxParams) -> HexBytes:
+        address = wallet.address
+        latest_nonce = await execution_client.eth.get_transaction_count(address, 'latest')
+        pending_nonce = await execution_client.eth.get_transaction_count(address, 'pending')
+
+        # forget gas records for nonces that have already been mined (nonce
+        # `latest_nonce` itself is still pending, so keep it)
+        self._pending_gas = {n: p for n, p in self._pending_gas.items() if n >= latest_nonce}
+
+        gas_params = await build_gas_manager().get_high_priority_tx_params()
+        max_fee = int(gas_params['maxFeePerGas'])
+        priority_fee = int(gas_params['maxPriorityFeePerGas'])
+
+        if pending_nonce > latest_nonce:
+            # an earlier transaction is stuck at latest_nonce - replace it instead of
+            # queuing a new one behind it
+            prev = self._pending_gas.get(latest_nonce)
+            if prev is not None:
+                max_fee = max(max_fee, _bump(int(prev['maxFeePerGas'])))
+                priority_fee = max(priority_fee, _bump(int(prev['maxPriorityFeePerGas'])))
+            logger.info(
+                'Found pending transaction at nonce %d, replacing it',
+                latest_nonce,
+            )
+
+        max_fee_cap = Web3.to_wei(settings.max_fee_per_gas_gwei, 'gwei')
+
+        last_error: ValueError | None = None
+        for _ in range(REPLACEMENT_ATTEMPTS):
+            max_fee, priority_fee = _cap_fees(max_fee, priority_fee, max_fee_cap)
+            params: TxParams = {
+                **tx_params,
+                'nonce': latest_nonce,
+                'maxFeePerGas': Wei(max_fee),
+                'maxPriorityFeePerGas': Wei(priority_fee),
+            }
+            try:
+                tx_hash = await tx_function.transact(params)
+                self._pending_gas[latest_nonce] = params
+                return tx_hash
+            except ValueError as e:
+                if not _is_replacement_underpriced_error(e):
+                    raise
+                last_error = e
+                if max_fee >= max_fee_cap:
+                    # cannot bump further without exceeding the configured ceiling
+                    logger.warning(
+                        'Cannot replace pending transaction at nonce %d: gas price would '
+                        'exceed the configured maximum of %s gwei',
+                        latest_nonce,
+                        settings.max_fee_per_gas_gwei,
+                    )
+                    break
+                max_fee = _bump(max_fee)
+                priority_fee = _bump(priority_fee)
+
+        raise last_error  # type: ignore[misc]
+
+
+def _bump(value: int) -> int:
+    return ceil(value * REPLACEMENT_GAS_BUMP)
+
+
+def _cap_fees(max_fee: int, priority_fee: int, cap: int) -> tuple[int, int]:
+    max_fee = min(max_fee, cap)
+    # maxPriorityFeePerGas must never exceed maxFeePerGas
+    priority_fee = min(priority_fee, max_fee)
+    return max_fee, priority_fee
+
+
+def _is_replacement_underpriced_error(e: ValueError) -> bool:
+    message = ''
+    if e.args and isinstance(e.args[0], dict):
+        message = str(e.args[0].get('message', ''))
+    else:
+        message = str(e)
+    return 'replacement transaction underpriced' in message.lower()
+
+
+tx_manager = TransactionManager()

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -49,12 +49,6 @@ class Fees:
         self.priority_fee_per_gas = self._bump(self.priority_fee_per_gas)
         self._cap()
 
-    def _cap(self) -> None:
-        # never exceed the configured ceiling
-        self.fee_per_gas = min(self.fee_per_gas, self.max_fee_per_gas)
-        # maxPriorityFeePerGas must never exceed maxFeePerGas
-        self.priority_fee_per_gas = min(self.priority_fee_per_gas, self.fee_per_gas)
-
     def max_with(self, other: 'Fees') -> 'Fees':
         return Fees(
             fee_per_gas=max(self.fee_per_gas, other.fee_per_gas),
@@ -62,11 +56,18 @@ class Fees:
             max_fee_per_gas=self.max_fee_per_gas,
         )
 
+    @property
     def tx_params(self) -> TxParams:
         return {
             'maxFeePerGas': Wei(self.fee_per_gas),
             'maxPriorityFeePerGas': Wei(self.priority_fee_per_gas),
         }
+
+    def _cap(self) -> None:
+        # never exceed the configured ceiling
+        self.fee_per_gas = min(self.fee_per_gas, self.max_fee_per_gas)
+        # maxPriorityFeePerGas must never exceed maxFeePerGas
+        self.priority_fee_per_gas = min(self.priority_fee_per_gas, self.fee_per_gas)
 
     @staticmethod
     def _bump(value: int) -> int:
@@ -123,6 +124,8 @@ class TransactionManager:
         high_priority: bool,
     ) -> TxReceipt | None:
         address = wallet.address
+        # Since nonces are 0-indexed, that tx count equals the nonce
+        # of the next transaction to be mined.
         latest_nonce = await execution_client.eth.get_transaction_count(address, 'latest')
         pending_nonce = await execution_client.eth.get_transaction_count(address, 'pending')
 
@@ -165,7 +168,7 @@ class TransactionManager:
             prev_fees.bump()
             fees = fees.max_with(prev_fees)
 
-        params: TxParams = {**tx_params, 'nonce': nonce, **fees.tx_params()}
+        params: TxParams = {**tx_params, 'nonce': nonce, **fees.tx_params}
         tx_hash = await tx_function.transact(params)
         self._nonce_to_tx_params[nonce] = params
         return tx_hash

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -50,10 +50,18 @@ class Fees:
             max_fee_per_gas=max_fee_per_gas,
         )
 
-    def bump(self) -> None:
-        self.fee_per_gas = self._bump(self.fee_per_gas)
-        self.priority_fee_per_gas = self._bump(self.priority_fee_per_gas)
-        self._cap()
+    def to_tx_params(self) -> TxParams:
+        return {
+            'maxFeePerGas': Wei(self.fee_per_gas),
+            'maxPriorityFeePerGas': Wei(self.priority_fee_per_gas),
+        }
+
+    def bump(self) -> 'Fees':
+        return Fees(
+            fee_per_gas=self._bump(self.fee_per_gas),
+            priority_fee_per_gas=self._bump(self.priority_fee_per_gas),
+            max_fee_per_gas=self.max_fee_per_gas,
+        )
 
     def max_with(self, other: 'Fees') -> 'Fees':
         return Fees(
@@ -69,13 +77,6 @@ class Fees:
         return self.fee_per_gas >= ceil(
             prev.fee_per_gas * MIN_REPLACEMENT_RATIO
         ) and self.priority_fee_per_gas >= ceil(prev.priority_fee_per_gas * MIN_REPLACEMENT_RATIO)
-
-    @property
-    def tx_params(self) -> TxParams:
-        return {
-            'maxFeePerGas': Wei(self.fee_per_gas),
-            'maxPriorityFeePerGas': Wei(self.priority_fee_per_gas),
-        }
 
     def _cap(self) -> None:
         # never exceed the configured ceiling
@@ -185,9 +186,7 @@ class TransactionManager:
         if prev is not None:
             # a transaction we sent for this nonce is still pending - bump from its fees
             prev_fees = Fees.from_tx_params(prev)
-            bumped_prev = Fees.from_tx_params(prev)
-            bumped_prev.bump()
-            fees = fees.max_with(bumped_prev)
+            fees = fees.max_with(prev_fees.bump())
             if not fees.replaces(prev_fees):
                 # the bump got clamped to the max_fee_per_gas ceiling and no longer clears
                 # the node's replacement threshold, so it would reject it as underpriced.
@@ -201,7 +200,7 @@ class TransactionManager:
                 )
                 return None
 
-        params: TxParams = {**tx_params, 'nonce': nonce, **fees.tx_params}
+        params: TxParams = {**tx_params, 'nonce': nonce, **fees.to_tx_params()}
         tx_hash = await tx_function.transact(params)
         self._nonce_to_tx_params[nonce] = params
         return tx_hash

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -98,8 +98,7 @@ class TransactionManager:
     Trade-off: while a transaction is being mined the lock blocks other tasks, so no
     two tasks can collide on a nonce. On a receipt timeout the lock is released with
     the transaction still pending, so a different task may replace it on its next run.
-    That is harmless - nothing can be mined past the stuck nonce anyway, and every
-    replacement bumps the fee (capped at `max_fee_per_gas`), so it converges.
+    That is harmless.
     """
 
     def __init__(self) -> None:
@@ -155,6 +154,9 @@ class TransactionManager:
                 # default gas was not accepted - escalate to high priority fees
                 tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
 
+        if tx_hash is None:
+            # nothing was broadcast (the pending tx is pinned at the fee ceiling)
+            return None
         return await self._wait_for_receipt(tx_hash)
 
     async def _submit_high_priority(
@@ -162,7 +164,7 @@ class TransactionManager:
         tx_function: AsyncContractFunction,
         tx_params: TxParams,
         nonce: Nonce,
-    ) -> HexBytes:
+    ) -> HexBytes | None:
         gas_params = await build_gas_manager().get_high_priority_tx_params()
         fees = Fees.from_tx_params(gas_params)
 
@@ -170,8 +172,21 @@ class TransactionManager:
         if prev is not None:
             # a transaction we sent for this nonce is still pending - bump from its fees
             prev_fees = Fees.from_tx_params(prev)
+            prev_fee_per_gas = prev_fees.fee_per_gas
             prev_fees.bump()
             fees = fees.max_with(prev_fees)
+            if fees.fee_per_gas <= prev_fee_per_gas:
+                # already at the max_fee_per_gas ceiling - the bump is a no-op, so the node
+                # would reject the replacement as underpriced. Leave the pending tx in place;
+                # it will mine once the base fee drops.
+                logger.warning(
+                    'Pending transaction at nonce %d is at the max_fee_per_gas_gwei ceiling '
+                    '(%s gwei); cannot bump fees to replace it. Waiting for it to mine or for '
+                    'the base fee to drop. Consider raising max_fee_per_gas_gwei.',
+                    nonce,
+                    settings.max_fee_per_gas_gwei,
+                )
+                return None
 
         params: TxParams = {**tx_params, 'nonce': nonce, **fees.tx_params}
         tx_hash = await tx_function.transact(params)

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -5,6 +5,7 @@ from math import ceil
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract.async_contract import AsyncContractFunction
+from web3.exceptions import TimeExhausted
 from web3.types import Nonce, TxParams, TxReceipt, Wei
 
 from src.common.clients import execution_client
@@ -111,10 +112,14 @@ class TransactionManager:
         tx_function: AsyncContractFunction,
         tx_params: TxParams | None = None,
         high_priority: bool = False,
+        estimate_gas: bool = False,
     ) -> TxReceipt | None:
+        params: TxParams = dict(tx_params or {})  # type: ignore[assignment]
         # serialize submit + receipt wait so only one wallet tx is in flight at a time
         async with self._lock:
-            params: TxParams = dict(tx_params or {})  # type: ignore[assignment]
+            if estimate_gas:
+                # simulate the transaction before submitting it
+                await tx_function.estimate_gas(params)
             return await self._transact(tx_function, params, high_priority)
 
     async def _transact(
@@ -196,9 +201,16 @@ class TransactionManager:
     @staticmethod
     async def _wait_for_receipt(tx_hash: HexBytes) -> TxReceipt | None:
         logger.info('Waiting for transaction %s confirmation', Web3.to_hex(tx_hash))
-        tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-            tx_hash, timeout=settings.execution_transaction_timeout
-        )
+        try:
+            tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
+                tx_hash, timeout=settings.execution_transaction_timeout
+            )
+        except TimeExhausted:
+            logger.info(
+                'Transaction %s is still pending, will replace it on the next run',
+                Web3.to_hex(tx_hash),
+            )
+            return None
         if not tx_receipt['status']:
             return None
         return tx_receipt

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -5,12 +5,13 @@ from math import ceil
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract.async_contract import AsyncContractFunction
-from web3.types import TxParams, Wei
+from web3.types import Nonce, TxParams, TxReceipt, Wei
 
 from src.common.clients import execution_client
-from src.common.execution import build_gas_manager
+from src.common.execution import build_gas_manager, is_alchemy_used
 from src.common.wallet import wallet
-from src.config.settings import settings
+from src.config.networks import HOODI
+from src.config.settings import ATTEMPTS_WITH_DEFAULT_GAS, settings
 
 logger = logging.getLogger(__name__)
 
@@ -18,110 +19,198 @@ logger = logging.getLogger(__name__)
 # least 10% to replace a pending transaction. Use a bit more for headroom.
 REPLACEMENT_GAS_BUMP = 1.125
 
-# how many times to bump the gas when a replacement is rejected as underpriced
-REPLACEMENT_ATTEMPTS = 5
+
+class Fees:
+    """
+    Holds EIP-1559 gas fees and keeps two invariants:
+    `priority_fee_per_gas <= fee_per_gas` and `fee_per_gas <= max_fee_per_gas`.
+    """
+
+    def __init__(
+        self, fee_per_gas: int, priority_fee_per_gas: int, max_fee_per_gas: int | None = None
+    ) -> None:
+        if max_fee_per_gas is None:
+            max_fee_per_gas = Web3.to_wei(settings.max_fee_per_gas_gwei, 'gwei')
+        self.max_fee_per_gas = max_fee_per_gas
+        self.fee_per_gas = fee_per_gas
+        self.priority_fee_per_gas = priority_fee_per_gas
+        self._cap()
+
+    @staticmethod
+    def from_tx_params(tx_params: TxParams, max_fee_per_gas: int | None = None) -> 'Fees':
+        return Fees(
+            fee_per_gas=int(tx_params['maxFeePerGas']),
+            priority_fee_per_gas=int(tx_params['maxPriorityFeePerGas']),
+            max_fee_per_gas=max_fee_per_gas,
+        )
+
+    def bump(self) -> None:
+        self.fee_per_gas = self._bump(self.fee_per_gas)
+        self.priority_fee_per_gas = self._bump(self.priority_fee_per_gas)
+        self._cap()
+
+    def _cap(self) -> None:
+        # never exceed the configured ceiling
+        self.fee_per_gas = min(self.fee_per_gas, self.max_fee_per_gas)
+        # maxPriorityFeePerGas must never exceed maxFeePerGas
+        self.priority_fee_per_gas = min(self.priority_fee_per_gas, self.fee_per_gas)
+
+    def max_with(self, other: 'Fees') -> 'Fees':
+        return Fees(
+            fee_per_gas=max(self.fee_per_gas, other.fee_per_gas),
+            priority_fee_per_gas=max(self.priority_fee_per_gas, other.priority_fee_per_gas),
+            max_fee_per_gas=self.max_fee_per_gas,
+        )
+
+    def tx_params(self) -> TxParams:
+        return {
+            'maxFeePerGas': Wei(self.fee_per_gas),
+            'maxPriorityFeePerGas': Wei(self.priority_fee_per_gas),
+        }
+
+    @staticmethod
+    def _bump(value: int) -> int:
+        return ceil(value * REPLACEMENT_GAS_BUMP)
 
 
 class TransactionManager:
     """
-    Submits transactions while keeping at most one in-flight transaction per nonce.
+    Submits wallet transactions, keeping at most one in flight at a time.
 
-    Instead of spending a new nonce while an earlier one is pending, this manager
-    re-uses the lowest unconfirmed nonce and bumps its gas price so the new
-    transaction *replaces* the stuck one in the mempool. As a bonus the replacing
-    transaction carries freshly built calldata, so it does not inherit the stale
-    state that doomed the original.
+    The manager owns both submission and receipt-waiting and holds a lock across
+    both, so exactly one transaction is in flight for the wallet at any moment. It
+    re-uses the lowest unconfirmed nonce: if an earlier transaction is still pending
+    (left by a previous task run), the next submission *replaces* it with freshly
+    built calldata and bumped fees instead of queuing a new nonce behind the stuck one.
+
+    There is no in-call fee-bump loop. A submission that does not confirm within
+    `execution_transaction_timeout` simply stops; the task retries on its next run,
+    where the pending transaction is detected and its fees bumped.
+
+    Two gas strategies:
+    - `high_priority=True` (e.g. validator registration) skips the default-gas attempts
+      and submits high-priority fees straight away.
+    - `high_priority=False` first tries the node's default gas, escalating to
+      high-priority fees once the default-gas attempts are exhausted.
+
+    Trade-off: while a transaction is being mined the lock blocks other tasks, so no
+    two tasks can collide on a nonce. On a receipt timeout the lock is released with
+    the transaction still pending, so a different task may replace it on its next run.
+    That is harmless - nothing can be mined past the stuck nonce anyway, and every
+    replacement bumps the fee (capped at `max_fee_per_gas`), so it converges.
     """
 
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
-        # nonce -> gas params last broadcast for it, used to size the replacement bump
-        self._pending_gas: dict[int, TxParams] = {}
+        # nonce -> tx params last broadcast for it, used to size the replacement bump
+        self._nonce_to_tx_params: dict[int, TxParams] = {}
 
     async def transact(
-        self, tx_function: AsyncContractFunction, tx_params: TxParams | None = None
-    ) -> HexBytes:
-        # serialize submissions so concurrent tasks do not grab the same nonce
+        self,
+        tx_function: AsyncContractFunction,
+        tx_params: TxParams | None = None,
+        high_priority: bool = False,
+    ) -> TxReceipt | None:
+        # serialize submit + receipt wait so only one wallet tx is in flight at a time
         async with self._lock:
-            return await self._transact(tx_function, dict(tx_params or {}))  # type: ignore
+            params: TxParams = dict(tx_params or {})  # type: ignore[assignment]
+            return await self._transact(tx_function, params, high_priority)
 
-    async def _transact(self, tx_function: AsyncContractFunction, tx_params: TxParams) -> HexBytes:
+    async def _transact(
+        self,
+        tx_function: AsyncContractFunction,
+        tx_params: TxParams,
+        high_priority: bool,
+    ) -> TxReceipt | None:
         address = wallet.address
         latest_nonce = await execution_client.eth.get_transaction_count(address, 'latest')
         pending_nonce = await execution_client.eth.get_transaction_count(address, 'pending')
 
         # forget gas records for nonces that have already been mined (nonce
-        # `latest_nonce` itself is still pending, so keep it)
-        self._pending_gas = {n: p for n, p in self._pending_gas.items() if n >= latest_nonce}
-
-        gas_params = await build_gas_manager().get_high_priority_tx_params()
-        max_fee = int(gas_params['maxFeePerGas'])
-        priority_fee = int(gas_params['maxPriorityFeePerGas'])
+        # `latest_nonce` itself may still be pending, so keep it)
+        self._nonce_to_tx_params = {
+            n: p for n, p in self._nonce_to_tx_params.items() if n >= latest_nonce
+        }
 
         if pending_nonce > latest_nonce:
             # an earlier transaction is stuck at latest_nonce - replace it instead of
-            # queuing a new one behind it
-            prev = self._pending_gas.get(latest_nonce)
-            if prev is not None:
-                max_fee = max(max_fee, _bump(int(prev['maxFeePerGas'])))
-                priority_fee = max(priority_fee, _bump(int(prev['maxPriorityFeePerGas'])))
-            logger.info(
-                'Found pending transaction at nonce %d, replacing it',
-                latest_nonce,
-            )
+            # queuing a new one behind it (skip the default-gas attempts)
+            logger.info('Found pending transaction at nonce %d, replacing it', latest_nonce)
+            tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
+        elif high_priority or _skip_default_gas():
+            tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
+        else:
+            default_tx_hash = await self._submit_default_gas(tx_function, tx_params, latest_nonce)
+            if default_tx_hash is not None:
+                tx_hash = default_tx_hash
+            else:
+                # default gas was not accepted - escalate to high priority fees
+                tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
 
-        max_fee_cap = Web3.to_wei(settings.max_fee_per_gas_gwei, 'gwei')
+        return await self._wait_for_receipt(tx_hash)
 
-        last_error: ValueError | None = None
-        for _ in range(REPLACEMENT_ATTEMPTS):
-            max_fee, priority_fee = _cap_fees(max_fee, priority_fee, max_fee_cap)
-            params: TxParams = {
-                **tx_params,
-                'nonce': latest_nonce,
-                'maxFeePerGas': Wei(max_fee),
-                'maxPriorityFeePerGas': Wei(priority_fee),
-            }
+    async def _submit_high_priority(
+        self,
+        tx_function: AsyncContractFunction,
+        tx_params: TxParams,
+        nonce: Nonce,
+    ) -> HexBytes:
+        gas_params = await build_gas_manager().get_high_priority_tx_params()
+        fees = Fees.from_tx_params(gas_params)
+
+        prev = self._nonce_to_tx_params.get(nonce)
+        if prev is not None:
+            # a transaction we sent for this nonce is still pending - bump from its fees
+            prev_fees = Fees.from_tx_params(prev)
+            prev_fees.bump()
+            fees = fees.max_with(prev_fees)
+
+        params: TxParams = {**tx_params, 'nonce': nonce, **fees.tx_params()}
+        tx_hash = await tx_function.transact(params)
+        self._nonce_to_tx_params[nonce] = params
+        return tx_hash
+
+    async def _submit_default_gas(
+        self,
+        tx_function: AsyncContractFunction,
+        tx_params: TxParams,
+        nonce: Nonce,
+    ) -> HexBytes | None:
+        # try the node's default gas, waiting a block between FeeTooLow rejections;
+        # returns None if every attempt is rejected so the caller can escalate
+        params: TxParams = {**tx_params, 'nonce': nonce}
+        for i in range(ATTEMPTS_WITH_DEFAULT_GAS):
             try:
-                tx_hash = await tx_function.transact(params)
-                self._pending_gas[latest_nonce] = params
-                return tx_hash
+                return await tx_function.transact(params)
             except ValueError as e:
-                if not _is_replacement_underpriced_error(e):
+                if not _is_fee_too_low_error(e):
                     raise
-                last_error = e
-                if max_fee >= max_fee_cap:
-                    # cannot bump further without exceeding the configured ceiling
-                    logger.warning(
-                        'Cannot replace pending transaction at nonce %d: gas price would '
-                        'exceed the configured maximum of %s gwei',
-                        latest_nonce,
-                        settings.max_fee_per_gas_gwei,
-                    )
-                    break
-                max_fee = _bump(max_fee)
-                priority_fee = _bump(priority_fee)
+                if i < ATTEMPTS_WITH_DEFAULT_GAS - 1:  # skip the last sleep
+                    await asyncio.sleep(settings.network_config.SECONDS_PER_BLOCK)
 
-        raise last_error  # type: ignore[misc]
+        return None
 
-
-def _bump(value: int) -> int:
-    return ceil(value * REPLACEMENT_GAS_BUMP)
+    @staticmethod
+    async def _wait_for_receipt(tx_hash: HexBytes) -> TxReceipt | None:
+        logger.info('Waiting for transaction %s confirmation', Web3.to_hex(tx_hash))
+        tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
+            tx_hash, timeout=settings.execution_transaction_timeout
+        )
+        if not tx_receipt['status']:
+            return None
+        return tx_receipt
 
 
-def _cap_fees(max_fee: int, priority_fee: int, cap: int) -> tuple[int, int]:
-    max_fee = min(max_fee, cap)
-    # maxPriorityFeePerGas must never exceed maxFeePerGas
-    priority_fee = min(priority_fee, max_fee)
-    return max_fee, priority_fee
+def _skip_default_gas() -> bool:
+    # Alchemy does not support eth_maxPriorityFeePerGas for Hoodi, go straight to high priority
+    return settings.network == HOODI and is_alchemy_used()
 
 
-def _is_replacement_underpriced_error(e: ValueError) -> bool:
-    message = ''
+def _is_fee_too_low_error(e: ValueError) -> bool:
+    code = None
     if e.args and isinstance(e.args[0], dict):
-        message = str(e.args[0].get('message', ''))
-    else:
-        message = str(e)
-    return 'replacement transaction underpriced' in message.lower()
+        code = e.args[0].get('code')
+    return code == -32010
 
 
 tx_manager = TransactionManager()

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -161,10 +161,8 @@ class TransactionManager:
         elif high_priority or _skip_default_gas():
             tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
         else:
-            default_tx_hash = await self._submit_default_gas(tx_function, tx_params, latest_nonce)
-            if default_tx_hash is not None:
-                tx_hash = default_tx_hash
-            else:
+            tx_hash = await self._submit_default_gas(tx_function, tx_params, latest_nonce)
+            if tx_hash is None:
                 # default gas was not accepted - escalate to high priority fees
                 tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
 

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -263,14 +263,16 @@ def _skip_default_gas() -> bool:
 
 # Node rejection messages (lowercased substrings) that a fee bump can clear. The
 # node returns these as a Web3RPCError with the generic code -32000, so match on the
-# message rather than the code. Nethermind: `FeeTooLow`, `FeeTooLowToCompete`,
-# `ReplacementNotAllowed`; Geth/Besu: `transaction underpriced`, `replacement
-# transaction underpriced`, `fee too low`.
+# message rather than the code. Messages observed across execution clients:
+#   Nethermind:      `FeeTooLow`, `FeeTooLowToCompete`, `ReplacementNotAllowed`
+#   Geth/Reth/Besu:  `transaction underpriced`, `replacement transaction underpriced`
+#   Erigon:          `could not replace existing tx`
 _FEE_TOO_LOW_MESSAGES = (
     'feetoolow',
     'fee too low',
     'underpriced',
     'replacementnotallowed',
+    'could not replace',
 )
 
 

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -5,7 +5,7 @@ from math import ceil
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract.async_contract import AsyncContractFunction
-from web3.exceptions import TimeExhausted
+from web3.exceptions import TimeExhausted, Web3RPCError
 from web3.types import Nonce, TxParams, TxReceipt, Wei
 
 from src.common.clients import execution_client
@@ -201,7 +201,20 @@ class TransactionManager:
                 return None
 
         params: TxParams = {**tx_params, 'nonce': nonce, **fees.to_tx_params()}
-        tx_hash = await tx_function.transact(params)
+        try:
+            tx_hash = await tx_function.transact(params)
+        except Web3RPCError as e:
+            if not _is_fee_too_low_error(e):
+                raise
+            # This happens when we have no record to bump from (e.g. after a restart)
+            logger.warning(
+                'Transaction at nonce %d rejected as underpriced (%s); recorded its '
+                'fees and will bump them on the next run.',
+                nonce,
+                _rpc_error_message(e),
+            )
+            self._nonce_to_tx_params[nonce] = params
+            return None
         self._nonce_to_tx_params[nonce] = params
         return tx_hash
 
@@ -217,7 +230,7 @@ class TransactionManager:
         for i in range(ATTEMPTS_WITH_DEFAULT_GAS):
             try:
                 return await tx_function.transact(params)
-            except ValueError as e:
+            except Web3RPCError as e:
                 if not _is_fee_too_low_error(e):
                     raise
                 if i < ATTEMPTS_WITH_DEFAULT_GAS - 1:  # skip the last sleep
@@ -248,11 +261,32 @@ def _skip_default_gas() -> bool:
     return settings.network == HOODI and is_alchemy_used()
 
 
-def _is_fee_too_low_error(e: ValueError) -> bool:
-    code = None
-    if e.args and isinstance(e.args[0], dict):
-        code = e.args[0].get('code')
-    return code == -32010
+# Node rejection messages (lowercased substrings) that a fee bump can clear. The
+# node returns these as a Web3RPCError with the generic code -32000, so match on the
+# message rather than the code. Nethermind: `FeeTooLow`, `FeeTooLowToCompete`,
+# `ReplacementNotAllowed`; Geth/Besu: `transaction underpriced`, `replacement
+# transaction underpriced`, `fee too low`.
+_FEE_TOO_LOW_MESSAGES = (
+    'feetoolow',
+    'fee too low',
+    'underpriced',
+    'replacementnotallowed',
+)
+
+
+def _rpc_error_message(e: Web3RPCError) -> str:
+    rpc_response = getattr(e, 'rpc_response', None)
+    if isinstance(rpc_response, dict) and isinstance(rpc_response.get('error'), dict):
+        message = rpc_response['error'].get('message')
+        if message is not None:
+            return str(message)
+    # fall back to the exception's own string (args[0] is repr(error) in web3 7.x)
+    return str(e)
+
+
+def _is_fee_too_low_error(e: Web3RPCError) -> bool:
+    message = _rpc_error_message(e).lower()
+    return any(token in message for token in _FEE_TOO_LOW_MESSAGES)
 
 
 tx_manager = TransactionManager()

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -299,7 +299,7 @@ class Settings(metaclass=Singleton):
         self.concurrency = concurrency
         self.execution_timeout = decouple_config('EXECUTION_TIMEOUT', default=30, cast=int)
         self.execution_transaction_timeout = decouple_config(
-            'EXECUTION_TRANSACTION_TIMEOUT', default=300, cast=int
+            'EXECUTION_TRANSACTION_TIMEOUT', default=60, cast=int
         )
         self.execution_retry_timeout = decouple_config(
             'EXECUTION_RETRY_TIMEOUT', default=60, cast=int

--- a/src/exits/execution.py
+++ b/src/exits/execution.py
@@ -3,9 +3,8 @@ import logging
 from eth_typing import ChecksumAddress, HexStr
 from web3 import Web3
 
-from src.common.clients import execution_client
 from src.common.contracts import keeper_contract
-from src.common.execution import transaction_gas_wrapper
+from src.common.transaction import tx_manager
 from src.common.typings import OraclesApproval
 from src.common.utils import format_error
 from src.config.settings import settings
@@ -26,7 +25,7 @@ async def submit_exit_signatures(
             approval.ipfs_hash,
             approval.signatures,
         )
-        tx = await transaction_gas_wrapper(tx_function)
+        tx_receipt = await tx_manager.transact(tx_function)
 
     except Exception as e:
         logger.error('Failed to update exit signatures: %s', format_error(e))
@@ -35,11 +34,7 @@ async def submit_exit_signatures(
             logger.exception(e)
         return None
 
-    logger.info('Waiting for transaction %s confirmation', Web3.to_hex(tx))
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
+    if tx_receipt is None:
         logger.error('UpdateExitSignatures transaction failed')
         return None
-    return Web3.to_hex(tx)
+    return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/harvest/execution.py
+++ b/src/harvest/execution.py
@@ -4,9 +4,8 @@ from eth_typing import HexStr
 from web3 import Web3
 from web3.exceptions import ContractLogicError
 
-from src.common.clients import execution_client
 from src.common.contracts import VaultContract, multicall_contract
-from src.common.execution import transaction_gas_wrapper
+from src.common.transaction import tx_manager
 from src.common.typings import HarvestParams
 from src.common.utils import format_error
 from src.config.settings import settings
@@ -21,20 +20,15 @@ async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr | 
     ]
     try:
         tx_function = multicall_contract.functions.aggregate(calls)
-        tx = await transaction_gas_wrapper(tx_function)
-        tx_hash = Web3.to_hex(tx)
+        tx_receipt = await tx_manager.transact(tx_function)
     except (ValueError, ContractLogicError) as e:
         logger.error('Failed to harvest: %s', format_error(e))
         if settings.verbose:
             logger.exception(e)
         return None
 
-    logger.info('Waiting for transaction %s confirmation', tx_hash)
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx_hash, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
+    if tx_receipt is None:
         logger.error('Harvest transaction failed')
         return None
 
-    return tx_hash
+    return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/meta_vault/contracts.py
+++ b/src/meta_vault/contracts.py
@@ -1,9 +1,9 @@
 from eth_typing import HexStr
-from web3 import AsyncWeb3, Web3
-from web3.types import ChecksumAddress, Wei
+from web3 import AsyncWeb3
+from web3.types import ChecksumAddress, TxReceipt, Wei
 
 from src.common.contracts import BaseEncoder, ContractWrapper
-from src.common.execution import transaction_gas_wrapper
+from src.common.transaction import tx_manager
 from src.common.typings import HarvestParams
 from src.meta_vault.typings import SubVaultExitRequest
 
@@ -51,10 +51,9 @@ class MetaVaultEncoder(BaseEncoder):
 class SubVaultsRegistryContract(ContractWrapper):
     abi_path = 'abi/ISubVaultsRegistry.json'
 
-    async def deposit_to_sub_vaults(self) -> HexStr:
+    async def deposit_to_sub_vaults(self) -> TxReceipt | None:
         tx_function = self.contract.functions.depositToSubVaults()
-        tx_hash = await transaction_gas_wrapper(tx_function)
-        return Web3.to_hex(tx_hash)
+        return await tx_manager.transact(tx_function)
 
 
 class SubVaultsRegistryEncoder(BaseEncoder):

--- a/src/meta_vault/tasks.py
+++ b/src/meta_vault/tasks.py
@@ -1,7 +1,6 @@
 import logging
 
 from eth_typing import ChecksumAddress, HexStr
-from hexbytes import HexBytes
 from sw_utils import (
     GNO_NETWORKS,
     InterruptHandler,
@@ -11,7 +10,6 @@ from sw_utils import (
 from sw_utils.networks import ContractReleaseVersion
 from web3 import Web3
 
-from src.common.clients import execution_client
 from src.common.contracts import VaultContract, VaultEncoder, multicall_contract
 from src.common.execution import check_gas_price
 from src.common.graph import wait_for_graph_node_sync
@@ -205,16 +203,11 @@ async def meta_vault_update_state(
     )
     logger.info('Transaction steps: \n%s', '\n'.join(tx_steps))
 
-    tx_hash = await multicall_contract.tx_aggregate(calls)
+    tx_receipt = await multicall_contract.tx_aggregate(calls)
+    if tx_receipt is None:
+        raise RuntimeError('Failed to confirm meta vault state update tx')
 
-    logger.info('Waiting for transaction %s confirmation', tx_hash)
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        HexBytes(Web3.to_bytes(hexstr=tx_hash)), timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
-        raise RuntimeError(
-            f'Failed to confirm tx: {tx_hash}',
-        )
+    tx_hash = Web3.to_hex(tx_receipt['transactionHash'])
     logger.info('Transaction %s confirmed', tx_hash)
     await wait_for_graph_node_sync(tx_receipt['blockNumber'])
 
@@ -398,15 +391,10 @@ async def process_deposit_to_sub_vaults(meta_vault_address: ChecksumAddress) -> 
     logger.info('Depositing to sub vaults for meta vault %s', meta_vault_address)
     sub_vaults_registry_address = await meta_vault_contract.sub_vaults_registry()
     sub_vaults_registry_contract = SubVaultsRegistryContract(sub_vaults_registry_address)
-    tx_hash = await sub_vaults_registry_contract.deposit_to_sub_vaults()
+    tx_receipt = await sub_vaults_registry_contract.deposit_to_sub_vaults()
+    if tx_receipt is None:
+        raise RuntimeError('Failed to confirm deposit to sub vaults tx')
 
-    logger.info('Waiting for transaction %s confirmation', tx_hash)
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        HexBytes(Web3.to_bytes(hexstr=tx_hash)), timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
-        raise RuntimeError(
-            f'Failed to confirm tx: {tx_hash}',
-        )
+    tx_hash = Web3.to_hex(tx_receipt['transactionHash'])
     logger.info('Transaction %s confirmed', tx_hash)
     await wait_for_graph_node_sync(tx_receipt['blockNumber'])

--- a/src/meta_vault/tests/test_tasks.py
+++ b/src/meta_vault/tests/test_tasks.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
 from sw_utils.tests import faker
 
 from src.config.settings import settings
@@ -109,14 +110,14 @@ class TestMetaVaultTreeUpdateStateCalls:
         ), mock.patch(
             'src.meta_vault.tasks.get_claimable_sub_vault_exit_requests', return_value=[]
         ), mock.patch.object(
-            multicall_contract, 'tx_aggregate', return_value='0x123'
-        ) as tx_aggregate_mock, mock.patch(
-            'src.meta_vault.tasks.execution_client', new=mock.AsyncMock()
-        ) as execution_client_mock:
-            execution_client_mock.eth.wait_for_transaction_receipt.return_value = {
+            multicall_contract,
+            'tx_aggregate',
+            return_value={
                 'status': 1,
+                'transactionHash': HexBytes(b'\x12' * 32),
                 'blockNumber': 123,
-            }
+            },
+        ) as tx_aggregate_mock:
             yield tx_aggregate_mock
 
 

--- a/src/reward_splitter/tasks.py
+++ b/src/reward_splitter/tasks.py
@@ -7,9 +7,10 @@ from web3.types import BlockNumber, ChecksumAddress, HexStr, Wei
 from src.common.app_state import AppState
 from src.common.clients import execution_client
 from src.common.contracts import RewardSplitterContract, RewardSplitterEncoder
-from src.common.execution import check_gas_price, transaction_gas_wrapper
+from src.common.execution import check_gas_price
 from src.common.harvest import get_harvest_params
 from src.common.tasks import BaseTask
+from src.common.transaction import tx_manager
 from src.common.typings import ExitRequest, HarvestParams
 from src.common.wallet import wallet
 from src.config.settings import FEE_SPLITTER_INTERVAL, FEE_SPLITTER_MIN_ASSETS, settings
@@ -139,18 +140,11 @@ async def claim_reward_splitters_for_vault(
             execution_client=execution_client,
         )
         tx_function = contract.functions.multicall(address_calls)
-        tx = await transaction_gas_wrapper(tx_function)
-        tx_hash = Web3.to_hex(tx)
-        logger.info('Waiting for transaction %s confirmation', tx_hash)
+        tx_receipt = await tx_manager.transact(tx_function)
+        if tx_receipt is None:
+            raise RuntimeError('Failed to confirm fee splitter tx')
 
-        tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-            tx, timeout=settings.execution_transaction_timeout
-        )
-        if not tx_receipt['status']:
-            raise RuntimeError(
-                f'Failed to confirm fee splitter tx: {tx_hash}',
-            )
-        logger.info('Transaction %s confirmed', tx_hash)
+        logger.info('Transaction %s confirmed', Web3.to_hex(tx_receipt['transactionHash']))
 
     logger.info('All fee splitter calls processed')
 

--- a/src/reward_splitter/tests/test_tasks.py
+++ b/src/reward_splitter/tests/test_tasks.py
@@ -84,8 +84,8 @@ class TestClaimRewardSplittersForVault:
         ), mock.patch(
             'src.reward_splitter.tasks.graph_get_claimable_exit_requests'
         ) as exit_requests_mock, mock.patch(
-            'src.reward_splitter.tasks.transaction_gas_wrapper'
-        ) as gas_wrapper_mock, mock.patch(
+            'src.reward_splitter.tasks.tx_manager'
+        ) as tx_manager_mock, mock.patch(
             'src.reward_splitter.tasks.wallet', new=mock.MagicMock()
         ):
             await claim_reward_splitters_for_vault(
@@ -95,7 +95,7 @@ class TestClaimRewardSplittersForVault:
             )
 
         exit_requests_mock.assert_not_called()
-        gas_wrapper_mock.assert_not_called()
+        tx_manager_mock.transact.assert_not_called()
 
     async def test_submits_claim_transaction(self):
         # After building the calls the claim tx must be submitted and its receipt awaited.
@@ -110,17 +110,18 @@ class TestClaimRewardSplittersForVault:
             'src.reward_splitter.tasks.graph_get_claimable_exit_requests',
             return_value={},
         ), mock.patch(
-            'src.reward_splitter.tasks.transaction_gas_wrapper',
-            return_value=HexBytes(b'\x12' * 32),
-        ) as gas_wrapper_mock, mock.patch(
+            'src.reward_splitter.tasks.tx_manager'
+        ) as tx_manager_mock, mock.patch(
             'src.reward_splitter.tasks.RewardSplitterContract', new=mock.MagicMock()
         ), mock.patch(
-            'src.reward_splitter.tasks.execution_client'
-        ) as execution_client_mock, mock.patch(
             'src.reward_splitter.tasks.wallet', new=mock.MagicMock()
         ):
-            execution_client_mock.eth.wait_for_transaction_receipt = mock.AsyncMock(
-                return_value={'status': 1, 'blockNumber': Web3.to_int(123)}
+            tx_manager_mock.transact = mock.AsyncMock(
+                return_value={
+                    'status': 1,
+                    'transactionHash': HexBytes(b'\x12' * 32),
+                    'blockNumber': Web3.to_int(123),
+                }
             )
             await claim_reward_splitters_for_vault(
                 vault=ZERO_CHECKSUM_ADDRESS,
@@ -128,8 +129,7 @@ class TestClaimRewardSplittersForVault:
                 harvest_params=None,
             )
 
-        gas_wrapper_mock.assert_called_once()
-        execution_client_mock.eth.wait_for_transaction_receipt.assert_awaited_once()
+        tx_manager_mock.transact.assert_awaited_once()
 
 
 @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')

--- a/src/validators/execution.py
+++ b/src/validators/execution.py
@@ -9,7 +9,8 @@ from web3.types import Wei
 
 from src.common.clients import execution_client
 from src.common.contracts import VaultContract, multicall_contract
-from src.common.execution import build_gas_manager, transaction_gas_wrapper
+from src.common.execution import transaction_gas_wrapper
+from src.common.transaction import tx_manager
 from src.common.typings import HarvestParams, OraclesApproval
 from src.common.utils import format_error
 from src.config.settings import settings
@@ -70,11 +71,11 @@ async def tx_register_validators(
             logger.exception(e)
         return None
 
-    # Send transaction
+    # Send transaction. Re-use the lowest unconfirmed nonce and bump-and-replace any
+    # pending transaction instead of spending a new nonce (which would queue behind a
+    # stuck tx and land later with stale calldata).
     try:
-        gas_manager = build_gas_manager()
-        tx_params = await gas_manager.get_high_priority_tx_params()
-        tx = await vault_contract.functions.multicall(calls).transact(tx_params)
+        tx = await tx_manager.transact(vault_contract.functions.multicall(calls))
     except Exception as e:
         logger.error('Failed to register validator(s): %s', format_error(e))
         if settings.verbose:

--- a/src/validators/execution.py
+++ b/src/validators/execution.py
@@ -55,10 +55,14 @@ async def tx_register_validators(
         )
     )
 
-    # Simulate transaction
+    # Simulate (estimate_gas) and send transaction with high-priority fees.
     logger.info('Submitting registration transaction')
     try:
-        await vault_contract.functions.multicall(calls).estimate_gas()
+        tx_receipt = await tx_manager.transact(
+            vault_contract.functions.multicall(calls),
+            high_priority=True,
+            estimate_gas=True,
+        )
     except (ValueError, ContractLogicError) as e:
         logger.error(
             'Failed to register validator(s): %s. '
@@ -68,12 +72,6 @@ async def tx_register_validators(
         if settings.verbose:
             logger.exception(e)
         return None
-
-    # Send transaction with high-priority fees.
-    try:
-        tx_receipt = await tx_manager.transact(
-            vault_contract.functions.multicall(calls), high_priority=True
-        )
     except Exception as e:
         logger.error('Failed to register validator(s): %s', format_error(e))
         if settings.verbose:

--- a/src/validators/execution.py
+++ b/src/validators/execution.py
@@ -7,9 +7,7 @@ from web3 import Web3
 from web3.exceptions import ContractLogicError
 from web3.types import Wei
 
-from src.common.clients import execution_client
 from src.common.contracts import VaultContract, multicall_contract
-from src.common.execution import transaction_gas_wrapper
 from src.common.transaction import tx_manager
 from src.common.typings import HarvestParams, OraclesApproval
 from src.common.utils import format_error
@@ -71,28 +69,22 @@ async def tx_register_validators(
             logger.exception(e)
         return None
 
-    # Send transaction. Re-use the lowest unconfirmed nonce and bump-and-replace any
-    # pending transaction instead of spending a new nonce (which would queue behind a
-    # stuck tx and land later with stale calldata).
+    # Send transaction with high-priority fees.
     try:
-        tx = await tx_manager.transact(vault_contract.functions.multicall(calls))
+        tx_receipt = await tx_manager.transact(
+            vault_contract.functions.multicall(calls), high_priority=True
+        )
     except Exception as e:
         logger.error('Failed to register validator(s): %s', format_error(e))
         if settings.verbose:
             logger.exception(e)
         return None
 
-    # Wait for transaction confirmation
-    tx_hash = Web3.to_hex(tx)
-    logger.info('Waiting for transaction %s confirmation', tx_hash)
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
+    if tx_receipt is None:
         logger.error('Registration transaction failed')
         return None
 
-    return tx_hash
+    return Web3.to_hex(tx_receipt['transactionHash'])
 
 
 async def tx_fund_validators(
@@ -120,23 +112,18 @@ async def tx_fund_validators(
     logger.info('Submitting fund validators transaction')
     try:
         tx_function = vault_contract.functions.multicall(calls)
-        tx = await transaction_gas_wrapper(tx_function)
+        tx_receipt = await tx_manager.transact(tx_function)
     except Exception as e:
         logger.error('Failed to fund validator(s): %s', format_error(e))
         if settings.verbose:
             logger.exception(e)
         return None
 
-    tx_hash = Web3.to_hex(tx)
-    logger.info('Waiting for transaction %s confirmation', tx_hash)
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
+    if tx_receipt is None:
         logger.error('Funding transaction failed')
         return None
 
-    return tx_hash
+    return Web3.to_hex(tx_receipt['transactionHash'])
 
 
 async def get_withdrawable_assets(harvest_params: HarvestParams | None) -> Wei:
@@ -174,16 +161,12 @@ async def tx_consolidate_validators(
             Web3.to_bytes(hexstr=validators_manager_signature),
             oracle_signatures,
         )
-        tx = await transaction_gas_wrapper(tx_function, tx_params={'value': tx_fee})
+        tx_receipt = await tx_manager.transact(tx_function, tx_params={'value': tx_fee})
     except Exception as e:
         logger.info('Failed to submit consolidate validators transaction: %s', format_error(e))
         return None
 
-    logger.info('Waiting for transaction %s confirmation', Web3.to_hex(tx))
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
+    if tx_receipt is None:
         logger.info('Consolidate validators transaction failed')
         return None
-    return Web3.to_hex(tx)
+    return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/withdrawals/execution.py
+++ b/src/withdrawals/execution.py
@@ -4,9 +4,8 @@ from eth_typing import HexStr
 from web3 import Web3
 from web3.types import Gwei, Wei
 
-from src.common.clients import execution_client
 from src.common.contracts import VaultContract
-from src.common.execution import transaction_gas_wrapper
+from src.common.transaction import tx_manager
 from src.common.utils import format_error
 from src.config.settings import settings
 
@@ -26,19 +25,15 @@ async def submit_withdraw_validators(
             _encode_withdrawals(withdrawals),
             Web3.to_bytes(hexstr=validators_manager_signature),
         )
-        tx = await transaction_gas_wrapper(tx_function, tx_params={'value': tx_fee})
+        tx_receipt = await tx_manager.transact(tx_function, tx_params={'value': tx_fee})
     except Exception as e:
         logger.info('Failed to withdraw from validators: %s', format_error(e))
         return None
 
-    logger.info('Waiting for transaction %s confirmation', Web3.to_hex(tx))
-    tx_receipt = await execution_client.eth.wait_for_transaction_receipt(
-        tx, timeout=settings.execution_transaction_timeout
-    )
-    if not tx_receipt['status']:
+    if tx_receipt is None:
         logger.info('Withdraw validators transaction failed')
         return None
-    return Web3.to_hex(tx)
+    return Web3.to_hex(tx_receipt['transactionHash'])
 
 
 def _encode_withdrawals(withdrawals: dict[HexStr, Gwei]) -> bytes:


### PR DESCRIPTION
## Summary

Routes **all** wallet transactions through a single `TransactionManager.transact(...)` path and removes `transaction_gas_wrapper`. The manager owns submit + receipt-wait under a lock (one in-flight tx at a time), reuses the lowest unconfirmed nonce, and replaces a stuck pending tx with bumped fees instead of an in-call retry loop.

## What changed

- `transact(tx_function, tx_params=None, high_priority=False) -> TxReceipt | None`: serializes submit and the receipt wait so exactly one wallet tx is in flight at a time; returns the receipt (or `None` on revert).
- Two gas strategies:
  - `high_priority=True` (e.g. validator registration) skips the default-gas attempts and submits high-priority fees straight away.
  - `high_priority=False` keeps the existing default-gas attempts loop, escalating to high-priority fees on `FeeTooLow`.
- No in-call fee-bump loop. A run submits once; if it doesn't confirm within `execution_transaction_timeout` the task retries on its next run, where a pending tx is detected and its fees bumped (`max(high_priority, bump(prev))`, capped at `max_fee_per_gas`).
- Deleted `transaction_gas_wrapper`; migrated every caller (validators register/fund/consolidate, withdrawals, exits, harvest, reward splitter, meta vault) plus the `tx_aggregate` / `deposit_to_sub_vaults` wrappers, which now return `TxReceipt | None`.

## Behavior note

- A receipt timeout is caught inside the manager: `transact` returns `None` and leaves the tx pending, so the next run detects and replaces it (previously `TimeExhausted` propagated out of the caller).
- When the pending tx is at or near the `max_fee_per_gas` ceiling, the bump can't clear the node's +10% replacement threshold, so the manager skips the replacement, logs a warning, and returns `None` instead of broadcasting a doomed underpriced tx — it mines once the base fee drops or is retried on a later run.
