### PR TITLE
Add balance symbol to queued assets log

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -234,9 +234,13 @@ async def _redeem_os_token_positions(
     queued_assets = os_token_converter.to_assets(queued_shares)
     if queued_assets < Web3.to_wei(min_queued_assets, 'gwei'):
         logger.info(
-            'Queued assets %s below threshold %s. Skipping to next interval.',
-            Web3.from_wei(queued_assets, 'ether'),
-            Web3.from_wei(Web3.to_wei(min_queued_assets, 'gwei'), 'ether'),
+            'Queued assets %(queued)s %(symbol)s below threshold %(threshold)s %(symbol)s. '
+            'Skipping to next interval.',
+            {
+                'queued': Web3.from_wei(queued_assets, 'ether'),
+                'threshold': Web3.from_wei(Web3.to_wei(min_queued_assets, 'gwei'), 'ether'),
+                'symbol': settings.network_config.VAULT_BALANCE_SYMBOL,
+            },
         )
         return
 


### PR DESCRIPTION
The "queued assets below threshold" log in `process-redeemer` printed both amounts as bare numbers with no unit attached, leaving it ambiguous what denomination they were in.

Both amounts are now labelled with `settings.network_config.VAULT_BALANCE_SYMBOL`, matching the "Process queued shares for redemption" log just below it and making the unit network-correct (ETH / GNO).

Switched the call to named placeholders so the symbol is supplied once instead of being passed twice positionally.
