### PR TITLE
Defer funding instead of blocking registration when interval has not passed

### DIFF
--- a/src/validators/tasks.py
+++ b/src/validators/tasks.py
@@ -101,7 +101,10 @@ class ValidatorRegistrationSubtask:
         """
         Processes funding compounding validators.
         Returns the remaining vault assets if funding is successful.
-        Raises FundingException on failure.
+        If the funding interval has not passed yet, defers funding to the next cycle and
+        returns the assets with the planned funding amounts reserved, so registration still
+        proceeds with the unreserved remainder.
+        Raises FundingException on genuine failures (empty relayer response, failed tx).
         """
         validators_balances = await fetch_funding_validators_balances()
         funding_amounts = _get_funding_amounts(
@@ -113,7 +116,9 @@ class ValidatorRegistrationSubtask:
             return vault_assets
 
         if not await _is_funding_interval_passed():
-            raise FundingException('Funding interval has not passed yet')
+            logger.info('Funding interval has not passed yet, deferring funding to next cycle')
+            # Reserve the planned funding amounts so they are not spent on registration instead
+            return Gwei(vault_assets - sum(funding_amounts.values()))
 
         for validator_fundings_chunk in batched(
             list(funding_amounts.items()), VALIDATORS_FUNDING_BATCH_SIZE

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -248,7 +248,7 @@ class TestProcessFunding:
 
     @pytest.mark.usefixtures('fake_settings')
     async def test_funding_interval_not_passed(self):
-        """Raises FundingException when funding interval hasn't passed."""
+        """Defers funding and reserves the planned amounts, leaving the rest for registration."""
         vault_assets = ether_to_gwei(100)
         pub_key = faker.validator_public_key()
         with (
@@ -256,9 +256,30 @@ class TestProcessFunding:
             self.patch_is_funding_interval_passed(False),
             self.patch_fund_validators_chunk(None) as mock_fund,
         ):
-            with pytest.raises(FundingException, match='Funding interval has not passed yet'):
-                await self.subtask.process_funding(vault_assets=vault_assets, harvest_params=None)
+            result = await self.subtask.process_funding(
+                vault_assets=vault_assets, harvest_params=None
+            )
         mock_fund.assert_not_called()
+        funding_amounts = _get_funding_amounts(
+            validators_balances={pub_key: ether_to_gwei(32)}, vault_assets=vault_assets
+        )
+        assert result == Gwei(vault_assets - sum(funding_amounts.values()))
+
+    @pytest.mark.usefixtures('fake_settings')
+    async def test_funding_interval_not_passed_reserves_all_assets(self):
+        """When planned funding would consume all assets, the deferred return is zero."""
+        vault_assets = ether_to_gwei(100)
+        pub_key = faker.validator_public_key()
+        with (
+            self.patch_funding_validators_balances({pub_key: Gwei(0)}),
+            self.patch_is_funding_interval_passed(False),
+            self.patch_fund_validators_chunk(None) as mock_fund,
+        ):
+            result = await self.subtask.process_funding(
+                vault_assets=vault_assets, harvest_params=None
+            )
+        mock_fund.assert_not_called()
+        assert result == Gwei(0)
 
     @pytest.mark.usefixtures('fake_settings')
     async def test_successful_funding_single_validator(self):

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -248,10 +248,12 @@ class TestProcessFunding:
 
     @pytest.mark.usefixtures('fake_settings')
     async def test_funding_interval_not_passed(self):
-        """Defers funding and reserves the planned amounts, leaving the rest for registration."""
+        """Defers funding and reserves only the planned amount, registration proceeds
+        with the remainder."""
         vault_assets = ether_to_gwei(100)
         pub_key = faker.validator_public_key()
         with (
+            patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_funding_validators_balances({pub_key: ether_to_gwei(32)}),
             self.patch_is_funding_interval_passed(False),
             self.patch_fund_validators_chunk(None) as mock_fund,
@@ -260,10 +262,7 @@ class TestProcessFunding:
                 vault_assets=vault_assets, harvest_params=None
             )
         mock_fund.assert_not_called()
-        funding_amounts = _get_funding_amounts(
-            validators_balances={pub_key: ether_to_gwei(32)}, vault_assets=vault_assets
-        )
-        assert result == Gwei(vault_assets - sum(funding_amounts.values()))
+        assert result == ether_to_gwei(68)
 
     @pytest.mark.usefixtures('fake_settings')
     async def test_funding_interval_not_passed_reserves_all_assets(self):


### PR DESCRIPTION
## Description

`process_funding` raised `FundingException` whenever funding amounts were planned but the `min_deposit_delay` interval had not passed. Since `process` swallows that exception with an early return, new-validator registration was skipped for the whole cycle — a vault receiving a large inflow shortly after a funding round could not register validators for up to an hour, and a partially completed funding batch locked out both the remaining chunks and registration for the same period.

The interval throttle is now a deferral, not a failure: `process_funding` returns the vault assets with the planned funding amounts reserved, so funding keeps its priority for those assets (retried next cycle once the interval passes) while registration proceeds with the unreserved remainder. Genuine failures (empty relayer response, failed funding transaction) still raise `FundingException` and abort the cycle as before.
