### PR TITLE
Exclude consolidation source validators from withdrawal selection

### DIFF
--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -147,6 +147,7 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
             validator_min_active_epochs=protocol_config.validator_min_active_epochs,
             oracle_exit_indexes={val.index for val in oracle_exiting_validators},
             consolidation_target_indexes={c.target_index for c in consolidations},
+            consolidation_source_indexes={c.source_index for c in consolidations},
             pending_deposits=pending_deposits,
         )
         if not withdrawals:
@@ -221,6 +222,7 @@ async def _get_withdrawals(
     validator_min_active_epochs: int,
     oracle_exit_indexes: set[int],
     consolidation_target_indexes: set[int],
+    consolidation_source_indexes: set[int],
     pending_deposits: dict[HexStr, Gwei],
 ) -> dict[HexStr, Gwei]:
     if queued_assets <= 0:
@@ -232,9 +234,15 @@ async def _get_withdrawals(
             withdrawal.validator_index
         ] += withdrawal.amount  # type: ignore
 
-    # Find all partial-withdrawable validators
+    # Find all partial-withdrawable validators, excluding consolidation sources: the CL
+    # ignores a consolidation whose source has a pending partial withdrawal, so counting
+    # a source's capacity here would both misstate partial_capacity and risk cancelling
+    # the vault's own consolidation.
     partial_validators = [
-        v for v in consensus_validators if v.is_partially_withdrawable(chain_head.epoch)
+        v
+        for v in consensus_validators
+        if v.is_partially_withdrawable(chain_head.epoch)
+        and v.index not in consolidation_source_indexes
     ]
     partial_validator_indexes = {v.index for v in partial_validators}
     partial_capacity = 0
@@ -263,6 +271,7 @@ async def _get_withdrawals(
         oracle_exit_indexes=oracle_exit_indexes,
         partial_withdrawal_indexes=set(validator_partial_withdrawals.keys()),
         consolidation_target_indexes=consolidation_target_indexes,
+        consolidation_source_indexes=consolidation_source_indexes,
         pending_deposits=pending_deposits,
     )
 
@@ -328,6 +337,7 @@ def _filter_exitable_validators(
     oracle_exit_indexes: set[int],
     partial_withdrawal_indexes: set[int],
     consolidation_target_indexes: set[int],
+    consolidation_source_indexes: set[int],
     pending_deposits: dict[HexStr, Gwei],
 ) -> list[ConsensusValidator]:
     """
@@ -347,6 +357,8 @@ def _filter_exitable_validators(
         if validator.index in partial_withdrawal_indexes:
             continue
         if validator.index in consolidation_target_indexes:
+            continue
+        if validator.index in consolidation_source_indexes:
             continue
         can_be_exited_validators.append(validator)
     can_be_exited_validators.sort(

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -236,6 +236,7 @@ async def _get_withdrawals(
     partial_validators = [
         v for v in consensus_validators if v.is_partially_withdrawable(chain_head.epoch)
     ]
+    partial_validator_indexes = {v.index for v in partial_validators}
     partial_capacity = 0
     for validator in partial_validators:
         partial_withdrawals = validator_partial_withdrawals.get(validator.index, 0)
@@ -274,7 +275,8 @@ async def _get_withdrawals(
         queued_assets = Gwei(max(0, queued_assets - validator.balance))
 
         # Remove exited validator from partials
-        partial_capacity = Gwei(partial_capacity - validator.withdrawal_capacity)
+        if validator.index in partial_validator_indexes:
+            partial_capacity = Gwei(partial_capacity - validator.withdrawal_capacity)
         if partial_capacity >= queued_assets:
             partials = _get_partial_withdrawals(
                 partial_validators=[

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -798,6 +798,60 @@ async def test_get_withdrawals(data_dir):
     assert result == {}
 
 
+@pytest.mark.asyncio
+async def test_get_withdrawals_non_compounding_exit_does_not_reduce_partial_capacity(data_dir):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+
+    # v1 is 0x01 and never contributes to partial_capacity, so its full exit must not
+    # decrement it either; only v2/v3 (0x02) capacity should be tracked and consumed
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(67)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            index=1,
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+            is_compounding=False,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            index=2,
+            balance=ether_to_gwei(50),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=85,
+        ),
+        create_consensus_validator(
+            public_key='0x3',
+            index=3,
+            balance=ether_to_gwei(45),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=80,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes=set(),
+        consolidation_target_indexes=set(),
+        pending_deposits={},
+    )
+    # v1 (40 ETH) is the cheapest to exit and is fully exited, leaving 27 ETH still
+    # needed. partial_capacity (31 ETH from v2+v3) is untouched by v1's exit, so it
+    # covers the remainder via partials, fattest balance first: v2 gets its full
+    # 18 ETH capacity, v3 covers the rest (9 ETH) — v3 must not be fully exited.
+    expected = {
+        '0x1': ether_to_gwei(0),
+        '0x2': ether_to_gwei(18),
+        '0x3': ether_to_gwei(9),
+    }
+    assert result == expected
+
+
 def test_is_partial_withdrawable_validator():
     epoch = 500
 

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -260,6 +260,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(2), '0x2': ether_to_gwei(18)}
@@ -290,6 +291,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
@@ -323,6 +325,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert result == {'0x1': ether_to_gwei(8), '0x2': ether_to_gwei(18)}
@@ -353,6 +356,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0)}
@@ -383,6 +387,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(10)}
@@ -419,6 +424,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(18), '0x3': ether_to_gwei(28)}
@@ -454,6 +460,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
@@ -489,6 +496,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(49), '0x2': ether_to_gwei(11)}
@@ -519,6 +527,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0)}
@@ -549,6 +558,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
@@ -580,6 +590,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x1': 0}
@@ -612,6 +623,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes={1},
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
@@ -644,6 +656,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes={1},
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
@@ -676,6 +689,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
@@ -710,6 +724,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={'0x1': ether_to_gwei(1800)},
     )
     # only the plain validator ('0x2') is exited; '0x1' with the huge pending
@@ -748,6 +763,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={'0x1': ether_to_gwei(5)},
     )
     # '0x1' sorts first (10 + 5 = 15 ETH effective, versus '0x2' at 50 ETH), but only
@@ -776,6 +792,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     expected = {}
@@ -793,6 +810,7 @@ async def test_get_withdrawals(data_dir):
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert result == {}
@@ -838,6 +856,7 @@ async def test_get_withdrawals_non_compounding_exit_does_not_reduce_partial_capa
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     # v1 (40 ETH) is the cheapest to exit and is fully exited, leaving 27 ETH still
@@ -849,6 +868,47 @@ async def test_get_withdrawals_non_compounding_exit_does_not_reduce_partial_capa
         '0x2': ether_to_gwei(18),
         '0x3': ether_to_gwei(9),
     }
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+
+    # v1 is the source of a still-pending consolidation: it is the cheapest to exit
+    # (40 ETH) and, being 0x02 compounding, would also inflate partial_capacity. It
+    # must be excluded from both selection paths entirely -- neither fully exited nor
+    # partially withdrawn -- leaving v2 to cover the request on its own.
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(30)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            index=1,
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            index=2,
+            balance=ether_to_gwei(50),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes=set(),
+        consolidation_target_indexes=set(),
+        consolidation_source_indexes={1},
+        pending_deposits={},
+    )
+    expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
 
 
@@ -930,6 +990,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert len(result) == 1
@@ -950,6 +1011,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert len(result) == 1
@@ -970,6 +1032,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes={2},
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert len(result) == 1
@@ -990,6 +1053,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes={2},
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert len(result) == 1
@@ -1010,6 +1074,28 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes={2},
+        consolidation_source_indexes=set(),
+        pending_deposits={},
+    )
+    assert len(result) == 1
+    assert result[0].index == 1
+
+    # validators_with_consolidation_sources_are_excluded
+    validators = [
+        create_consensus_validator(
+            index=1, activation_epoch=10, status=ValidatorStatus.ACTIVE_ONGOING, balance=32
+        ),
+        create_consensus_validator(
+            index=2, activation_epoch=10, status=ValidatorStatus.ACTIVE_ONGOING, balance=32
+        ),
+    ]
+    result = _filter_exitable_validators(
+        validators,
+        max_activation_epoch=12,
+        oracle_exit_indexes=set(),
+        partial_withdrawal_indexes=set(),
+        consolidation_target_indexes=set(),
+        consolidation_source_indexes={2},
         pending_deposits={},
     )
     assert len(result) == 1
@@ -1033,6 +1119,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert len(result) == 3
@@ -1063,6 +1150,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={'0x1': ether_to_gwei(1800)},
     )
     assert len(result) == 2
@@ -1084,6 +1172,7 @@ def test_filter_exitable_validators():
         oracle_exit_indexes={1},
         partial_withdrawal_indexes=set(),
         consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
         pending_deposits={},
     )
     assert len(result) == 0


### PR DESCRIPTION
## Description

Withdrawal selection excluded only consolidation **target** indexes; **source** indexes were never filtered. A consolidation still queued in the EL predeploy has a source validator that is still `ACTIVE_ONGOING`, so it passed every selection filter — and, typically being low-balance, sorted first for a full exit.

Selecting a consolidation source is harmful in every ordering:
- **Full exit, exit request processed first**: the CL later drops the vault's own consolidation (source already exiting).
- **Full exit, consolidation processed first**: the exit request is a silent no-op, yet the greedy loop already credited the source's balance against `queued_assets` — that balance flows to the consolidation target, never to the vault, leaving the exit queue under-funded.
- **Partial withdrawal on a source**: per Electra `process_consolidation_request`, a consolidation is ignored when the source has pending partial withdrawals, so the request cancels the vault's own consolidation. A compounding source also wrongly inflated `partial_capacity`.

`_get_withdrawals` and `_filter_exitable_validators` now take `consolidation_source_indexes` and skip those validators in both the full-exit filter and the partial-withdrawable set (which also keeps them out of `partial_capacity`), mirroring the exclusion that `_calculate_validators_exits_amount` already applies on the assets side.

Stacked on #796 (same code region); the base will retarget to master once #796 merges.