### PR TITLE
Account for pending deposits in exit validator selection

### DIFF
--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -60,6 +60,27 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     return validators_balances
 
 
+async def fetch_pending_deposits_amounts(public_keys: set[HexStr], slot: str) -> dict[HexStr, Gwei]:
+    """
+    Sums pending-deposit-queue amounts (Gwei) per pubkey, restricted to ``public_keys``.
+    Unlike funding balances, counts every pending deposit regardless of its
+    withdrawal_credentials prefix, since any queued amount tied to the validator
+    is at risk of being lost if the validator exits before it is processed.
+    """
+    if not public_keys:
+        return {}
+
+    pending_amounts: dict[HexStr, Gwei] = defaultdict(lambda: Gwei(0))
+    all_pending_deposits = await consensus_client.get_pending_deposits(slot)
+    for deposit in all_pending_deposits:
+        public_key: HexStr = deposit['pubkey']
+        if public_key not in public_keys:
+            continue
+        pending_amounts[public_key] = Gwei(pending_amounts[public_key] + int(deposit['amount']))
+
+    return dict(pending_amounts)
+
+
 async def fetch_consensus_validators(
     validator_ids: list[HexStr] | list[str], slot: str = 'head'
 ) -> list[ConsensusValidator]:

--- a/src/validators/tests/test_consensus.py
+++ b/src/validators/tests/test_consensus.py
@@ -1,0 +1,97 @@
+from unittest.mock import AsyncMock, patch
+
+from sw_utils.tests import faker
+
+from src.common.tests.utils import ether_to_gwei
+from src.validators.consensus import fetch_pending_deposits_amounts
+
+
+async def test_fetch_pending_deposits_amounts_empty_public_keys():
+    """No pubkeys requested means no beacon call and an empty result."""
+    mock_consensus = AsyncMock()
+
+    with patch('src.validators.consensus.consensus_client', mock_consensus):
+        result = await fetch_pending_deposits_amounts(public_keys=set(), slot='100')
+
+    assert result == {}
+    mock_consensus.get_pending_deposits.assert_not_called()
+
+
+async def test_fetch_pending_deposits_amounts_sums_multiple_deposits():
+    """Multiple pending deposits for the same pubkey are summed."""
+    pub_key = faker.validator_public_key()
+
+    mock_consensus = AsyncMock()
+    mock_consensus.get_pending_deposits.return_value = [
+        {
+            'pubkey': pub_key,
+            'amount': str(ether_to_gwei(1000)),
+            'withdrawal_credentials': '0x02' + '00' * 30,
+            'slot': '90',
+        },
+        {
+            'pubkey': pub_key,
+            'amount': str(ether_to_gwei(800)),
+            'withdrawal_credentials': '0x02' + '00' * 30,
+            'slot': '95',
+        },
+    ]
+
+    with patch('src.validators.consensus.consensus_client', mock_consensus):
+        result = await fetch_pending_deposits_amounts(public_keys={pub_key}, slot='100')
+
+    assert result == {pub_key: ether_to_gwei(1800)}
+    mock_consensus.get_pending_deposits.assert_called_once_with('100')
+
+
+async def test_fetch_pending_deposits_amounts_filters_by_requested_public_keys():
+    """Deposits for pubkeys outside the requested set are ignored."""
+    requested_pub_key = faker.validator_public_key()
+    other_pub_key = faker.validator_public_key()
+
+    mock_consensus = AsyncMock()
+    mock_consensus.get_pending_deposits.return_value = [
+        {
+            'pubkey': requested_pub_key,
+            'amount': str(ether_to_gwei(32)),
+            'withdrawal_credentials': '0x02' + '00' * 30,
+            'slot': '90',
+        },
+        {
+            'pubkey': other_pub_key,
+            'amount': str(ether_to_gwei(9999)),
+            'withdrawal_credentials': '0x02' + '00' * 30,
+            'slot': '91',
+        },
+    ]
+
+    with patch('src.validators.consensus.consensus_client', mock_consensus):
+        result = await fetch_pending_deposits_amounts(public_keys={requested_pub_key}, slot='100')
+
+    assert result == {requested_pub_key: ether_to_gwei(32)}
+
+
+async def test_fetch_pending_deposits_amounts_counts_regardless_of_credentials_prefix():
+    """Unlike funding balances, every pending deposit counts, not only 0x02-prefixed ones."""
+    pub_key = faker.validator_public_key()
+
+    mock_consensus = AsyncMock()
+    mock_consensus.get_pending_deposits.return_value = [
+        {
+            'pubkey': pub_key,
+            'amount': str(ether_to_gwei(10)),
+            'withdrawal_credentials': '0x01' + '00' * 30,
+            'slot': '90',
+        },
+        {
+            'pubkey': pub_key,
+            'amount': str(ether_to_gwei(20)),
+            'withdrawal_credentials': '0x02' + '00' * 30,
+            'slot': '91',
+        },
+    ]
+
+    with patch('src.validators.consensus.consensus_client', mock_consensus):
+        result = await fetch_pending_deposits_amounts(public_keys={pub_key}, slot='100')
+
+    assert result == {pub_key: ether_to_gwei(30)}

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -32,7 +32,10 @@ from src.config.settings import (
     WITHDRAWALS_INTERVAL,
     settings,
 )
-from src.validators.consensus import fetch_consensus_validators
+from src.validators.consensus import (
+    fetch_consensus_validators,
+    fetch_pending_deposits_amounts,
+)
 from src.validators.database import VaultValidatorCrud
 from src.validators.exceptions import EmptyRelayerResponseException
 from src.validators.oracles import poll_active_exits
@@ -131,6 +134,11 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
                 'the pending partial withdrawals queue has exceeded its limit.'
             )
             return
+
+        pending_deposits = await fetch_pending_deposits_amounts(
+            public_keys={val.public_key for val in vault_validators},
+            slot=str(chain_head.slot),
+        )
         withdrawals = await _get_withdrawals(
             chain_head=chain_head,
             queued_assets=queued_assets,
@@ -139,6 +147,7 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
             validator_min_active_epochs=protocol_config.validator_min_active_epochs,
             oracle_exit_indexes={val.index for val in oracle_exiting_validators},
             consolidation_target_indexes={c.target_index for c in consolidations},
+            pending_deposits=pending_deposits,
         )
         if not withdrawals:
             logger.info(
@@ -212,6 +221,7 @@ async def _get_withdrawals(
     validator_min_active_epochs: int,
     oracle_exit_indexes: set[int],
     consolidation_target_indexes: set[int],
+    pending_deposits: dict[HexStr, Gwei],
 ) -> dict[HexStr, Gwei]:
     if queued_assets <= 0:
         return {}
@@ -252,6 +262,7 @@ async def _get_withdrawals(
         oracle_exit_indexes=oracle_exit_indexes,
         partial_withdrawal_indexes=set(validator_partial_withdrawals.keys()),
         consolidation_target_indexes=consolidation_target_indexes,
+        pending_deposits=pending_deposits,
     )
 
     withdrawals: dict[HexStr, Gwei] = {}
@@ -308,16 +319,20 @@ def _get_partial_withdrawals(
     return withdrawals
 
 
+# pylint: disable-next=too-many-arguments
 def _filter_exitable_validators(
     consensus_validators: list[ConsensusValidator],
     max_activation_epoch: int,
     oracle_exit_indexes: set[int],
     partial_withdrawal_indexes: set[int],
     consolidation_target_indexes: set[int],
+    pending_deposits: dict[HexStr, Gwei],
 ) -> list[ConsensusValidator]:
     """
-    Return validators eligible for exit,
-    ordered by balance to minimize assets exited.
+    Return validators eligible for exit, ordered by balance to minimize assets exited.
+    Balance is adjusted with any amount queued for the validator in the pending-deposit
+    queue, so validators with large pending top-ups sort last instead of looking "cheap"
+    based on their current, not-yet-updated consensus balance.
     """
     can_be_exited_validators = []
     for validator in consensus_validators:
@@ -332,7 +347,9 @@ def _filter_exitable_validators(
         if validator.index in consolidation_target_indexes:
             continue
         can_be_exited_validators.append(validator)
-    can_be_exited_validators.sort(key=lambda x: (x.balance, x.index))
+    can_be_exited_validators.sort(
+        key=lambda x: (x.balance + pending_deposits.get(x.public_key, 0), x.index)
+    )
 
     return can_be_exited_validators
 

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -713,9 +713,47 @@ async def test_get_withdrawals(data_dir):
         pending_deposits={'0x1': ether_to_gwei(1800)},
     )
     # only the plain validator ('0x2') is exited; '0x1' with the huge pending
-    # deposit is left untouched, and queued_assets accounting only ever
-    # subtracts the validator's current CL balance, not balance + pending deposits
+    # deposit sorts last and is left untouched
     expected = {'0x2': ether_to_gwei(0)}
+    assert result == expected
+
+    # queued_assets accounting subtracts a validator's real CL balance, not
+    # balance + pending deposits: if the pending deposit were wrongly counted
+    # as already-recovered assets, exiting '0x1' would look sufficient and
+    # '0x2' would never be exited
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(12)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            balance=ether_to_gwei(10),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+            index=1,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            balance=ether_to_gwei(50),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=85,
+            index=2,
+            is_compounding=False,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes=set(),
+        consolidation_target_indexes=set(),
+        pending_deposits={'0x1': ether_to_gwei(5)},
+    )
+    # '0x1' sorts first (10 + 5 = 15 ETH effective, versus '0x2' at 50 ETH), but only
+    # its real 10 ETH balance is subtracted from queued_assets, leaving 2 ETH still
+    # needed and forcing '0x2' to be exited too
+    expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
     assert result == expected
 
     # zero queued assets

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -260,6 +260,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(2), '0x2': ether_to_gwei(18)}
     assert result == expected
@@ -289,6 +290,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
 
@@ -321,6 +323,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert result == {'0x1': ether_to_gwei(8), '0x2': ether_to_gwei(18)}
     settings.disable_full_withdrawals = False
@@ -350,6 +353,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0)}
     assert result == expected
@@ -379,6 +383,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(10)}
     assert result == expected
@@ -414,6 +419,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(18), '0x3': ether_to_gwei(28)}
     assert result == expected
@@ -448,6 +454,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -482,6 +489,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(49), '0x2': ether_to_gwei(11)}
     assert result == expected
@@ -511,6 +519,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0)}
     assert result == expected
@@ -540,6 +549,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
     assert result == expected
@@ -570,6 +580,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x1': 0}
     assert result == expected
@@ -601,6 +612,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes={1},
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -632,6 +644,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes={1},
+        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -663,7 +676,45 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
+    expected = {'0x2': ether_to_gwei(0)}
+    assert result == expected
+
+    # skips full withdrawal of a low-balance validator with large pending deposits
+    # in favor of a plain validator (mirrors incident: ~32 ETH CL balance masking
+    # ~1800 ETH of pending top-ups still in the entry queue)
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(20)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            balance=ether_to_gwei(32),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+            index=1,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=85,
+            index=2,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes=set(),
+        consolidation_target_indexes=set(),
+        pending_deposits={'0x1': ether_to_gwei(1800)},
+    )
+    # only the plain validator ('0x2') is exited; '0x1' with the huge pending
+    # deposit is left untouched, and queued_assets accounting only ever
+    # subtracts the validator's current CL balance, not balance + pending deposits
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
 
@@ -687,6 +738,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     expected = {}
     assert result == expected
@@ -703,6 +755,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert result == {}
 
@@ -785,6 +838,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -804,6 +858,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -823,6 +878,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes={2},
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -842,6 +898,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes={2},
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -861,6 +918,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes={2},
+        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -883,11 +941,41 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert len(result) == 3
     assert result[0].index == 2
     assert result[1].index == 3
     assert result[2].index == 1
+
+    # validators_with_pending_deposits_sort_last_but_are_not_excluded
+    validators = [
+        create_consensus_validator(
+            index=1,
+            public_key='0x1',
+            activation_epoch=10,
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            balance=ether_to_gwei(32),
+        ),
+        create_consensus_validator(
+            index=2,
+            public_key='0x2',
+            activation_epoch=10,
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            balance=ether_to_gwei(50),
+        ),
+    ]
+    result = _filter_exitable_validators(
+        validators,
+        max_activation_epoch=12,
+        oracle_exit_indexes=set(),
+        partial_withdrawal_indexes=set(),
+        consolidation_target_indexes=set(),
+        pending_deposits={'0x1': ether_to_gwei(1800)},
+    )
+    assert len(result) == 2
+    assert result[0].index == 2
+    assert result[1].index == 1
 
     # no_validators_returned_when_all_are_excluded
     validators = [
@@ -904,5 +992,6 @@ def test_filter_exitable_validators():
         oracle_exit_indexes={1},
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        pending_deposits={},
     )
     assert len(result) == 0


### PR DESCRIPTION
## Problem

When selecting validators for full exit, `_filter_exitable_validators` sorts candidates by consensus-layer balance ascending to minimize exited assets. Post-Pectra, top-up deposits sit in the beacon chain's pending-deposit queue and are not reflected in that balance. A validator with a large amount of queued top-ups therefore looks like a plain ~32 ETH validator and can be picked for exit first — losing its entry-queue position, and the queued funds are later returned to the vault and must re-enter the deposit queue from scratch.

This happened on mainnet: a vault validator with ~1800 ETH of pending top-ups (CL balance ~32 ETH) was selected for full exit ahead of empty 32 ETH validators.

## Fix

- Add `fetch_pending_deposits_amounts` helper that sums pending-deposit-queue amounts per pubkey for the vault validators (all deposits counted, regardless of withdrawal-credentials prefix — any queued amount tied to the validator is at risk).
- Thread the map into `_filter_exitable_validators` and sort by `(balance + pending_deposits, index)`, so validators with pending top-ups are deprioritized for exit but never excluded (excluding could leave no exitable validators).
- Exit-queue accounting is unchanged: an exit still only counts the current active balance, since pending deposits land much later.