### PR TITLE
Add Docker smoke test running init command in CI

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,6 +54,23 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           no-cache-filters: production
+      - name: Load image locally for smoke test
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          load: true
+          tags: operator-smoke-test:ci
+          cache-from: type=gha,scope=${{ matrix.platform }}
+      - name: Smoke test Docker image
+        # Run the `init` command inside the container to verify it starts and the
+        # CLI is wired up correctly. `--no-verify` skips interactive mnemonic checks.
+        run: |
+          docker run --rm \
+            -e VAULT=0x0000000000000000000000000000000000000000 \
+            -e NETWORK=mainnet \
+            -e DATA_DIR=/tmp/stakewise \
+            operator-smoke-test:ci \
+            src/main.py init --language english --no-verify
       - name: Export digest
         run: |
           mkdir -p /tmp/digests

--- a/poetry.lock
+++ b/poetry.lock
@@ -923,13 +923,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.3.3"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
-    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
+    {file = "click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"},
+    {file = "click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2"},
 ]
 
 [package.dependencies]
@@ -4304,4 +4304,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<3.13"
-content-hash = "60a02688f89f185809b9c7a18e286bdfcbecae430fa53184cda9c8242dd67207"
+content-hash = "c2ab9c04f2388ed1aaf0d9293ebe17f4eb977e385ebc8cbc26694f2124a3718e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ sentry-sdk = "==1.45.1"
 sw-utils = {git = "https://github.com/stakewise/sw-utils.git", rev = "v0.13.2"}
 staking-deposit = { git = "https://github.com/ethereum/staking-deposit-cli.git", rev = "v2.8.0" }
 pycryptodomex = "3.19.1"
-click = "==8.2.1"
+click = "==8.3.3"
 eciespy = "==0.4.3"
 prometheus-client = "==0.17.1"
 psycopg2 = "==2.9.9"


### PR DESCRIPTION
## Summary

Adds a smoke test to the Docker CI workflow to verify the built container image is functional beyond just building successfully.

## Details

In the per-platform `docker` job, after the push-by-digest build:

- **Load image locally for smoke test** — rebuilds the image with `load: true` (reusing the GHA cache, so effectively free) and tags it `operator-smoke-test:ci` so it can be run locally on the runner.
- **Smoke test Docker image** — runs the `init` command inside the container. `init` exercises the CLI wiring and Python startup without needing execution/consensus RPC endpoints, so it runs offline and exits `0` on success. `--no-verify` skips the interactive mnemonic verification that would otherwise block on stdin.

If the container fails to start or the CLI is broken, `docker run` returns non-zero and the step (and job) fails.
