### PR TITLE
Remove is_alchemy_used check

### DIFF
--- a/src/common/execution.py
+++ b/src/common/execution.py
@@ -1,5 +1,4 @@
 import logging
-from urllib.parse import urlparse
 
 from sw_utils import GasManager, InterruptHandler
 from web3 import Web3
@@ -9,12 +8,9 @@ from src.common.clients import execution_client
 from src.common.metrics import metrics
 from src.common.tasks import BaseTask
 from src.common.wallet import wallet
-from src.config.networks import HOODI
 from src.config.settings import settings
 
 logger = logging.getLogger(__name__)
-
-ALCHEMY_DOMAIN = '.alchemy.com'
 
 
 class WalletTask(BaseTask):
@@ -48,10 +44,6 @@ async def get_wallet_balance() -> Wei:
 
 async def check_gas_price(high_priority: bool = False) -> bool:
     gas_manager = build_gas_manager()
-    # Alchemy does not support eth_maxPriorityFeePerGas for Hoodi, skip
-    if settings.network == HOODI and is_alchemy_used():
-        return True
-
     return await gas_manager.check_gas_price(high_priority)
 
 
@@ -64,14 +56,6 @@ def build_gas_manager() -> GasManager:
         priority_fee_percentile=settings.priority_fee_percentile,
         min_effective_priority_fee_per_gas=min_effective_priority_fee_per_gas,
     )
-
-
-def is_alchemy_used() -> bool:
-    for endpoint in settings.execution_endpoints:
-        domain = urlparse(endpoint).netloc
-        if domain.lower().endswith(ALCHEMY_DOMAIN):
-            return True
-    return False
 
 
 def fake_exponential(factor: int, numerator: int, denominator: int) -> int:

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -376,9 +376,7 @@ def _patch(
     wallet.address = '0x' + '11' * 20
     with mock.patch('src.common.transaction.execution_client', execution_client), mock.patch(
         'src.common.transaction.wallet', wallet
-    ), mock.patch('src.common.transaction.build_gas_manager', return_value=gas_manager), mock.patch(
-        'src.common.transaction.is_alchemy_used', return_value=False
-    ):
+    ), mock.patch('src.common.transaction.build_gas_manager', return_value=gas_manager):
         yield
 
 

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -9,9 +9,8 @@ from web3.exceptions import TimeExhausted, Web3RPCError
 from web3.types import Nonce, TxParams, TxReceipt, Wei
 
 from src.common.clients import execution_client
-from src.common.execution import build_gas_manager, is_alchemy_used
+from src.common.execution import build_gas_manager
 from src.common.wallet import wallet
-from src.config.networks import HOODI
 from src.config.settings import ATTEMPTS_WITH_DEFAULT_GAS, settings
 
 logger = logging.getLogger(__name__)
@@ -158,7 +157,7 @@ class TransactionManager:
             # queuing a new one behind it (skip the default-gas attempts)
             logger.info('Found pending transaction at nonce %d, replacing it', latest_nonce)
             tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
-        elif high_priority or _skip_default_gas():
+        elif high_priority:
             tx_hash = await self._submit_high_priority(tx_function, tx_params, latest_nonce)
         else:
             tx_hash = await self._submit_default_gas(tx_function, tx_params, latest_nonce)
@@ -252,11 +251,6 @@ class TransactionManager:
         if not tx_receipt['status']:
             return None
         return tx_receipt
-
-
-def _skip_default_gas() -> bool:
-    # Alchemy does not support eth_maxPriorityFeePerGas for Hoodi, go straight to high priority
-    return settings.network == HOODI and is_alchemy_used()
 
 
 # Node rejection messages (lowercased substrings) that a fee bump can clear. The


### PR DESCRIPTION
## Summary

Removes the Alchemy special-casing in gas price handling. `eth_maxPriorityFeePerGas` now works on Alchemy and other Hoodi nodes, so the workaround that skipped the gas price check and forced high-priority transactions on Hoodi + Alchemy is no longer needed.

## Changes

- Delete `is_alchemy_used()`, the `ALCHEMY_DOMAIN` constant, and the skip-check in `check_gas_price()`.
- Delete `_skip_default_gas()` and simplify the transaction branch to `elif high_priority:`.
- Drop now-unused `urlparse` and `HOODI` imports.
- Remove the `is_alchemy_used` mock patch from transaction tests.
