### PR TITLE
Remove Infura IPFS settings

### DIFF
--- a/src/common/clients.py
+++ b/src/common/clients.py
@@ -139,15 +139,6 @@ def build_ipfs_upload_clients() -> IpfsMultiUploadClient:
             )
         )
 
-    if settings.ipfs_infura_client_username and settings.ipfs_infura_client_password:
-        ipfs_client = IpfsUploadClient(
-            settings.ipfs_infura_client_endpoint,
-            settings.ipfs_infura_client_username,
-            settings.ipfs_infura_client_password,
-            timeout=settings.ipfs_upload_client_timeout,
-        )
-        clients.append(ipfs_client)
-
     if settings.ipfs_pinata_api_key and settings.ipfs_pinata_secret_key:
         pinata_client = PinataUploadClient(
             settings.ipfs_pinata_api_key,

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -93,9 +93,6 @@ class Settings(metaclass=Singleton):
     ipfs_local_client_endpoint: str
     ipfs_local_username: str | None
     ipfs_local_password: str | None
-    ipfs_infura_client_endpoint: str
-    ipfs_infura_client_username: str | None
-    ipfs_infura_client_password: str | None
     ipfs_pinata_api_key: str | None
     ipfs_pinata_secret_key: str | None
 
@@ -306,15 +303,6 @@ class Settings(metaclass=Singleton):
         )
         self.ipfs_local_username: str | None = decouple_config('IPFS_LOCAL_USERNAME', default=None)
         self.ipfs_local_password: str | None = decouple_config('IPFS_LOCAL_PASSWORD', default=None)
-
-        # infura
-        self.ipfs_infura_client_endpoint: str = '/dns/ipfs.infura.io/tcp/5001/https'
-        self.ipfs_infura_client_username: str = decouple_config(
-            'IPFS_INFURA_CLIENT_USERNAME', default=''
-        )
-        self.ipfs_infura_client_password: str = decouple_config(
-            'IPFS_INFURA_CLIENT_PASSWORD', default=''
-        )
 
         # pinata
         self.ipfs_pinata_api_key: str = decouple_config('IPFS_PINATA_API_KEY', default='')


### PR DESCRIPTION
Infura is sunsetting its IPFS service, so the Infura upload client is removed.

- Drop `IPFS_INFURA_CLIENT_USERNAME` / `IPFS_INFURA_CLIENT_PASSWORD` settings and the hardcoded Infura endpoint.
- Drop the Infura branch in `build_ipfs_upload_clients()`; local IPFS node and Pinata remain as upload providers.
