### PR TITLE
Handle contract custom errors in redemptions

### DIFF
--- a/src/common/tests/test_utils.py
+++ b/src/common/tests/test_utils.py
@@ -1,9 +1,30 @@
+import logging
 from decimal import Decimal
+from unittest.mock import patch
 
-from src.common.utils import round_down
+import pytest
+
+from src.common.utils import error_verbose, round_down
 
 
 def test_round_down():
     assert round_down(100, 2) == Decimal('100.00')
     assert round_down(Decimal('100.123'), 2) == Decimal('100.12')
     assert round_down(Decimal('100.999'), 2) == Decimal('100.99')
+
+
+@pytest.mark.parametrize('verbose', [True, False])
+def test_error_verbose_keeps_message(verbose: bool, caplog: pytest.LogCaptureFixture) -> None:
+    """The message and its args survive in both modes; only the traceback differs."""
+    with patch('src.common.utils.settings') as mock_settings:
+        mock_settings.verbose = verbose
+        with caplog.at_level(logging.ERROR, logger='src.common.utils'):
+            try:
+                raise ValueError('boom')
+            except ValueError:
+                error_verbose('Failed to process vault %s', '0xabc')
+
+    record = caplog.records[0]
+    assert record.getMessage() == 'Failed to process vault 0xabc'
+    # Traceback is attached only in verbose mode
+    assert (record.exc_info is not None) is verbose

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -43,6 +43,20 @@ def log_verbose(e: Exception) -> None:
         logger.error(format_error(e))
 
 
+def error_verbose(msg: str, *args) -> None:  # type: ignore
+    """Log an error message, attaching the traceback of the exception currently
+    being handled when verbose mode is on. Mirrors the ``logger.error``
+    signature, so unlike ``log_verbose`` the message is not lost.
+
+    Call from inside an ``except`` block, otherwise there is no traceback for
+    the verbose branch to attach.
+    """
+    if settings.verbose:
+        logger.exception(msg, *args)
+    else:
+        logger.error(msg, *args)
+
+
 def warning_verbose(msg: str, *args) -> None:  # type: ignore
     if settings.verbose:
         logger.warning(msg, *args)

--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -280,7 +280,9 @@ async def _redeem_os_token_positions(
         # Bring vaults up to date on-chain so withdrawable assets and position LTV
         # are computed from fresh state rather than skipping unharvested vaults.
         vaults = list({position.vault for position in os_token_positions})
-        await update_vaults_state(vaults=vaults)
+        if not await update_vaults_state(vaults=vaults):
+            logger.error('Some vaults were left with stale state. Skipping to next interval.')
+            return
 
         # Re-fetch the block number so the freshly-updated state is visible downstream.
         block_number = await execution_client.eth.block_number

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -297,6 +297,21 @@ class TestProcess:
         # The merkle tree is built from the fetched nonce; leaves use nonce - 1 internally
         assert redeem_call.kwargs['tree'].nonce == 5
 
+    async def test_stale_vault_state_skips_redemption(self) -> None:
+        """A failed vault state update leaves stale withdrawable assets and LTVs,
+        so the redemption pass is skipped until the next interval."""
+        positions = [make_position(leaf_shares=1000, processed_shares=500, shares_to_redeem=500)]
+
+        with _mock_process(positions=positions) as mocks:
+            mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(1000))
+            mocks['mock_redeemer'].nonce = AsyncMock(return_value=5)
+            mocks['mock_update_state'].return_value = False
+
+            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+
+        mocks['mock_update_state'].assert_awaited_once()
+        mocks['mock_redeem'].assert_not_awaited()
+
 
 # --- Helpers ---
 
@@ -416,7 +431,7 @@ def _mock_process(
         ) as mock_redeem,
         patch(
             f'{MODULE}.update_vaults_state',
-            new=AsyncMock(),
+            new=AsyncMock(return_value=True),
         ) as mock_update_state,
         patch(f'{MODULE}.execution_client', new=mock_client),
     ):

--- a/src/redemptions/contracts.py
+++ b/src/redemptions/contracts.py
@@ -1,11 +1,11 @@
 from web3 import Web3
 from web3.types import BlockNumber, ChecksumAddress, EventData, Wei
 
-from src.common.contracts import ContractWrapper
+from src.common.contracts import ContractWrapper, ErrorMixin
 from src.redemptions.typings import OsTokenPosition, RedeemablePositions
 
 
-class OsTokenRedeemerContract(ContractWrapper):
+class OsTokenRedeemerContract(ContractWrapper, ErrorMixin):
     abi_path = 'abi/IOsTokenRedeemer.json'
     settings_key = 'OS_TOKEN_REDEEMER_CONTRACT_ADDRESS'
 

--- a/src/redemptions/execution.py
+++ b/src/redemptions/execution.py
@@ -4,12 +4,13 @@ from itertools import batched
 from eth_typing import ChecksumAddress, HexStr
 from web3 import Web3
 from web3.contract.async_contract import AsyncContractFunction
-from web3.exceptions import Web3Exception
+from web3.exceptions import ContractCustomError
 
 from src.common.contracts import VaultContract, multicall_contract
 from src.common.execution import wait_for_execution_endpoints_synced
 from src.common.harvest import get_multiple_harvest_params
 from src.common.transaction import tx_manager
+from src.common.utils import error_verbose
 from src.config.settings import MULTICALL_CHUNK_SIZE
 from src.meta_vault.service import is_meta_vault
 from src.redemptions.contracts import os_token_redeemer_contract
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 async def update_vaults_state(
     vaults: list[ChecksumAddress],
-) -> None:
+) -> bool:
     """Bring every regular vault in ``vaults`` up to date on-chain via batched
     updateState multicalls.
 
@@ -29,6 +30,9 @@ async def update_vaults_state(
     latest state. Fresh on-chain state lets ``get_withdrawable_assets`` (and
     position LTV) read accurate values without threading harvest_params through
     every call.
+
+    Returns ``True`` when every vault is up to date, ``False`` when a multicall
+    was not confirmed and some vaults are left with stale state.
     """
     logger.info('Processing vault state updates')
     regular_vaults: list[ChecksumAddress] = []
@@ -38,7 +42,7 @@ async def update_vaults_state(
         regular_vaults.append(vault)
 
     if not regular_vaults:
-        return
+        return True
 
     vault_to_harvest_params = await get_multiple_harvest_params(regular_vaults)
     calls: list[tuple[ChecksumAddress, HexStr]] = []
@@ -52,7 +56,7 @@ async def update_vaults_state(
         )
 
     if not calls:
-        return
+        return True
 
     update_vaults = [address for address, _ in calls]
     logger.info(
@@ -62,27 +66,47 @@ async def update_vaults_state(
     )
 
     for chunk in batched(calls, MULTICALL_CHUNK_SIZE):
-        await tx_update_vaults_state(list(chunk))
+        if await tx_update_vaults_state(list(chunk)) is None:
+            # Leave the remaining chunks for the next run.
+            return False
+
+    return True
 
 
-async def tx_update_vaults_state(calls: list[tuple[ChecksumAddress, HexStr]]) -> None:
-    """Submit a single updateState multicall and wait for its receipt."""
+async def tx_update_vaults_state(calls: list[tuple[ChecksumAddress, HexStr]]) -> HexStr | None:
+    """Submit a single updateState multicall and wait for its receipt.
 
-    tx_receipt = await multicall_contract.tx_aggregate(calls)
+    Returns the tx hash on success, ``None`` when the tx was not submitted or
+    not confirmed.
+    """
+
+    try:
+        tx_receipt = await multicall_contract.tx_aggregate(calls)
+    except Exception:  # pylint: disable=broad-except
+        error_verbose('Failed to submit updateState multicall tx')
+        return None
+
     if tx_receipt is None:
-        raise RuntimeError('updateState multicall tx failed.')
+        logger.error('Failed to confirm updateState multicall tx')
+        return None
 
     tx_hash = Web3.to_hex(tx_receipt['transactionHash'])
     logger.info('updateState multicall confirmed. Tx Hash: %s', tx_hash)
+    return tx_hash
 
 
 async def tx_process_exit_queue() -> None:
     """Call processExitQueue() on the redeemer contract."""
     tx_function = os_token_redeemer_contract.contract.functions.processExitQueue()
-    tx_receipt = await tx_manager.transact(tx_function)
+    try:
+        tx_receipt = await tx_manager.transact(tx_function)
+    except ContractCustomError as e:
+        reason = os_token_redeemer_contract.decode_custom_error(str(e.data)) or e.data
+        logger.error('Failed to process exit queue: execution reverted with %s', reason)
+        return
 
     if tx_receipt is None:
-        logger.error('processExitQueue transaction failed.')
+        logger.error('Failed to confirm processExitQueue tx')
         return
 
     tx_hash = Web3.to_hex(tx_receipt['transactionHash'])
@@ -101,7 +125,17 @@ async def simulate_redeem_position(
 
     try:
         await tx_function.call()
-    except (Web3Exception, RuntimeError, ValueError) as e:
+    except ContractCustomError as e:
+        reason = os_token_redeemer_contract.decode_custom_error(str(e.data)) or e.data
+        logger.error(
+            'Failed to simulate redeem position (vault %s, owner %s): '
+            'execution reverted with %s',
+            position.vault,
+            position.owner,
+            reason,
+        )
+        return False
+    except Exception as e:  # pylint: disable=broad-except
         logger.error(
             'Failed to simulate redeem position (vault %s, owner %s): %r',
             position.vault,
@@ -130,8 +164,17 @@ async def tx_redeem_position(
 
     try:
         tx_receipt = await tx_manager.transact(tx_function)
-    except (Web3Exception, RuntimeError, ValueError):
-        logger.exception(
+    except ContractCustomError as e:
+        reason = os_token_redeemer_contract.decode_custom_error(str(e.data)) or e.data
+        logger.error(
+            'Failed to redeem position (vault %s, owner %s): execution reverted with %s',
+            position.vault,
+            position.owner,
+            reason,
+        )
+        return False
+    except Exception:  # pylint: disable=broad-except
+        error_verbose(
             'Failed to redeem position (vault %s, owner %s)',
             position.vault,
             position.owner,
@@ -140,7 +183,7 @@ async def tx_redeem_position(
 
     if tx_receipt is None:
         logger.error(
-            'Failed to redeem position (vault %s, owner %s).',
+            'Failed to confirm redeem position tx (vault %s, owner %s)',
             position.vault,
             position.owner,
         )

--- a/src/redemptions/execution.py
+++ b/src/redemptions/execution.py
@@ -104,6 +104,9 @@ async def tx_process_exit_queue() -> None:
         reason = os_token_redeemer_contract.decode_custom_error(str(e.data)) or e.data
         logger.error('Failed to process exit queue: execution reverted with %s', reason)
         return
+    except Exception:  # pylint: disable=broad-except
+        error_verbose('Failed to submit processExitQueue tx')
+        return
 
     if tx_receipt is None:
         logger.error('Failed to confirm processExitQueue tx')
@@ -135,12 +138,11 @@ async def simulate_redeem_position(
             reason,
         )
         return False
-    except Exception as e:  # pylint: disable=broad-except
-        logger.error(
-            'Failed to simulate redeem position (vault %s, owner %s): %r',
+    except Exception:  # pylint: disable=broad-except
+        error_verbose(
+            'Failed to simulate redeem position (vault %s, owner %s)',
             position.vault,
             position.owner,
-            e,
         )
         return False
     logger.debug(

--- a/src/redemptions/execution.py
+++ b/src/redemptions/execution.py
@@ -10,7 +10,7 @@ from src.common.contracts import VaultContract, multicall_contract
 from src.common.execution import wait_for_execution_endpoints_synced
 from src.common.harvest import get_multiple_harvest_params
 from src.common.transaction import tx_manager
-from src.common.utils import error_verbose
+from src.common.utils import error_verbose, format_error
 from src.config.settings import MULTICALL_CHUNK_SIZE
 from src.meta_vault.service import is_meta_vault
 from src.redemptions.contracts import os_token_redeemer_contract
@@ -82,8 +82,8 @@ async def tx_update_vaults_state(calls: list[tuple[ChecksumAddress, HexStr]]) ->
 
     try:
         tx_receipt = await multicall_contract.tx_aggregate(calls)
-    except Exception:  # pylint: disable=broad-except
-        error_verbose('Failed to submit updateState multicall tx')
+    except Exception as e:  # pylint: disable=broad-except
+        error_verbose('Failed to submit updateState multicall tx: %s', format_error(e))
         return None
 
     if tx_receipt is None:
@@ -104,8 +104,8 @@ async def tx_process_exit_queue() -> None:
         reason = os_token_redeemer_contract.decode_custom_error(str(e.data)) or e.data
         logger.error('Failed to process exit queue: execution reverted with %s', reason)
         return
-    except Exception:  # pylint: disable=broad-except
-        error_verbose('Failed to submit processExitQueue tx')
+    except Exception as e:  # pylint: disable=broad-except
+        error_verbose('Failed to submit processExitQueue tx: %s', format_error(e))
         return
 
     if tx_receipt is None:
@@ -138,11 +138,12 @@ async def simulate_redeem_position(
             reason,
         )
         return False
-    except Exception:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         error_verbose(
-            'Failed to simulate redeem position (vault %s, owner %s)',
+            'Failed to simulate redeem position (vault %s, owner %s): %s',
             position.vault,
             position.owner,
+            format_error(e),
         )
         return False
     logger.debug(
@@ -175,11 +176,12 @@ async def tx_redeem_position(
             reason,
         )
         return False
-    except Exception:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         error_verbose(
-            'Failed to redeem position (vault %s, owner %s)',
+            'Failed to redeem position (vault %s, owner %s): %s',
             position.vault,
             position.owner,
+            format_error(e),
         )
         return False
 

--- a/src/redemptions/tests/test_execution.py
+++ b/src/redemptions/tests/test_execution.py
@@ -6,7 +6,7 @@ import pytest
 from eth_typing import BlockNumber, ChecksumAddress
 from hexbytes import HexBytes
 from web3 import Web3
-from web3.exceptions import Web3Exception
+from web3.exceptions import ContractCustomError
 from web3.types import Wei
 
 from src.redemptions.execution import (
@@ -19,6 +19,9 @@ from src.redemptions.merkle_tree import PositionsMerkleTree
 from src.redemptions.typings import OsTokenPosition
 
 MODULE = 'src.redemptions.execution'
+
+# error_verbose reads settings.verbose on the failure paths exercised below.
+pytestmark = pytest.mark.usefixtures('fake_settings')
 
 VAULT_1 = Web3.to_checksum_address('0x' + '11' * 20)
 VAULT_2 = Web3.to_checksum_address('0x' + '22' * 20)
@@ -49,11 +52,11 @@ class TestTxRedeemPosition:
         # No sync barrier when the tx reverted
         mocks['wait_for_execution_endpoints_synced'].assert_not_awaited()
 
-    @pytest.mark.parametrize('exc_class', [Web3Exception, RuntimeError, ValueError])
-    async def test_tx_build_failure_returns_false(self, exc_class: type[Exception]) -> None:
-        """Each caught exception during tx build/send returns False."""
+    async def test_tx_build_failure_returns_false(self) -> None:
+        """An error during tx build/send returns False, so a single bad position
+        cannot abort the whole redemption run."""
         position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_tx_redeem_position(send_exception=exc_class('boom')) as mocks:
+        with _mock_tx_redeem_position(send_exception=Exception('boom')) as mocks:
             result = await tx_redeem_position(
                 position=position,
                 tree=make_tree([position]),
@@ -62,15 +65,18 @@ class TestTxRedeemPosition:
         # No sync barrier when the tx build/send step raised
         mocks['wait_for_execution_endpoints_synced'].assert_not_awaited()
 
-    async def test_unexpected_exception_propagates(self) -> None:
-        """Exceptions outside the (Web3Exception, RuntimeError, ValueError) catch list propagate."""
+    async def test_custom_error_returns_false(self) -> None:
+        """A custom error revert is decoded and returns False without raising."""
         position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_tx_redeem_position(send_exception=KeyError('boom')):
-            with pytest.raises(KeyError):
-                await tx_redeem_position(
-                    position=position,
-                    tree=make_tree([position]),
-                )
+        error = ContractCustomError('reverted', data='0x1234abcd')
+        with _mock_tx_redeem_position(send_exception=error) as mocks:
+            result = await tx_redeem_position(
+                position=position,
+                tree=make_tree([position]),
+            )
+        assert result is False
+        mocks['redeemer'].decode_custom_error.assert_called_once_with('0x1234abcd')
+        mocks['wait_for_execution_endpoints_synced'].assert_not_awaited()
 
 
 class TestSimulateRedeemPosition:
@@ -84,16 +90,27 @@ class TestSimulateRedeemPosition:
         assert result is True
         mocks['call'].assert_awaited_once()
 
-    @pytest.mark.parametrize('exc_class', [Web3Exception, RuntimeError, ValueError])
-    async def test_call_failure_returns_false(self, exc_class: type[Exception]) -> None:
+    async def test_call_failure_returns_false(self) -> None:
         """A failed simulation returns False without raising."""
         position = make_position(leaf_shares=1000, shares_to_redeem=500)
-        with _mock_simulate_redeem_position(call_exception=exc_class('boom')):
+        with _mock_simulate_redeem_position(call_exception=Exception('boom')):
             result = await simulate_redeem_position(
                 position=position,
                 tree=make_tree([position]),
             )
         assert result is False
+
+    async def test_custom_error_returns_false(self) -> None:
+        """A custom error revert during simulation is decoded and returns False."""
+        position = make_position(leaf_shares=1000, shares_to_redeem=500)
+        error = ContractCustomError('reverted', data='0x1234abcd')
+        with _mock_simulate_redeem_position(call_exception=error) as mocks:
+            result = await simulate_redeem_position(
+                position=position,
+                tree=make_tree([position]),
+            )
+        assert result is False
+        mocks['redeemer'].decode_custom_error.assert_called_once_with('0x1234abcd')
 
 
 class TestTxProcessExitQueue:
@@ -113,11 +130,25 @@ class TestTxProcessExitQueue:
             mock_redeemer.contract.functions.processExitQueue.assert_called_once()
             mock_tx_manager.transact.assert_awaited_once()
 
+    async def test_custom_error_is_decoded(self) -> None:
+        """A custom error revert is decoded and swallowed."""
+        mock_tx_manager = MagicMock()
+        mock_tx_manager.transact = AsyncMock(
+            side_effect=ContractCustomError('reverted', data='0x1234abcd')
+        )
+        with (
+            patch(f'{MODULE}.os_token_redeemer_contract') as mock_redeemer,
+            patch(f'{MODULE}.tx_manager', new=mock_tx_manager),
+        ):
+            await tx_process_exit_queue()
+            mock_redeemer.decode_custom_error.assert_called_once_with('0x1234abcd')
+
 
 class TestUpdateVaultsState:
     async def test_submits_multicall_for_harvestable_vaults(self) -> None:
         with _mock_update_vaults_state() as mocks:
-            await update_vaults_state(vaults=[VAULT_1, VAULT_2])
+            result = await update_vaults_state(vaults=[VAULT_1, VAULT_2])
+        assert result is True
         mocks['tx_aggregate'].assert_awaited_once()
         await_args = mocks['tx_aggregate'].await_args
         assert await_args is not None
@@ -125,14 +156,17 @@ class TestUpdateVaultsState:
         assert len(await_args.args[0]) == 2
 
     async def test_skips_meta_vaults(self) -> None:
+        """Nothing to update is still up to date, so the caller may proceed."""
         with _mock_update_vaults_state(is_meta_vault=True) as mocks:
-            await update_vaults_state(vaults=[VAULT_1])
+            result = await update_vaults_state(vaults=[VAULT_1])
+        assert result is True
         mocks['tx_aggregate'].assert_not_awaited()
 
     async def test_skips_when_not_harvestable(self) -> None:
         """can_harvest returns no harvest params, so there is nothing to update."""
         with _mock_update_vaults_state(harvest_params=None) as mocks:
-            await update_vaults_state(vaults=[VAULT_1])
+            result = await update_vaults_state(vaults=[VAULT_1])
+        assert result is True
         mocks['tx_aggregate'].assert_not_awaited()
 
     async def test_batches_calls_into_chunks(self) -> None:
@@ -144,10 +178,21 @@ class TestUpdateVaultsState:
         for call in mocks['tx_aggregate'].await_args_list:
             assert len(call.args[0]) == 1
 
-    async def test_raises_on_failed_receipt(self) -> None:
-        with _mock_update_vaults_state(tx_status=0):
-            with pytest.raises(RuntimeError, match='updateState multicall tx failed'):
-                await update_vaults_state(vaults=[VAULT_1])
+    async def test_stops_on_unconfirmed_receipt(self) -> None:
+        """An unconfirmed multicall stops the loop without raising, leaving the
+        remaining chunks unsubmitted, and reports stale state to the caller."""
+        with _mock_update_vaults_state(tx_status=0, chunk_size=1) as mocks:
+            result = await update_vaults_state(vaults=[VAULT_1, VAULT_2])
+        assert result is False
+        # First chunk was not confirmed, so the second chunk is never submitted.
+        assert mocks['tx_aggregate'].await_count == 1
+
+    async def test_stops_on_send_failure(self) -> None:
+        """An error while submitting stops the loop without raising."""
+        with _mock_update_vaults_state(send_exception=Exception('boom'), chunk_size=1) as mocks:
+            result = await update_vaults_state(vaults=[VAULT_1, VAULT_2])
+        assert result is False
+        assert mocks['tx_aggregate'].await_count == 1
 
 
 # --- Helpers ---
@@ -159,18 +204,23 @@ def _mock_update_vaults_state(
     harvest_params: object = object(),
     tx_status: int = 1,
     chunk_size: int | None = None,
+    send_exception: BaseException | None = None,
 ) -> Iterator[dict[str, AsyncMock]]:
     """Mock setup for update_vaults_state tests. VaultContract, harvest params and
     the multicall contract are all stubbed so only the orchestration logic is
     exercised. ``harvest_params=None`` models a vault that can_harvest filtered
-    out. ``tx_status=0`` models a failed multicall tx, i.e. ``tx_aggregate``
-    returning no receipt. ``chunk_size`` overrides MULTICALL_CHUNK_SIZE."""
+    out. ``tx_status=0`` models an unconfirmed multicall tx, i.e. ``tx_aggregate``
+    returning no receipt, while ``send_exception`` makes ``tx_aggregate`` raise.
+    ``chunk_size`` overrides MULTICALL_CHUNK_SIZE."""
     vault_contract = MagicMock()
     vault_contract.contract_address = VAULT_1
     vault_contract.get_update_state_call = MagicMock(return_value='0xdeadbeef')
 
     tx_receipt = {'status': 1, 'transactionHash': HexBytes(b'\xab' * 32)} if tx_status else None
-    tx_aggregate = AsyncMock(return_value=tx_receipt)
+    if send_exception is not None:
+        tx_aggregate = AsyncMock(side_effect=send_exception)
+    else:
+        tx_aggregate = AsyncMock(return_value=tx_receipt)
     mock_multicall = MagicMock()
     mock_multicall.tx_aggregate = tx_aggregate
 


### PR DESCRIPTION
Adds custom error decoding to the redemption transaction paths, following the pattern already used in the harvest task.

## Custom error handling

`OsTokenRedeemerContract` now mixes in `ErrorMixin`, so reverts can be decoded against its own ABI merged with the shared `Errors.json` library ABI.

Three call sites in `src/redemptions/execution.py` go through `os_token_redeemer_contract` directly rather than the multicall contract, and none of them decoded reverts:

| Call site | Path | Before |
|---|---|---|
| `tx_process_exit_queue` | `tx_manager.transact` | no exception handling at all |
| `tx_redeem_position` | `tx_manager.transact` | broad catch, logged `%r` |
| `simulate_redeem_position` | `.call()` | broad catch, logged `%r` |

Each now catches `ContractCustomError` first and logs `decode_custom_error(str(e.data)) or e.data`. Verified against the real ABI: `0x09bde339` decodes to `InvalidProof()`, `0x4ca88867` to `AccessDenied()`.

`tx_update_vaults_state` is left alone — it submits through the multicall contract.

## Exception handling cleanup

The `except (Web3Exception, RuntimeError, ValueError)` tuples were stale. `RuntimeError` dated back to when these sites wrapped a helper that raised `RuntimeError` on a failed receipt; that helper is long gone and `tx_manager.transact` signals failure by returning `None`. `ValueError` predates web3 v7, where every error subclasses `Web3Exception`. Both catches are now plain `except Exception`, so a single bad position cannot abort a whole redemption run.

## Unconfirmed vs failed transactions

`tx_manager.transact` returns `None` on timeout, on `status == 0`, and on exhausted send retries — so "failed" was misleading. Reworded the three receipt checks in the file to the house pattern (`Failed to confirm <thing> tx`).

`tx_update_vaults_state` no longer raises `RuntimeError`; it returns the tx hash or `None`, and `update_vaults_state` stops the chunk loop and returns a bool. `process_redeemer` now skips the redemption pass when the state update did not fully succeed — previously the `RuntimeError` aborted the run, and simply dropping it would have let redemptions proceed against stale withdrawable assets and LTVs.

## `error_verbose`

`log_verbose` logs only the exception instance, so the message describing what failed is lost. Added `error_verbose(msg, *args)` in `src/common/utils.py`, mirroring the `logger.error` signature and delegating to `logger.exception` when verbose is on. Wired into the two redemption sites that previously logged tracebacks unconditionally.

Note: `error_verbose` makes `settings.verbose` a runtime dependency of any code path that calls it, so unit tests reaching those paths need the `fake_settings` fixture.

## Tests

- custom error decoding on all three redemption paths
- `update_vaults_state` return flag, including the stop-on-failure and stop-on-unconfirmed cases
- `process_redeemer` skipping redemption on a failed state update
- `error_verbose` preserving the message in both modes, with `exc_info` attached only when verbose
