### PR TITLE
Add module name to verbose plain logs

### DIFF
--- a/src/common/logging.py
+++ b/src/common/logging.py
@@ -48,7 +48,11 @@ def setup_logging() -> None:
         else:
             logHandler = logging.StreamHandler()
 
-        formatter = TokenPlainFormatter('%(asctime)s %(levelname)-8s %(message)s')
+        if settings.verbose:
+            format_str = '%(asctime)s %(levelname)-8s %(name)-30s %(message)s'
+        else:
+            format_str = '%(asctime)s %(levelname)-8s %(message)s'
+        formatter = TokenPlainFormatter(format_str)
         logHandler.setFormatter(formatter)
         logging.basicConfig(
             datefmt=LOG_DATE_FORMAT,


### PR DESCRIPTION
Include the logger name (`%(name)s`) in plain-text logs when verbose mode is enabled, padded for alignment like the level name. JSON format and non-verbose output are unchanged.