### PR TITLE
Exclude CL-invisible validators without 0x02 pending deposits from funding

### DIFF
--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -35,9 +35,8 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     slot = consensus_block['data']['message']['slot']
     consensus_validators = await fetch_consensus_validators(list(vault_public_keys), slot=slot)
 
-    # A validator seen by the CL is fundable only if it is compounding and not exiting.
-    # Others (non-compounding, exiting/exited) are tracked as ineligible so a later
-    # 0x02 pending deposit for them cannot resurrect their funding eligibility (#621).
+    # Filter compounding and remove exiting/withdrawn validators,
+    # as they are not eligible for funding
     validators_balances: dict[HexStr, Gwei] = {}
     ineligible_public_keys: set[HexStr] = set()
     for validator in consensus_validators:
@@ -47,10 +46,6 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
             ineligible_public_keys.add(validator.public_key)
 
     # Add balances from pending deposits that are not yet reflected in the consensus node.
-    # A vault key absent from the CL set (e.g. a 0x01 V1 deposit still queued, or a key
-    # the CL hasn't caught up with yet) is only made fundable here if it has a queued
-    # 0x02 deposit: a V1 deposit would revert funding (CannotTopUpV1Validators), and
-    # otherwise treating a CL-lagged key as having full capacity would double-fund it.
     all_pending_deposits = await consensus_client.get_pending_deposits(slot)
     for deposit in all_pending_deposits:
         public_key, amount = deposit['pubkey'], int(deposit['amount'])

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -30,32 +30,37 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     if not vault_public_keys:
         return {}
 
-    # Initialize balances for every validator
-    # including those that are not present in CL yet, but have pending deposits.
-    validators_balances = defaultdict(lambda: Gwei(0), {key: Gwei(0) for key in vault_public_keys})
-
     # Fetch consensus validators
     consensus_block = await consensus_client.get_block('head')
     slot = consensus_block['data']['message']['slot']
     consensus_validators = await fetch_consensus_validators(list(vault_public_keys), slot=slot)
 
-    # Filter compounding and remove exiting/withdrawn validators,
-    # as they are not eligible for funding
+    # A validator seen by the CL is fundable only if it is compounding and not exiting.
+    # Others (non-compounding, exiting/exited) are tracked as ineligible so a later
+    # 0x02 pending deposit for them cannot resurrect their funding eligibility (#621).
+    validators_balances: dict[HexStr, Gwei] = {}
+    ineligible_public_keys: set[HexStr] = set()
     for validator in consensus_validators:
         if validator.is_compounding and validator.status not in EXITING_STATUSES:
             validators_balances[validator.public_key] = validator.balance
         else:
-            validators_balances.pop(validator.public_key, None)
+            ineligible_public_keys.add(validator.public_key)
 
-    # Add balances from pending deposits that are not yet reflected in the consensus node
+    # Add balances from pending deposits that are not yet reflected in the consensus node.
+    # A vault key absent from the CL set (e.g. a 0x01 V1 deposit still queued, or a key
+    # the CL hasn't caught up with yet) is only made fundable here if it has a queued
+    # 0x02 deposit: a V1 deposit would revert funding (CannotTopUpV1Validators), and
+    # otherwise treating a CL-lagged key as having full capacity would double-fund it.
     all_pending_deposits = await consensus_client.get_pending_deposits(slot)
     for deposit in all_pending_deposits:
         public_key, amount = deposit['pubkey'], int(deposit['amount'])
-        if public_key not in validators_balances:
+        if public_key not in vault_public_keys or public_key in ineligible_public_keys:
             continue
         if not deposit['withdrawal_credentials'].startswith('0x02'):
             continue
-        validators_balances[public_key] = Gwei(validators_balances[public_key] + amount)
+        validators_balances[public_key] = Gwei(
+            validators_balances.get(public_key, Gwei(0)) + amount
+        )
 
     return validators_balances
 

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -45,19 +45,45 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
         else:
             ineligible_public_keys.add(validator.public_key)
 
+    # Keys not yet known to the consensus node are eligible too,
+    # their balances come solely from pending deposits.
+    eligible_public_keys = vault_public_keys - ineligible_public_keys
+
     # Add balances from pending deposits that are not yet reflected in the consensus node.
-    all_pending_deposits = await consensus_client.get_pending_deposits(slot)
-    for deposit in all_pending_deposits:
-        public_key, amount = deposit['pubkey'], int(deposit['amount'])
-        if public_key not in vault_public_keys or public_key in ineligible_public_keys:
-            continue
-        if not deposit['withdrawal_credentials'].startswith('0x02'):
-            continue
+    pending_deposits_amounts = await fetch_compounding_pending_deposits_amounts(
+        public_keys=eligible_public_keys, slot=slot
+    )
+    for public_key, amount in pending_deposits_amounts.items():
         validators_balances[public_key] = Gwei(
             validators_balances.get(public_key, Gwei(0)) + amount
         )
 
     return validators_balances
+
+
+async def fetch_compounding_pending_deposits_amounts(
+    public_keys: set[HexStr], slot: str
+) -> dict[HexStr, Gwei]:
+    """
+    Sums pending-deposit-queue amounts (Gwei) per pubkey, restricted to ``public_keys``.
+    Only deposits with compounding (0x02) withdrawal credentials are counted:
+    non-0x02 deposits are still processed by the CL, but they never contribute
+    fundable compounding balance, so counting them would overstate top-up capacity.
+    """
+    if not public_keys:
+        return {}
+
+    pending_amounts: dict[HexStr, Gwei] = defaultdict(lambda: Gwei(0))
+    all_pending_deposits = await consensus_client.get_pending_deposits(slot)
+    for deposit in all_pending_deposits:
+        public_key: HexStr = deposit['pubkey']
+        if public_key not in public_keys:
+            continue
+        if not deposit['withdrawal_credentials'].startswith('0x02'):
+            continue
+        pending_amounts[public_key] = Gwei(pending_amounts[public_key] + int(deposit['amount']))
+
+    return dict(pending_amounts)
 
 
 async def fetch_pending_deposits_amounts(public_keys: set[HexStr], slot: str) -> dict[HexStr, Gwei]:

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -720,6 +720,7 @@ class TestProcessFunding:
         with (
             self.patch_get_latest_vault_v2_validator_public_keys(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
+            self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(None) as mock_fund,
         ):
             vault_assets = ether_to_gwei(100)

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -636,6 +636,100 @@ class TestProcessFunding:
         }
         assert result == Gwei(0)
 
+    async def test_fetch_funding_skips_v1_pending_deposit_for_cl_absent_key(
+        self, vault_validator_crud, compounding_creds
+    ):
+        """A CL-absent key whose only pending deposit is 0x01 (V1) is not funded, even
+        though a sibling compounding CL validator in the same vault is fundable normally.
+        Regression test: previously such a key was seeded at balance 0 and treated as
+        having full compounding capacity, causing fundValidators to revert with
+        CannotTopUpV1Validators."""
+        pub_key_active = faker.validator_public_key()
+        pub_key_v1_pending = faker.validator_public_key()
+        v1_creds = '0x01' + compounding_creds[4:]
+
+        vault_validator_crud.save_vault_validators(
+            [
+                VaultValidator(public_key=pub_key_active, block_number=1),
+                VaultValidator(public_key=pub_key_v1_pending, block_number=2),
+            ]
+        )
+
+        consensus_validators_data = [
+            {
+                'index': '1',
+                'balance': str(ether_to_gwei(40)),
+                'validator': {
+                    'pubkey': pub_key_active[2:],
+                    'withdrawal_credentials': compounding_creds,
+                    'activation_epoch': '0',
+                },
+                'status': ValidatorStatus.ACTIVE_ONGOING.value,
+            },
+        ]
+
+        mock_consensus = AsyncMock()
+        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
+        # pub_key_v1_pending is not present in the consensus state yet
+        mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
+        mock_consensus.get_pending_deposits.return_value = [
+            {
+                'pubkey': pub_key_v1_pending,
+                'amount': str(ether_to_gwei(32)),
+                'withdrawal_credentials': v1_creds,
+            },
+        ]
+
+        with (
+            patch_max_validator_balance(ether_to_gwei(64)),
+            self.patch_get_latest_vault_v2_validator_public_keys(),
+            patch('src.validators.consensus.consensus_client', mock_consensus),
+            self.patch_is_funding_interval_passed(True),
+            self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
+        ):
+            vault_assets = ether_to_gwei(100)
+            result = await self.subtask.process_funding(
+                vault_assets=vault_assets, harvest_params=None
+            )
+
+        mock_fund.assert_called_once()
+        # Only the active compounding validator is funded (capacity = 64 - 40 = 24);
+        # the V1-queued key gets nothing.
+        assert dict(mock_fund.call_args[1]['validator_fundings']) == {
+            pub_key_active: ether_to_gwei(24),
+        }
+        assert result == ether_to_gwei(76)
+
+    async def test_fetch_funding_excludes_cl_absent_key_without_pending_deposit(
+        self, vault_validator_crud, compounding_creds
+    ):
+        """A DB key absent from the CL set with no pending deposits at all is excluded
+        from funding this cycle. It becomes fundable again once it either appears on
+        the CL as an active compounding validator, or gets a 0x02 pending deposit."""
+        pub_key = faker.validator_public_key()
+
+        vault_validator_crud.save_vault_validators(
+            [VaultValidator(public_key=pub_key, block_number=1)]
+        )
+
+        mock_consensus = AsyncMock()
+        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
+        mock_consensus.get_validators_by_ids.return_value = {'data': []}
+        mock_consensus.get_pending_deposits.return_value = []
+
+        with (
+            self.patch_get_latest_vault_v2_validator_public_keys(),
+            patch('src.validators.consensus.consensus_client', mock_consensus),
+            self.patch_fund_validators_chunk(None) as mock_fund,
+        ):
+            vault_assets = ether_to_gwei(100)
+            result = await self.subtask.process_funding(
+                vault_assets=vault_assets, harvest_params=None
+            )
+
+        mock_fund.assert_not_called()
+        assert result == vault_assets
+
     async def test_fetch_funding_excludes_non_compounding(
         self, vault_validator_crud, compounding_creds
     ):


### PR DESCRIPTION
## Description

`fetch_funding_validators_balances` seeded every vault public key at balance 0, including keys not present in the CL validator set. Since `ValidatorRegistered` (V1) and `V2ValidatorRegistered` share the vault-validators table, a 0x01 validator whose initial deposit is still in the CL pending-deposit queue was treated as a compounding validator with full capacity: it is absent from the CL set (so never filtered out) and its pending deposit is skipped by the 0x02 credentials filter. Funding it reverts with `CannotTopUpV1Validators`, raising `FundingException` every cycle — which also blocks new validator registration — until the validator appears on the CL.

A vault key absent from the CL set is now fundable only if it has a queued 0x02 deposit (its balance is the sum of those deposits). This also prevents double-funding a freshly registered validator when the consensus node's head lags the execution layer: such a key no longer appears as full free capacity.

Behavior preserved from previous fixes: ineligible validators (non-compounding, exiting/exited) still cannot be resurrected by pending deposits (#621), and validators visible only through the deposit queue remain fundable (#735).
