### PR TITLE
Fix partial capacity accounting for non-compounding validator exits

### DIFF
--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -236,6 +236,7 @@ async def _get_withdrawals(
     partial_validators = [
         v for v in consensus_validators if v.is_partially_withdrawable(chain_head.epoch)
     ]
+    partial_validator_indexes = {v.index for v in partial_validators}
     partial_capacity = 0
     for validator in partial_validators:
         partial_withdrawals = validator_partial_withdrawals.get(validator.index, 0)
@@ -274,7 +275,8 @@ async def _get_withdrawals(
         queued_assets = Gwei(max(0, queued_assets - validator.balance))
 
         # Remove exited validator from partials
-        partial_capacity = Gwei(partial_capacity - validator.withdrawal_capacity)
+        if validator.index in partial_validator_indexes:
+            partial_capacity = Gwei(partial_capacity - validator.withdrawal_capacity)
         if partial_capacity >= queued_assets:
             partials = _get_partial_withdrawals(
                 partial_validators=[

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -798,6 +798,60 @@ async def test_get_withdrawals(data_dir):
     assert result == {}
 
 
+@pytest.mark.asyncio
+async def test_get_withdrawals_non_compounding_exit_does_not_reduce_partial_capacity(data_dir):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+
+    # v1 is 0x01 and never contributes to partial_capacity, so its full exit must not
+    # decrement it either; only v2/v3 (0x02) capacity should be tracked and consumed
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(67)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            index=1,
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+            is_compounding=False,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            index=2,
+            balance=ether_to_gwei(50),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=85,
+        ),
+        create_consensus_validator(
+            public_key='0x3',
+            index=3,
+            balance=ether_to_gwei(45),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=80,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes=set(),
+        consolidation_target_indexes=set(),
+        pending_deposits={},
+    )
+    # v1 (40 ETH) is the cheapest to exit and is fully exited, leaving 27 ETH still
+    # needed. partial_capacity (31 ETH from v2+v3) is untouched by v1's exit, so it
+    # covers the remainder via partials, fattest balance first: v2 gets its full
+    # 18 ETH capacity, v3 covers the rest (9 ETH) — v3 must not be fully exited.
+    expected = {
+        '0x1': ether_to_gwei(0),
+        '0x2': ether_to_gwei(18),
+        '0x3': ether_to_gwei(9),
+    }
+    assert result == expected
+
+
 def test_is_partial_withdrawable_validator():
     epoch = 500
 


### PR DESCRIPTION
## Description

In `_get_withdrawals`, `partial_capacity` is built by summing withdrawal capacity only over partially-withdrawable (compounding 0x02) validators, but the greedy full-exit loop decremented it by `withdrawal_capacity` for **every** exited validator — including non-compounding 0x01 ones whose capacity was never part of the sum.

This understated the remaining partial capacity, so the `partial_capacity >= queued_assets` top-up gate could wrongly stay closed, forcing additional unnecessary full exits instead of covering the remainder with partial withdrawals. Example: a 0x01 validator holding 32.3 ETH (0.3 ETH of unswept rewards) and two compounding validators (50 and 45 ETH) against 63.2 ETH of queued assets. The 0x01 validator is exited first as the cheapest, leaving 30.9 ETH to cover — within the 31 ETH of real partial capacity, so the remainder should be covered by partials. But the buggy decrement of the 0x01 validator's 0.3 ETH "capacity" left only 30.7 ETH on the counter, so the operator needlessly full-exited the 45 ETH compounding validator: a 0.3 ETH accounting error escalated into a 45 ETH over-exit.

The decrement is now applied only when the exited validator actually contributed to `partial_capacity`. (Exitable validators can never have queued pending partials — they are filtered out of exit selection — so a contributing validator's share is always exactly its full `withdrawal_capacity`.)