### PR TITLE
Fix outdated web3 exception handling

### DIFF
--- a/src/harvest/execution.py
+++ b/src/harvest/execution.py
@@ -21,7 +21,7 @@ async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr | 
     try:
         tx_function = multicall_contract.functions.aggregate(calls)
         tx_receipt = await tx_manager.transact(tx_function)
-    except (ValueError, ContractLogicError) as e:
+    except ContractLogicError as e:
         logger.error('Failed to harvest: %s', format_error(e))
         if settings.verbose:
             logger.exception(e)

--- a/src/harvest/execution.py
+++ b/src/harvest/execution.py
@@ -4,7 +4,7 @@ from eth_typing import HexStr
 from web3 import Web3
 from web3.exceptions import ContractLogicError
 
-from src.common.contracts import VaultContract, multicall_contract
+from src.common.contracts import VaultContract
 from src.common.transaction import tx_manager
 from src.common.typings import HarvestParams
 from src.common.utils import format_error
@@ -15,11 +15,15 @@ logger = logging.getLogger(__name__)
 
 async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr | None:
     vault_contract = VaultContract(settings.vault)
-    calls = [
-        (vault_contract.contract_address, vault_contract.get_update_state_call(harvest_params))
-    ]
     try:
-        tx_function = multicall_contract.functions.aggregate(calls)
+        tx_function = vault_contract.functions.updateState(
+            (
+                harvest_params.rewards_root,
+                harvest_params.reward,
+                harvest_params.unlocked_mev_reward,
+                harvest_params.proof,
+            )
+        )
         tx_receipt = await tx_manager.transact(tx_function)
     except ContractLogicError as e:
         logger.error('Failed to harvest: %s', format_error(e))

--- a/src/harvest/execution.py
+++ b/src/harvest/execution.py
@@ -2,7 +2,7 @@ import logging
 
 from eth_typing import HexStr
 from web3 import Web3
-from web3.exceptions import ContractLogicError
+from web3.exceptions import Web3Exception
 
 from src.common.contracts import VaultContract
 from src.common.transaction import tx_manager
@@ -25,7 +25,7 @@ async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr | 
             )
         )
         tx_receipt = await tx_manager.transact(tx_function)
-    except ContractLogicError as e:
+    except Web3Exception as e:
         logger.error('Failed to harvest: %s', format_error(e))
         if settings.verbose:
             logger.exception(e)

--- a/src/validators/execution.py
+++ b/src/validators/execution.py
@@ -63,7 +63,7 @@ async def tx_register_validators(
             high_priority=True,
             estimate_gas=True,
         )
-    except (ValueError, ContractLogicError) as e:
+    except ContractLogicError as e:
         logger.error(
             'Failed to register validator(s): %s. '
             'Most likely registry root has changed during validators registration. Retrying...',


### PR DESCRIPTION
Replaces the legacy `ValueError` catches with the web3 v7 exception types, and drops a
leftover single-call multicall in the harvest path.

### Exception handling

`except (ValueError, ContractLogicError)` dates back to web3 v6, which raised a bare
`ValueError` for JSON-RPC errors. web3 v7 raises typed exceptions instead, so the
`ValueError` arm is dead code.

The right replacement differs per call site, because it depends on whether the
transaction is simulated before submission:

- `validators/execution.py` — `tx_register_validators` passes `estimate_gas=True`, so a
  revert is caught during simulation and surfaces as `ContractLogicError`. Narrowed to
  that, keeping the "registry root has changed" message meaningful. The existing generic
  `except Exception` below still handles everything else.
- `harvest/execution.py` — `submit_harvest_transaction` does not simulate, so a revert
  comes back from the node on send as `Web3RPCError`, which is *not* a
  `ContractLogicError` subclass. Widened to `Web3Exception` (the common base of
  `Web3RPCError`, `ContractLogicError` and `TimeExhausted`), since this handler has no
  revert-reason-specific message to preserve.

### Harvest: drop the multicall wrapper

`submit_harvest_transaction` wrapped a single `updateState` call in `multicall.aggregate`.
That batch became single-element in #574, which removed the xDAI swap. It now calls
`updateState` on the vault directly — one less hop of calldata and a bit less gas.

`VaultState.updateState` is permissionless, and the inner `keeper.harvest()` uses the
vault's own address as `msg.sender`, so moving the caller from Multicall3 to the operator
wallet does not change behaviour.

Verified against a mainnet vault with real harvest params: encodes, `eth_call` succeeds,
`estimate_gas` returns ~139k.
