### PR TITLE
Add env-vars command listing supported environment variables

### DIFF
--- a/src/commands/env_vars.py
+++ b/src/commands/env_vars.py
@@ -1,0 +1,75 @@
+import itertools
+import tempfile
+from pathlib import Path
+
+import click
+from web3 import Web3
+
+from src.config.env_vars import EnvVar, get_env_vars
+from src.config.networks import MAINNET
+from src.config.settings import settings
+
+# Placeholders used to populate the settings singleton. The command never
+# connects anywhere, it only needs `Settings.set()` to run so that the
+# variables declared inside it register themselves. The variables are network
+# agnostic, so the network is not worth exposing as an option.
+PLACEHOLDER_VAULT = Web3.to_checksum_address('0x' + '00' * 20)
+PLACEHOLDER_NETWORK = MAINNET
+
+
+@click.option(
+    '--format',
+    'output_format',
+    default='text',
+    help='Output format. Use markdown to generate documentation.',
+    type=click.Choice(['text', 'markdown'], case_sensitive=False),
+)
+@click.command(help='Lists the environment variables recognized by the operator.')
+def env_vars(output_format: str) -> None:
+    _load_settings()
+    variables = get_env_vars()
+
+    if output_format == 'markdown':
+        _print_markdown(variables)
+    else:
+        _print_text(variables)
+
+
+def _load_settings() -> None:
+    """
+    Populate the registry with the variables read inside `Settings.set()`.
+
+    A temporary vault directory is used because `Settings.set()` creates it.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        settings.set(
+            vault=PLACEHOLDER_VAULT,
+            vault_dir=Path(tmp_dir),
+            network=PLACEHOLDER_NETWORK,
+        )
+
+
+def _print_text(variables: list[EnvVar]) -> None:
+    for group, group_vars in _grouped(variables):
+        click.secho(f'\n{group}', bold=True)
+        for var in group_vars:
+            click.echo(f'  {click.style(var.name, fg="green")} ({var.type_name})')
+            if var.description:
+                click.echo(f'    {var.description}')
+            click.echo(f'    Default: {var.formatted_default}')
+
+
+def _print_markdown(variables: list[EnvVar]) -> None:
+    for group, group_vars in _grouped(variables):
+        click.echo(f'\n### {group}\n')
+        click.echo('| Variable | Type | Default | Description |')
+        click.echo('| --- | --- | --- | --- |')
+        for var in group_vars:
+            click.echo(
+                f'| `{var.name}` | {var.type_name} '
+                f'| `{var.formatted_default}` | {var.description} |'
+            )
+
+
+def _grouped(variables: list[EnvVar]) -> itertools.groupby:
+    return itertools.groupby(variables, key=lambda var: var.group)

--- a/src/commands/env_vars.py
+++ b/src/commands/env_vars.py
@@ -17,6 +17,18 @@ PLACEHOLDER_VAULT = Web3.to_checksum_address('0x' + '00' * 20)
 PLACEHOLDER_NETWORK = MAINNET
 
 
+HELP_TEXT = (
+    'Lists the advanced environment variables that are not documented elsewhere.\n'
+    '\n'
+    'These variables can only be set via the environment (or the vault .env file) '
+    'and are mostly intended for fine tuning.\n'
+    '\n'
+    'Environment variables that act as fallbacks for command line options are not '
+    'listed here, they are shown in the help of the corresponding command '
+    '(for example "operator start --help").'
+)
+
+
 @click.option(
     '--format',
     'output_format',
@@ -24,7 +36,7 @@ PLACEHOLDER_NETWORK = MAINNET
     help='Output format. Use markdown to generate documentation.',
     type=click.Choice(['text', 'markdown'], case_sensitive=False),
 )
-@click.command(help='Lists the environment variables recognized by the operator.')
+@click.command(help=HELP_TEXT)
 def env_vars(output_format: str) -> None:
     _load_settings()
     variables = get_env_vars()
@@ -50,6 +62,10 @@ def _load_settings() -> None:
 
 
 def _print_text(variables: list[EnvVar]) -> None:
+    for paragraph in HELP_TEXT.split('\n\n'):
+        click.echo(click.wrap_text(paragraph.strip()))
+        click.echo()
+
     for group, group_vars in _grouped(variables):
         click.secho(f'\n{group}', bold=True)
         for var in group_vars:

--- a/src/commands/env_vars.py
+++ b/src/commands/env_vars.py
@@ -53,7 +53,7 @@ def _print_text(variables: list[EnvVar]) -> None:
     for group, group_vars in _grouped(variables):
         click.secho(f'\n{group}', bold=True)
         for var in group_vars:
-            click.echo(f'  {click.style(var.name, fg="green")} ({var.type_name})')
+            click.echo(f'  {click.style(var.name, fg='green')} ({var.type_name})')
             if var.description:
                 click.echo(f'    {var.description}')
             click.echo(f'    Default: {var.formatted_default}')

--- a/src/config/env_vars.py
+++ b/src/config/env_vars.py
@@ -1,0 +1,85 @@
+"""
+Self-documenting wrapper around `decouple.config`.
+
+Every environment variable the operator reads is declared through
+`decouple_config` below, which records its name, default, cast and description
+in `REGISTRY` in addition to resolving the value. The `env-vars` CLI command
+renders the registry, so the documentation cannot drift from the code.
+"""
+
+import typing
+from dataclasses import dataclass
+
+from decouple import Csv
+from decouple import config as _decouple_config
+from decouple import undefined
+
+
+@dataclass(frozen=True)
+class EnvVar:
+    name: str
+    group: str
+    description: str
+    default: typing.Any
+    cast: typing.Any
+    default_repr: str | None = None
+
+    @property
+    def type_name(self) -> str:
+        if isinstance(self.cast, Csv):
+            return 'list'
+        if isinstance(self.cast, type):
+            return self.cast.__name__
+        return 'str'
+
+    @property
+    def formatted_default(self) -> str:
+        if self.default_repr is not None:
+            return self.default_repr
+        if isinstance(self.default, undefined.__class__):
+            return '<required>'
+        if isinstance(self.default, bool):
+            return 'true' if self.default else 'false'
+        if self.default is None:
+            return 'none'
+        if self.default == '':
+            return "'' (empty)"
+        return str(self.default)
+
+
+# Keyed by variable name so that repeated `Settings.set()` calls do not
+# duplicate entries. Insertion order is the declaration order.
+REGISTRY: dict[str, EnvVar] = {}
+
+
+# pylint: disable-next=too-many-arguments
+def decouple_config(
+    option: str,
+    default: typing.Any = undefined,
+    cast: typing.Any = undefined,
+    group: str = 'Other',
+    description: str = '',
+    default_repr: str | None = None,
+) -> typing.Any:
+    """
+    Drop-in replacement for `decouple.config` that also registers the variable.
+
+    `group` and `description` are metadata only — they are used to render the
+    `env-vars` command output and are ignored when resolving the value.
+    `default_repr` overrides how the default is displayed, for defaults that are
+    computed at runtime (e.g. derived from the network or the vault directory).
+    """
+    REGISTRY[option] = EnvVar(
+        name=option,
+        group=group,
+        description=description,
+        default=default,
+        cast=cast,
+        default_repr=default_repr,
+    )
+    return _decouple_config(option, default=default, cast=cast)
+
+
+def get_env_vars() -> list[EnvVar]:
+    """Return all registered variables, sorted by group and then by name."""
+    return sorted(REGISTRY.values(), key=lambda var: (var.group, var.name))

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from decouple import Csv
-from decouple import config as decouple_config
 from eth_typing import BlockNumber
 from web3 import Web3
 from web3.types import ChecksumAddress, Gwei, Wei
 
 from src.common.typings import Singleton, ValidatorType
+from src.config.env_vars import decouple_config
 from src.config.networks import MAINNET, NETWORKS, NetworkConfig
 
 DATA_DIR = Path.home() / '.stakewise'
@@ -103,18 +103,41 @@ class Settings(metaclass=Singleton):
     meta_vault_min_deposit_amount_gwei: Gwei
 
     # high priority fee
-    priority_fee_num_blocks: int = decouple_config('PRIORITY_FEE_NUM_BLOCKS', default=10, cast=int)
+    priority_fee_num_blocks: int = decouple_config(
+        'PRIORITY_FEE_NUM_BLOCKS',
+        default=10,
+        cast=int,
+        group='Gas',
+        description='Number of recent blocks sampled to estimate the priority fee.',
+    )
     priority_fee_percentile: float = decouple_config(
-        'PRIORITY_FEE_PERCENTILE', default=80.0, cast=float
+        'PRIORITY_FEE_PERCENTILE',
+        default=80.0,
+        cast=float,
+        group='Gas',
+        description='Percentile of the sampled priority fees used for transactions.',
     )
 
     disable_available_validators_warnings: bool = decouple_config(
-        'DISABLE_AVAILABLE_VALIDATORS_WARNINGS', default=False, cast=bool
+        'DISABLE_AVAILABLE_VALIDATORS_WARNINGS',
+        default=False,
+        cast=bool,
+        group='Logging',
+        description='Suppress warnings logged when the vault has no validator keys available.',
     )
     disable_full_withdrawals: bool = decouple_config(
-        'DISABLE_FULL_WITHDRAWALS', default=False, cast=bool
+        'DISABLE_FULL_WITHDRAWALS',
+        default=False,
+        cast=bool,
+        group='Withdrawals',
+        description='Never fully exit validators, only process partial withdrawals.',
     )
-    wallet_private_key: str | None = decouple_config('WALLET_PRIVATE_KEY', default=None)
+    wallet_private_key: str | None = decouple_config(
+        'WALLET_PRIVATE_KEY',
+        default=None,
+        group='Wallet',
+        description='Hot wallet private key, as an alternative to the encrypted wallet file.',
+    )
 
     min_deposit_amount_gwei: Gwei
     vault_min_balance_gwei: Gwei
@@ -228,6 +251,9 @@ class Settings(metaclass=Singleton):
             'KEYSTORES_PASSWORD_DIR',
             cast=Path,
             default=vault_dir / 'keystores',
+            group='Keystores',
+            description='Directory holding the per-keystore password files.',
+            default_repr='<vault-dir>/keystores',
         )
         self.keystores_password_file = (
             Path(keystores_password_file)
@@ -238,7 +264,13 @@ class Settings(metaclass=Singleton):
         # remote signer configuration
         self.remote_signer_url = remote_signer_url
         self.remote_signer_public_keys_url: str = decouple_config(
-            'REMOTE_SIGNER_PUBLIC_KEYS_URL', default=None
+            'REMOTE_SIGNER_PUBLIC_KEYS_URL',
+            default=None,
+            group='Remote signer',
+            description=(
+                'URL used to list the public keys held by the remote signer, '
+                'when it differs from the signer URL.'
+            ),
         )
         self.dappnode = dappnode
 
@@ -269,11 +301,31 @@ class Settings(metaclass=Singleton):
 
         self.log_level = log_level or 'INFO'
         self.log_format = log_format or LOG_PLAIN
-        self.web3_log_level = decouple_config('WEB3_LOG_LEVEL', default='INFO')
-        self.gql_log_level = decouple_config('GQL_LOG_LEVEL', default='WARNING')
+        self.web3_log_level = decouple_config(
+            'WEB3_LOG_LEVEL',
+            default='INFO',
+            group='Logging',
+            description='Log level of the web3 library.',
+        )
+        self.gql_log_level = decouple_config(
+            'GQL_LOG_LEVEL',
+            default='WARNING',
+            group='Logging',
+            description='Log level of the gql (subgraph client) library.',
+        )
 
-        self.sentry_dsn = decouple_config('SENTRY_DSN', default='')
-        self.sentry_environment = decouple_config('SENTRY_ENVIRONMENT', default='')
+        self.sentry_dsn = decouple_config(
+            'SENTRY_DSN',
+            default='',
+            group='Monitoring',
+            description='Sentry DSN. Error reporting is disabled when empty.',
+        )
+        self.sentry_environment = decouple_config(
+            'SENTRY_ENVIRONMENT',
+            default='',
+            group='Monitoring',
+            description='Environment name reported to Sentry.',
+        )
 
         self.ipfs_fetch_endpoints = decouple_config(
             'IPFS_FETCH_ENDPOINTS',
@@ -281,45 +333,139 @@ class Settings(metaclass=Singleton):
             default='https://ipfs.io,'
             'https://stakewise.myfilebase.com,'
             'https://stakewise-ipfs.quicknode-ipfs.com',
+            group='IPFS',
+            description='Comma separated IPFS gateways used to fetch oracle data.',
         )
-        self.ipfs_timeout = decouple_config('IPFS_TIMEOUT', default=60, cast=int)
-        self.ipfs_retry_timeout = decouple_config('IPFS_RETRY_TIMEOUT', default=120, cast=int)
+        self.ipfs_timeout = decouple_config(
+            'IPFS_TIMEOUT',
+            default=60,
+            cast=int,
+            group='IPFS',
+            description='Timeout of a single IPFS request, in seconds.',
+        )
+        self.ipfs_retry_timeout = decouple_config(
+            'IPFS_RETRY_TIMEOUT',
+            default=120,
+            cast=int,
+            group='IPFS',
+            description='Total time spent retrying a failed IPFS request, in seconds.',
+        )
 
         # Genesis validators ipfs fetch may have larger timeouts
         self.genesis_validators_ipfs_timeout = decouple_config(
-            'GENESIS_VALIDATORS_IPFS_TIMEOUT', default=300, cast=int
+            'GENESIS_VALIDATORS_IPFS_TIMEOUT',
+            default=300,
+            cast=int,
+            group='IPFS',
+            description=(
+                'Timeout of the genesis validators IPFS request, in seconds. '
+                'Larger than IPFS_TIMEOUT because the file is big.'
+            ),
         )
         self.genesis_validators_ipfs_retry_timeout = decouple_config(
-            'GENESIS_VALIDATORS_IPFS_RETRY_TIMEOUT', default=600, cast=int
+            'GENESIS_VALIDATORS_IPFS_RETRY_TIMEOUT',
+            default=600,
+            cast=int,
+            group='IPFS',
+            description=(
+                'Total time spent retrying the genesis validators IPFS request, in seconds.'
+            ),
         )
 
         self.validators_fetch_chunk_size = decouple_config(
-            'VALIDATORS_FETCH_CHUNK_SIZE', default=50000, cast=int
+            'VALIDATORS_FETCH_CHUNK_SIZE',
+            default=50000,
+            cast=int,
+            group='Consensus node',
+            description='Number of validators requested from the beacon node in a single call.',
         )
         self.concurrency = concurrency
-        self.execution_timeout = decouple_config('EXECUTION_TIMEOUT', default=30, cast=int)
+        self.execution_timeout = decouple_config(
+            'EXECUTION_TIMEOUT',
+            default=30,
+            cast=int,
+            group='Execution node',
+            description='Timeout of a single execution node request, in seconds.',
+        )
         self.execution_transaction_timeout = decouple_config(
-            'EXECUTION_TRANSACTION_TIMEOUT', default=60, cast=int
+            'EXECUTION_TRANSACTION_TIMEOUT',
+            default=60,
+            cast=int,
+            group='Execution node',
+            description='Time to wait for a submitted transaction receipt, in seconds.',
         )
         self.execution_retry_timeout = decouple_config(
-            'EXECUTION_RETRY_TIMEOUT', default=60, cast=int
+            'EXECUTION_RETRY_TIMEOUT',
+            default=60,
+            cast=int,
+            group='Execution node',
+            description='Total time spent retrying a failed execution node request, in seconds.',
         )
         self.events_blocks_range_interval = decouple_config(
             'EVENTS_BLOCKS_RANGE_INTERVAL',
             default=43200 // self.network_config.SECONDS_PER_BLOCK,  # 12 hrs
             cast=int,
+            group='Execution node',
+            description=(
+                'Block range size of a single eth_getLogs query. '
+                'Lower it when the RPC provider rejects the range as too large.'
+            ),
+            default_repr='12 hours of blocks (3600 on mainnet, 8640 on gnosis)',
         )
-        self.consensus_timeout = decouple_config('CONSENSUS_TIMEOUT', default=60, cast=int)
+        self.consensus_timeout = decouple_config(
+            'CONSENSUS_TIMEOUT',
+            default=60,
+            cast=int,
+            group='Consensus node',
+            description='Timeout of a single consensus node request, in seconds.',
+        )
         self.consensus_retry_timeout = decouple_config(
-            'CONSENSUS_RETRY_TIMEOUT', default=120, cast=int
+            'CONSENSUS_RETRY_TIMEOUT',
+            default=120,
+            cast=int,
+            group='Consensus node',
+            description='Total time spent retrying a failed consensus node request, in seconds.',
         )
-        self.graph_request_timeout = decouple_config('GRAPH_REQUEST_TIMEOUT', default=10, cast=int)
-        self.graph_retry_timeout = decouple_config('GRAPH_RETRY_TIMEOUT', default=60, cast=int)
-        self.graph_page_size = decouple_config('GRAPH_PAGE_SIZE', default=100, cast=int)
+        self.graph_request_timeout = decouple_config(
+            'GRAPH_REQUEST_TIMEOUT',
+            default=10,
+            cast=int,
+            group='Subgraph',
+            description='Timeout of a single subgraph request, in seconds.',
+        )
+        self.graph_retry_timeout = decouple_config(
+            'GRAPH_RETRY_TIMEOUT',
+            default=60,
+            cast=int,
+            group='Subgraph',
+            description='Total time spent retrying a failed subgraph request, in seconds.',
+        )
+        self.graph_page_size = decouple_config(
+            'GRAPH_PAGE_SIZE',
+            default=100,
+            cast=int,
+            group='Subgraph',
+            description='Number of records requested from the subgraph per page.',
+        )
         self.relayer_endpoint = relayer_endpoint or ''
-        self.relayer_timeout = decouple_config('RELAYER_TIMEOUT', default=10, cast=int)
+        self.relayer_timeout = decouple_config(
+            'RELAYER_TIMEOUT',
+            default=10,
+            cast=int,
+            group='Relayer',
+            description='Timeout of a single relayer request, in seconds.',
+        )
 
-        self.skip_startup_checks = decouple_config('SKIP_STARTUP_CHECKS', default=False, cast=bool)
+        self.skip_startup_checks = decouple_config(
+            'SKIP_STARTUP_CHECKS',
+            default=False,
+            cast=bool,
+            group='Advanced',
+            description=(
+                'Skip the connectivity and configuration checks performed on startup. '
+                'Intended for debugging.'
+            ),
+        )
         self.vault_first_block = vault_first_block or self.network_config.KEEPER_GENESIS_BLOCK
         self.meta_vault_min_deposit_amount_gwei = meta_vault_min_deposit_amount_gwei
         self.nodes_dir = nodes_dir
@@ -348,15 +494,33 @@ DEFAULT_NETWORK = MAINNET
 UPDATE_SIGNATURES_URL_PATH = '/signatures'
 OUTDATED_SIGNATURES_URL_PATH = '/signatures/{vault}'
 ORACLES_VALIDATORS_TIMEOUT: int = decouple_config(
-    'ORACLES_VALIDATORS_TIMEOUT', default=10, cast=int
+    'ORACLES_VALIDATORS_TIMEOUT',
+    default=10,
+    cast=int,
+    group='Oracles',
+    description='Timeout of a validator registration approval request, in seconds.',
 )
 ORACLES_CONSOLIDATION_TIMEOUT: int = decouple_config(
-    'ORACLES_CONSOLIDATION_TIMEOUT', default=10, cast=int
+    'ORACLES_CONSOLIDATION_TIMEOUT',
+    default=10,
+    cast=int,
+    group='Oracles',
+    description='Timeout of a validator consolidation approval request, in seconds.',
 )
-ORACLES_EXITS_TIMEOUT: int = decouple_config('ORACLES_EXITS_TIMEOUT', default=10, cast=int)
+ORACLES_EXITS_TIMEOUT: int = decouple_config(
+    'ORACLES_EXITS_TIMEOUT',
+    default=10,
+    cast=int,
+    group='Oracles',
+    description='Timeout of an exit signature submission request, in seconds.',
+)
 # withdrawals
 WITHDRAWALS_INTERVAL: int = decouple_config(
-    'WITHDRAWALS_INTERVAL', default=43200, cast=int  # every 12 hr
+    'WITHDRAWALS_INTERVAL',
+    default=43200,  # every 12 hr
+    cast=int,
+    group='Withdrawals',
+    description='Minimum time between withdrawal processing runs, in seconds.',
 )
 MIN_WITHDRAWAL_AMOUNT_GWEI: Gwei = Gwei(1)
 
@@ -371,35 +535,79 @@ MAX_EFFECTIVE_BALANCE: Wei = Web3.to_wei(2048, 'ether')
 MAX_EFFECTIVE_BALANCE_GWEI: Gwei = Gwei(int(Web3.from_wei(MAX_EFFECTIVE_BALANCE, 'gwei')))
 
 EVENTS_CONCURRENCY_CHUNK: int = decouple_config(
-    'EVENTS_CONCURRENCY_CHUNK', default=50_000, cast=int
+    'EVENTS_CONCURRENCY_CHUNK',
+    default=50_000,
+    cast=int,
+    group='Execution node',
+    description='Block range size of a chunk when scanning contract logs concurrently.',
 )
-EVENTS_CONCURRENCY_LIMIT: int = decouple_config('EVENTS_CONCURRENCY_LIMIT', default=10, cast=int)
+EVENTS_CONCURRENCY_LIMIT: int = decouple_config(
+    'EVENTS_CONCURRENCY_LIMIT',
+    default=10,
+    cast=int,
+    group='Execution node',
+    description=(
+        'Number of eth_getLogs queries sent in parallel when scanning contract logs. '
+        'Lower it to reduce the load on rate limited RPC providers.'
+    ),
+)
 
 # Backoff retries
 DEFAULT_RETRY_TIME = 60
 
 # Remote signer
 REMOTE_SIGNER_UPLOAD_CHUNK_SIZE = decouple_config(
-    'REMOTE_SIGNER_UPLOAD_CHUNK_SIZE', cast=int, default=5
+    'REMOTE_SIGNER_UPLOAD_CHUNK_SIZE',
+    cast=int,
+    default=5,
+    group='Remote signer',
+    description='Number of keystores uploaded to the remote signer in a single request.',
 )
-REMOTE_SIGNER_TIMEOUT = decouple_config('REMOTE_SIGNER_TIMEOUT', cast=int, default=30)
+REMOTE_SIGNER_TIMEOUT = decouple_config(
+    'REMOTE_SIGNER_TIMEOUT',
+    cast=int,
+    default=30,
+    group='Remote signer',
+    description='Timeout of a single remote signer request, in seconds.',
+)
 
 # Hashi vault timeout
 HASHI_VAULT_TIMEOUT = 10
 
-ATTEMPTS_WITH_DEFAULT_GAS: int = decouple_config('ATTEMPTS_WITH_DEFAULT_GAS', default=3, cast=int)
+ATTEMPTS_WITH_DEFAULT_GAS: int = decouple_config(
+    'ATTEMPTS_WITH_DEFAULT_GAS',
+    default=3,
+    cast=int,
+    group='Gas',
+    description=(
+        'Number of transaction attempts made with the default gas price '
+        'before the priority fee is raised.'
+    ),
+)
 
 # Validators funding batch size
 VALIDATORS_FUNDING_BATCH_SIZE = decouple_config(
-    'VALIDATORS_FUNDING_BATCH_SIZE', cast=int, default=10
+    'VALIDATORS_FUNDING_BATCH_SIZE',
+    cast=int,
+    default=10,
+    group='Validators',
+    description='Number of validators funded in a single transaction.',
 )
 
 # Minimum amount of rewards to process reward splitter
 FEE_SPLITTER_MIN_ASSETS: int = decouple_config(
-    'FEE_SPLITTER_MIN_ASSETS', default=Web3.to_wei('0.001', 'ether'), cast=int
+    'FEE_SPLITTER_MIN_ASSETS',
+    default=Web3.to_wei('0.001', 'ether'),
+    cast=int,
+    group='Fee splitter',
+    description='Minimum accrued rewards, in wei, before the fee splitter is claimed.',
 )
 FEE_SPLITTER_INTERVAL: int = decouple_config(
-    'FEE_SPLITTER_INTERVAL', default=86400, cast=int  # every 24 hr
+    'FEE_SPLITTER_INTERVAL',
+    default=86400,  # every 24 hr
+    cast=int,
+    group='Fee splitter',
+    description='Minimum time between fee splitter claims, in seconds.',
 )
 
 # logging
@@ -408,5 +616,12 @@ LOG_JSON = 'json'
 LOG_FORMATS = [LOG_PLAIN, LOG_JSON]
 LOG_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 LOG_WHITELISTED_DOMAINS = decouple_config(
-    'LOG_WHITELISTED_DOMAINS', cast=Csv(), default='stakewise.io,localhost'
+    'LOG_WHITELISTED_DOMAINS',
+    cast=Csv(),
+    default='stakewise.io,localhost',
+    group='Logging',
+    description=(
+        'Comma separated domains whose URLs are logged in full. '
+        'URLs of other domains are hidden to avoid leaking API tokens.'
+    ),
 )

--- a/src/config/tests/test_env_vars.py
+++ b/src/config/tests/test_env_vars.py
@@ -1,0 +1,47 @@
+from click.testing import CliRunner
+
+from src.commands.env_vars import env_vars
+from src.config.env_vars import get_env_vars
+
+
+class TestEnvVars:
+    def test_every_variable_is_documented(self, runner: CliRunner) -> None:
+        # populate the registry with the variables declared inside Settings.set()
+        runner.invoke(env_vars, [])
+
+        undocumented = [var.name for var in get_env_vars() if not var.description]
+        assert not undocumented, (
+            f'Environment variables without a description: {", ".join(undocumented)}. '
+            f'Pass group= and description= to decouple_config so that they show up '
+            f'in the env-vars command.'
+        )
+
+    def test_every_variable_is_grouped(self, runner: CliRunner) -> None:
+        runner.invoke(env_vars, [])
+
+        ungrouped = [var.name for var in get_env_vars() if var.group == 'Other']
+        assert not ungrouped, f'Environment variables without a group: {", ".join(ungrouped)}'
+
+    def test_text_output(self, runner: CliRunner) -> None:
+        result = runner.invoke(env_vars, [])
+
+        assert result.exit_code == 0
+        assert 'EVENTS_BLOCKS_RANGE_INTERVAL' in result.output
+        assert 'Block range size of a single eth_getLogs query' in result.output
+
+    def test_network_dependent_default_is_not_reported_as_a_single_number(
+        self, runner: CliRunner
+    ) -> None:
+        # the command runs against a placeholder network, so the one default
+        # derived from the network must describe itself instead of resolving
+        result = runner.invoke(env_vars, [])
+
+        assert result.exit_code == 0
+        assert 'Default: 12 hours of blocks (3600 on mainnet, 8640 on gnosis)' in result.output
+
+    def test_markdown_output(self, runner: CliRunner) -> None:
+        result = runner.invoke(env_vars, ['--format', 'markdown'])
+
+        assert result.exit_code == 0
+        assert '| Variable | Type | Default | Description |' in result.output
+        assert '| `EVENTS_CONCURRENCY_LIMIT` | int | `10` |' in result.output

--- a/src/config/tests/test_env_vars.py
+++ b/src/config/tests/test_env_vars.py
@@ -11,7 +11,7 @@ class TestEnvVars:
 
         undocumented = [var.name for var in get_env_vars() if not var.description]
         assert not undocumented, (
-            f'Environment variables without a description: {", ".join(undocumented)}. '
+            f'Environment variables without a description: {', '.join(undocumented)}. '
             f'Pass group= and description= to decouple_config so that they show up '
             f'in the env-vars command.'
         )
@@ -20,7 +20,7 @@ class TestEnvVars:
         runner.invoke(env_vars, [])
 
         ungrouped = [var.name for var in get_env_vars() if var.group == 'Other']
-        assert not ungrouped, f'Environment variables without a group: {", ".join(ungrouped)}'
+        assert not ungrouped, f'Environment variables without a group: {', '.join(ungrouped)}'
 
     def test_text_output(self, runner: CliRunner) -> None:
         result = runner.invoke(env_vars, [])

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ import click
 import src
 from src.commands.create_keys import create_keys
 from src.commands.create_wallet import create_wallet
+from src.commands.env_vars import env_vars
 from src.commands.init import init
 from src.commands.recover import recover
 from src.commands.start.hashi_vault import start_hashi_vault
@@ -54,6 +55,7 @@ cli.add_command(submit_rated_network)
 cli.add_command(node_install)
 cli.add_command(node_start)
 cli.add_command(node_status)
+cli.add_command(env_vars)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

The operator recognizes two disjoint sets of environment variables. 49 of them back a CLI option via `envvar=` and are already documented in `--help`. The other 41 are read directly through `decouple.config` and are documented nowhere: not in `--help`, not on the docs site. Operators have no way to discover them short of reading `src/config/settings.py`.

This came up in #775, where the reporter proposed adding a new `EVENTS_BLOCKS_RANGE_MAX` variable without knowing that `EVENTS_BLOCKS_RANGE_INTERVAL` already does exactly that.

## Solution

Make that second set self-documenting, and expose it through a new `env-vars` command.

`src/config/env_vars.py` wraps `decouple.config` with a shim that records each variable's name, group, description, default and cast in a registry, then delegates to decouple unchanged. All 41 call sites in `settings.py` now pass `group=` and `description=`; nothing about value resolution changes.

```
$ operator env-vars

Execution node
  EVENTS_BLOCKS_RANGE_INTERVAL (int)
    Block range size of a single eth_getLogs query. Lower it when the RPC
    provider rejects the range as too large.
    Default: 12 hours of blocks (3600 on mainnet, 8640 on gnosis)
  EVENTS_CONCURRENCY_LIMIT (int)
    Number of eth_getLogs queries sent in parallel when scanning contract
    logs. Lower it to reduce the load on rate limited RPC providers.
    Default: 10
```

`--format markdown` emits per-group tables for the docs site, so published documentation is generated from the same source of truth.

Two tests fail CI if a future `decouple_config` call omits a description or a group, naming the offending variable. That is what keeps this from drifting back to undocumented.

## Notes

- `env-vars` deliberately covers only the 41 env-only variables. The CLI-backed ones stay in `--help`, where they already are. Merging both listings into one view is possible later by walking the click command tree, but it would mean two sources of truth for the same output.
- The command populates the registry by calling `Settings.set()` with a placeholder vault and network, because 25 of the 41 variables are read inside that method. The placeholder network is fine since the variables are network agnostic, with one exception: `EVENTS_BLOCKS_RANGE_INTERVAL` derives its default from `SECONDS_PER_BLOCK`, so it declares an explicit `default_repr` naming both values rather than resolving to a mainnet-only number.
- Defaults computed from the vault directory (`KEYSTORES_PASSWORD_DIR`) likewise use `default_repr` so the output does not leak a temp path.
