### PR TITLE
Fix partial withdrawal activation epoch boundary

### DIFF
--- a/src/validators/typings.py
+++ b/src/validators/typings.py
@@ -68,7 +68,7 @@ class ConsensusValidator:
         return (
             self.is_compounding
             and self.status == ValidatorStatus.ACTIVE_ONGOING
-            and self.activation_epoch < epoch - settings.network_config.SHARD_COMMITTEE_PERIOD
+            and self.activation_epoch <= epoch - settings.network_config.SHARD_COMMITTEE_PERIOD
         )
 
     @staticmethod

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -798,6 +798,35 @@ async def test_get_withdrawals(data_dir):
     assert result == {}
 
 
+async def test_get_withdrawals_boundary_activation_epoch_prefers_partial_over_full_exit(data_dir):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+
+    # activation epoch exactly at the SHARD_COMMITTEE_PERIOD boundary is CL-eligible for
+    # a partial withdrawal, so it must not be routed into the full-exit branch
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(5)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=chain_head.epoch - settings.network_config.SHARD_COMMITTEE_PERIOD,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes=set(),
+        consolidation_target_indexes=set(),
+        pending_deposits={},
+    )
+    expected = {'0x1': ether_to_gwei(5)}
+    assert result == expected
+
+
 def test_is_partial_withdrawable_validator():
     epoch = 500
 
@@ -826,6 +855,15 @@ def test_is_partial_withdrawable_validator():
 
     validator = create_consensus_validator(
         balance=ether_to_gwei(32), status=ValidatorStatus.ACTIVE_ONGOING, activation_epoch=10
+    )
+    result = validator.is_partially_withdrawable(epoch)
+    assert result is True
+
+    # activation epoch exactly at the SHARD_COMMITTEE_PERIOD boundary is eligible
+    validator = create_consensus_validator(
+        balance=ether_to_gwei(32),
+        status=ValidatorStatus.ACTIVE_ONGOING,
+        activation_epoch=epoch - settings.network_config.SHARD_COMMITTEE_PERIOD,
     )
     result = validator.is_partially_withdrawable(epoch)
     assert result is True


### PR DESCRIPTION
## Description

`ConsensusValidator.is_partially_withdrawable` used a strict `activation_epoch < epoch - SHARD_COMMITTEE_PERIOD` check, one epoch stricter than the consensus-layer rule: Electra's `process_withdrawal_request` gates both full exits and partial withdrawals with the inclusive `current_epoch >= activation_epoch + SHARD_COMMITTEE_PERIOD`. The full-exit path (`max_activation_epoch` in `_get_withdrawals`) already follows the inclusive rule.

As a result, a compounding validator activated exactly `SHARD_COMMITTEE_PERIOD` epochs ago was wrongly excluded from the partial-withdrawable set. With no other partial capacity available, `_get_withdrawals` fell into the full-exit branch and irreversibly exited the validator, even though the consensus layer would have accepted a partial withdrawal request for it at that epoch.

Changed the comparison to `<=`, aligning partial-withdrawal eligibility with the spec and with the exit path.