### PR TITLE
Exclude slashed validators from funding and consolidation

### DIFF
--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -15,7 +15,7 @@ from src.validators.typings import ConsensusValidator
 
 EXITING_STATUSES = [
     ValidatorStatus.ACTIVE_EXITING,
-    ValidatorStatus.ACTIVE_SLASHED,  # awaiting forced exit, not eligible for funding/consolidation
+    ValidatorStatus.ACTIVE_SLASHED,
 ] + EXITED_STATUSES
 
 logger = logging.getLogger(__name__)

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -13,7 +13,10 @@ from src.validators.database import VaultValidatorCrud
 from src.validators.event_processors import get_latest_vault_v2_validator_public_keys
 from src.validators.typings import ConsensusValidator
 
-EXITING_STATUSES = [ValidatorStatus.ACTIVE_EXITING] + EXITED_STATUSES
+EXITING_STATUSES = [
+    ValidatorStatus.ACTIVE_EXITING,
+    ValidatorStatus.ACTIVE_SLASHED,  # awaiting forced exit, not eligible for funding/consolidation
+] + EXITED_STATUSES
 
 logger = logging.getLogger(__name__)
 

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -747,7 +747,6 @@ class TestConsolidationChecker:
             target_public_key=target_pk,
         )
 
-        # Test with slashed source validator
         consensus_validators = [
             create_consensus_validator(
                 public_key=source_pk,
@@ -773,7 +772,6 @@ class TestConsolidationChecker:
         ):
             selector.get_target_source()
 
-        # Test with slashed target validator
         consensus_validators = [
             create_consensus_validator(
                 public_key=source_pk,

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from eth_typing import HexStr
-from sw_utils import ChainHead
+from sw_utils import ChainHead, ValidatorStatus
 from sw_utils.tests import faker
 from web3.types import Gwei
 
@@ -734,6 +734,71 @@ class TestConsolidationChecker:
         with pytest.raises(
             ConsolidationError,
             match=f'Target validator {target_pk} is in exiting status {EXITING_STATUSES[0].value}.',
+        ):
+            selector.get_target_source()
+
+    def test_excludes_slashed_validators(self):
+        """ACTIVE_SLASHED validators are awaiting forced exit and must be rejected as
+        both source and target, same as ACTIVE_EXITING validators."""
+        source_pk = faker.validator_public_key()
+        target_pk = faker.validator_public_key()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source_pk],
+            target_public_key=target_pk,
+        )
+
+        # Test with slashed source validator
+        consensus_validators = [
+            create_consensus_validator(
+                public_key=source_pk,
+                activation_epoch=1,
+                is_compounding=False,
+                status=ValidatorStatus.ACTIVE_SLASHED,
+            ),
+            create_consensus_validator(
+                public_key=target_pk,
+                activation_epoch=1,
+                is_compounding=True,
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+
+        with pytest.raises(
+            ConsolidationError,
+            match=f'Validator {source_pk} is in exiting status {ValidatorStatus.ACTIVE_SLASHED.value}.',
+        ):
+            selector.get_target_source()
+
+        # Test with slashed target validator
+        consensus_validators = [
+            create_consensus_validator(
+                public_key=source_pk,
+                activation_epoch=1,
+                is_compounding=False,
+            ),
+            create_consensus_validator(
+                public_key=target_pk,
+                activation_epoch=1,
+                is_compounding=True,
+                status=ValidatorStatus.ACTIVE_SLASHED,
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+
+        with pytest.raises(
+            ConsolidationError,
+            match=(
+                f'Target validator {target_pk} is in exiting status '
+                f'{ValidatorStatus.ACTIVE_SLASHED.value}.'
+            ),
         ):
             selector.get_target_source()
 

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -334,13 +334,19 @@ class TestProcessFunding:
     # to ensure it's excluded regardless of funding order.
     # ACTIVE_SLASHED is covered too, since a slashed validator awaiting forced exit
     # must be excluded from funding just like ACTIVE_EXITING.
+    # max_validator_balance is pinned to 64 ETH and vault_assets to 40 ETH so that the
+    # active validator's capacity never absorbs all vault_assets: in every case a
+    # remainder is left over that would be routed to the exiting/slashed validator if
+    # it were wrongly included, so a regression that stops filtering it is caught.
     @pytest.mark.parametrize(
-        'active_balance, exiting_balance, exiting_status',
+        'active_balance, exiting_balance, exiting_status, active_funded, remainder',
         [
-            (40, 32, ValidatorStatus.ACTIVE_EXITING),
-            (32, 40, ValidatorStatus.ACTIVE_EXITING),
-            (40, 32, ValidatorStatus.ACTIVE_SLASHED),
-            (32, 40, ValidatorStatus.ACTIVE_SLASHED),
+            # capacity=64-40=24, funded=24, remainder=40-24=16
+            (40, 32, ValidatorStatus.ACTIVE_EXITING, 24, 16),
+            # capacity=64-32=32, funded=32, remainder=40-32=8
+            (32, 40, ValidatorStatus.ACTIVE_EXITING, 32, 8),
+            (40, 32, ValidatorStatus.ACTIVE_SLASHED, 24, 16),
+            (32, 40, ValidatorStatus.ACTIVE_SLASHED, 32, 8),
         ],
     )
     async def test_fetch_funding_filters_exiting_validators(
@@ -350,6 +356,8 @@ class TestProcessFunding:
         active_balance,
         exiting_balance,
         exiting_status,
+        active_funded,
+        remainder,
     ):
         """fetch_funding_validators_balances excludes exiting/exited validators."""
         pub_key_active = faker.validator_public_key()
@@ -391,13 +399,14 @@ class TestProcessFunding:
         mock_consensus.get_pending_deposits.return_value = []
 
         with (
+            patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
 
-            vault_assets = ether_to_gwei(100)
+            vault_assets = ether_to_gwei(40)
             result = await self.subtask.process_funding(
                 vault_assets=vault_assets, harvest_params=None
             )
@@ -405,9 +414,9 @@ class TestProcessFunding:
         # Only active compounding validator should be funded, not the exiting one
         mock_fund.assert_called_once()
         assert dict(mock_fund.call_args[1]['validator_fundings']) == {
-            pub_key_active: ether_to_gwei(100),
+            pub_key_active: ether_to_gwei(active_funded),
         }
-        assert result == Gwei(0)
+        assert result == ether_to_gwei(remainder)
 
     async def test_fetch_funding_includes_pending_deposits(
         self, vault_validator_crud, compounding_creds

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -332,12 +332,6 @@ class TestProcessFunding:
     # Funding prioritizes highest balances first, so we test both cases:
     # exiting validator has lower balance (32) and higher balance (40)
     # to ensure it's excluded regardless of funding order.
-    # ACTIVE_SLASHED is covered too, since a slashed validator awaiting forced exit
-    # must be excluded from funding just like ACTIVE_EXITING.
-    # max_validator_balance is pinned to 64 ETH and vault_assets to 40 ETH so that the
-    # active validator's capacity never absorbs all vault_assets: in every case a
-    # remainder is left over that would be routed to the exiting/slashed validator if
-    # it were wrongly included, so a regression that stops filtering it is caught.
     @pytest.mark.parametrize(
         'active_balance, exiting_balance, exiting_status, active_funded, remainder',
         [

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -332,12 +332,24 @@ class TestProcessFunding:
     # Funding prioritizes highest balances first, so we test both cases:
     # exiting validator has lower balance (32) and higher balance (40)
     # to ensure it's excluded regardless of funding order.
+    # ACTIVE_SLASHED is covered too, since a slashed validator awaiting forced exit
+    # must be excluded from funding just like ACTIVE_EXITING.
     @pytest.mark.parametrize(
-        'active_balance, exiting_balance',
-        [(40, 32), (32, 40)],
+        'active_balance, exiting_balance, exiting_status',
+        [
+            (40, 32, ValidatorStatus.ACTIVE_EXITING),
+            (32, 40, ValidatorStatus.ACTIVE_EXITING),
+            (40, 32, ValidatorStatus.ACTIVE_SLASHED),
+            (32, 40, ValidatorStatus.ACTIVE_SLASHED),
+        ],
     )
     async def test_fetch_funding_filters_exiting_validators(
-        self, vault_validator_crud, compounding_creds, active_balance, exiting_balance
+        self,
+        vault_validator_crud,
+        compounding_creds,
+        active_balance,
+        exiting_balance,
+        exiting_status,
     ):
         """fetch_funding_validators_balances excludes exiting/exited validators."""
         pub_key_active = faker.validator_public_key()
@@ -369,7 +381,7 @@ class TestProcessFunding:
                     'withdrawal_credentials': compounding_creds,
                     'activation_epoch': '0',
                 },
-                'status': ValidatorStatus.ACTIVE_EXITING.value,
+                'status': exiting_status.value,
             },
         ]
 
@@ -527,10 +539,14 @@ class TestProcessFunding:
         }
         assert result == Gwei(0)
 
+    @pytest.mark.parametrize(
+        'exiting_status',
+        [ValidatorStatus.ACTIVE_EXITING, ValidatorStatus.ACTIVE_SLASHED],
+    )
     async def test_fetch_funding_skips_pending_deposit_for_exiting_validator(
-        self, vault_validator_crud, compounding_creds
+        self, vault_validator_crud, compounding_creds, exiting_status
     ):
-        """Pending deposit for an exiting validator is not added back into the balances."""
+        """Pending deposit for an exiting/slashed validator is not added back into the balances."""
         pub_key_active = faker.validator_public_key()
         pub_key_exiting = faker.validator_public_key()
 
@@ -560,7 +576,7 @@ class TestProcessFunding:
                     'withdrawal_credentials': compounding_creds,
                     'activation_epoch': '0',
                 },
-                'status': ValidatorStatus.ACTIVE_EXITING.value,
+                'status': exiting_status.value,
             },
         ]
 


### PR DESCRIPTION
## Description

`EXITING_STATUSES` in `src/validators/consensus.py` was missing `ACTIVE_SLASHED`. A slashed compounding validator spends the forced-exit period (~36 days) in this status while leaking balance, yet it passed the funding filter and could receive top-ups — part of the deposit is destroyed by the correlation penalty and the rest is locked until withdrawal. `src/withdrawals/assets.py` already treats `ACTIVE_SLASHED` as exiting, so this aligns the shared constant.

Since the constant is reused by the consolidation manager and the exit command, slashed validators are now also excluded from consolidation source/target selection and exit requests (the CL silently drops such requests, wasting the request fee).
