### PR TITLE
Fix missing ABIs in binary build

### DIFF
--- a/operator.spec
+++ b/operator.spec
@@ -1,13 +1,21 @@
 # -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
 from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 from sys import platform
 
 datas = [
-    ('src/common/abi/*', 'src/common/abi/'),
     ('src/common/word_lists/*', 'src/common/word_lists/'),
     ('./pyproject.toml', '.'),
     ('./GIT_SHA', '.'),
 ]
+
+# Contract wrappers load their ABI relative to their own module (see
+# ContractWrapper._load_abi), so every module that ships an `abi/` directory
+# must be bundled. Collect them all automatically to avoid missing new modules.
+for abi_dir in sorted(Path('src').rglob('abi')):
+    if abi_dir.is_dir():
+        datas.append((abi_dir.as_posix(), abi_dir.as_posix()))
 
 datas += collect_data_files('certifi')
 datas += collect_data_files('coincurve')

--- a/src/commands/start/startup_check.py
+++ b/src/commands/start/startup_check.py
@@ -66,7 +66,7 @@ async def startup_checks() -> None:
     await wait_execution_catch_up_consensus(chain_state)
 
     if settings.claim_fee_splitter:
-        logger.info('Checking graph nodes...')
+        logger.info('Checking graph nodes %s...', settings.graph_endpoint)
         await wait_for_graph_node_sync_to_chain_head()
 
     logger.info('Checking oracles config...')

--- a/src/meta_vault/startup_check.py
+++ b/src/meta_vault/startup_check.py
@@ -29,7 +29,7 @@ async def startup_checks(meta_vault_addresses: list[ChecksumAddress]) -> None:
     logger.info('Checking execution nodes network...')
     await check_execution_nodes_network()
 
-    logger.info('Checking graph nodes...')
+    logger.info('Checking graph nodes %s...', settings.graph_endpoint)
     await wait_for_graph_node_sync_to_chain_head()
 
     logger.info('Checking meta vault addresses %s...', ', '.join(meta_vault_addresses))


### PR DESCRIPTION
## Summary

Fixes the binary build so that module-local ABI directories are bundled, and improves startup-check logging.

### Bundle all module `abi/` dirs in binary build

The PyInstaller spec only bundled `src/common/abi/*`, so ABIs living in other modules (e.g. `src/meta_vault/abi/`) were missing from the binary. This surfaced at runtime as:

```
FileNotFoundError: [Errno 2] No such file or directory:
'.../T/_MEIWI177t/src/meta_vault/abi/IEthMetaVault.json'
```

`ContractWrapper._load_abi` loads each ABI relative to its own module, so every module shipping an `abi/` directory must be bundled. The spec now collects all `abi/` directories under `src/` automatically, so new modules are covered without further changes.

### Log graph endpoint in startup checks

`Checking graph nodes...` now prints the configured `settings.graph_endpoint`, in both the main operator startup checks and the meta-vault startup checks, to make endpoint misconfiguration easier to diagnose.
