### PR TITLE
Resolve pending consolidations against all vault validators

### DIFF
--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -58,9 +58,7 @@ class ConsolidationManager(ABC):
             to_block=self.chain_head.block_number,
         )
 
-        # Fetch consensus validators for the full vault set, not just the user-provided keys:
-        # pending CL/EL consolidation queue entries must resolve against every vault validator,
-        # otherwise in-flight requests involving an unselected validator go undetected (blind spot).
+        # Fetch consensus validators
         self.consensus_validators = await fetch_consensus_validators(self.vault_validators)
 
         # Pending consolidations

--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -58,13 +58,10 @@ class ConsolidationManager(ABC):
             to_block=self.chain_head.block_number,
         )
 
-        # Fetch consensus validators
-        if consolidation_keys is not None:
-            self.consensus_validators = await fetch_consensus_validators(
-                consolidation_keys.all_public_keys
-            )
-        else:
-            self.consensus_validators = await fetch_consensus_validators(self.vault_validators)
+        # Fetch consensus validators for the full vault set, not just the user-provided keys:
+        # pending CL/EL consolidation queue entries must resolve against every vault validator,
+        # otherwise in-flight requests involving an unselected validator go undetected (blind spot).
+        self.consensus_validators = await fetch_consensus_validators(self.vault_validators)
 
         # Pending consolidations
         pending_consolidations = await get_pending_consolidations(

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from eth_typing import HexStr
@@ -13,6 +13,7 @@ from src.config.settings import settings
 from src.validators.consensus import EXITING_STATUSES
 from src.validators.consolidation_manager import (
     ConsolidationChecker,
+    ConsolidationManager,
     ConsolidationSelector,
 )
 from src.validators.exceptions import ConsolidationError
@@ -914,6 +915,106 @@ class TestConsolidationChecker:
                 checker.get_target_source()
 
 
+@pytest.mark.usefixtures('fake_settings')
+class TestConsolidationManagerCreate:
+    """Regression tests for the F1 blind spot: in Checker mode, ``create()`` must fetch
+    consensus data for every vault validator, not just the user-provided keys, otherwise
+    CL/EL queue entries involving an unselected vault validator go undetected."""
+
+    async def test_el_entry_from_unselected_validator_updates_target_incoming_balance(self):
+        """EL entry X->T where X is a vault validator outside the provided keys must still
+        be resolved so the target's pending incoming balance and both indexes are tracked."""
+        source, target, other = _create_vault_trio()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source.public_key],
+            target_public_key=target.public_key,
+        )
+
+        manager = await _create_manager_via_create(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in (source, target, other)],
+            consensus_validators=[source, target, other],
+            execution_consolidations=[
+                _create_execution_consolidation(other, target),
+            ],
+        )
+
+        assert manager.pending_incoming_balances[target.index] == other.balance
+        assert other.index in manager.consolidating_source_indexes
+        assert target.index in manager.consolidating_target_indexes
+
+    async def test_el_entry_from_provided_target_to_unselected_validator_is_detected(self):
+        """EL entry T->X (the provided target is already an in-flight source elsewhere) must
+        flag T as consolidating, so the target is rejected as 'involved in another consolidation'.
+        """
+        source, target, other = _create_vault_trio()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source.public_key],
+            target_public_key=target.public_key,
+        )
+
+        manager = await _create_manager_via_create(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in (source, target, other)],
+            consensus_validators=[source, target, other],
+            execution_consolidations=[
+                _create_execution_consolidation(target, other),
+            ],
+        )
+
+        assert target.index in manager.consolidating_source_indexes
+        with pytest.raises(
+            ConsolidationError,
+            match=f'Target validator {target.public_key} is involved in another consolidation.',
+        ):
+            manager.get_target_source()
+
+    async def test_cl_entry_from_unselected_validator_does_not_crash(self):
+        """CL entry X->T where X is a vault validator outside the provided keys must resolve
+        without error, since X's balance is now fetched along with the rest of the vault."""
+        source, target, other = _create_vault_trio()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source.public_key],
+            target_public_key=target.public_key,
+        )
+
+        manager = await _create_manager_via_create(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in (source, target, other)],
+            consensus_validators=[source, target, other],
+            consensus_consolidations=[
+                {'source_index': str(other.index), 'target_index': str(target.index)},
+            ],
+        )
+
+        assert manager.pending_incoming_balances[target.index] == other.balance
+
+    async def test_el_blind_spot_lets_max_balance_guard_approve_overfill(self):
+        """End-to-end guard effect: once the EL entry from the unselected validator is counted
+        as pending incoming balance, the max-balance guard correctly rejects the overfill."""
+        source, target, other = _create_vault_trio()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source.public_key],
+            target_public_key=target.public_key,
+        )
+
+        with patch.object(settings, 'max_validator_balance_gwei', ether_to_gwei(90)):
+            manager = await _create_manager_via_create(
+                consolidation_keys=consolidation_keys,
+                vault_validators=[v.public_key for v in (source, target, other)],
+                consensus_validators=[source, target, other],
+                execution_consolidations=[
+                    _create_execution_consolidation(other, target),
+                ],
+            )
+
+            with pytest.raises(
+                ConsolidationError,
+                match='Cannot consolidate validators, total balance exceeds',
+            ):
+                manager.get_target_source()
+
+
 def create_manager(
     consolidation_keys: ConsolidationKeys | None = None,
     chain_head: ChainHead | None = None,
@@ -962,4 +1063,76 @@ def create_manager(
         self.pending_incoming_balances = defaultdict(lambda: Gwei(0), pending_incoming_balances)
     else:
         self.pending_incoming_balances = defaultdict(lambda: Gwei(0))
+
     return self
+
+
+def _create_vault_trio() -> tuple[ConsensusValidator, ConsensusValidator, ConsensusValidator]:
+    """A source/target pair intended to be passed to the Checker, plus a third vault
+    validator ("other") that is never provided by the user but is still a vault member."""
+    source = create_consensus_validator(
+        index=10, activation_epoch=1, is_compounding=False, balance=ether_to_gwei(32.0)
+    )
+    target = create_consensus_validator(
+        index=11, activation_epoch=1, is_compounding=True, balance=ether_to_gwei(32.0)
+    )
+    other = create_consensus_validator(
+        index=12, activation_epoch=1, is_compounding=False, balance=ether_to_gwei(32.0)
+    )
+    return source, target, other
+
+
+def _create_execution_consolidation(source: ConsensusValidator, target: ConsensusValidator) -> dict:
+    return {
+        'source_address': settings.vault,
+        'source_pubkey': source.public_key,
+        'target_pubkey': target.public_key,
+    }
+
+
+async def _create_manager_via_create(
+    consolidation_keys: ConsolidationKeys | None,
+    vault_validators: list[HexStr],
+    consensus_validators: list[ConsensusValidator],
+    chain_head: ChainHead | None = None,
+    consensus_consolidations: list[dict] | None = None,
+    execution_consolidations: list[dict] | None = None,
+) -> ConsolidationManager:
+    """Exercises the real ``ConsolidationManager.create()`` assembly logic, mocking only the
+    network boundaries: vault event scan, consensus validator fetch, and the CL/EL
+    consolidation queues (the real ``get_pending_consolidations`` merge logic runs unmocked)."""
+    if chain_head is None:
+        chain_head = create_chain_head(epoch=1024)
+
+    vault_contract = MagicMock()
+    vault_contract.get_registered_validators_public_keys = AsyncMock(return_value=vault_validators)
+
+    async def fetch_requested_consensus_validators(
+        validator_ids: list[HexStr], slot: str = 'head'
+    ) -> list[ConsensusValidator]:
+        return [val for val in consensus_validators if val.public_key in validator_ids]
+
+    with (
+        patch('src.validators.consolidation_manager.VaultContract', return_value=vault_contract),
+        patch(
+            'src.validators.consolidation_manager.fetch_consensus_validators',
+            side_effect=fetch_requested_consensus_validators,
+        ),
+        patch(
+            'src.validators.consolidation_manager.get_pending_partial_withdrawals',
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            'src.common.consolidations.consensus_client.get_pending_consolidations',
+            AsyncMock(return_value=consensus_consolidations or []),
+        ),
+        patch(
+            'src.common.consolidations.get_execution_consolidations',
+            AsyncMock(return_value=execution_consolidations or []),
+        ),
+    ):
+        return await ConsolidationManager.create(
+            consolidation_keys=consolidation_keys,
+            chain_head=chain_head,
+            exclude_public_keys=set(),
+        )

--- a/src/validators/typings.py
+++ b/src/validators/typings.py
@@ -131,7 +131,3 @@ class ConsolidationRequest:
 class ConsolidationKeys:
     source_public_keys: list[HexStr]
     target_public_key: HexStr
-
-    @property
-    def all_public_keys(self) -> list[HexStr]:
-        return list(dict.fromkeys(self.source_public_keys + [self.target_public_key]))


### PR DESCRIPTION
## Description

When `--source-public-keys`/`--target-public-key` are provided, `ConsolidationManager.create()` fetched consensus data only for the provided keys. `get_pending_consolidations` then resolved CL/EL queue entries against that reduced set, so in-flight consolidations involving any other vault validator went undetected:

- an EL-queue request `X→T` into the chosen target was silently dropped, leaving `pending_incoming_balances` incomplete — the max-balance guard could approve overfilling the target past `max_validator_balance_gwei` (same class as #678, via the EL queue path);
- an EL-queue request `T→X` left the target unflagged as an in-flight source, so a new consolidation into it was accepted even though it is scheduled to consolidate away;
- a CL-queue entry `X→T` aborted with `Cannot determine balance for source validator index ...` because `X`'s balance was never fetched.

Consensus validators are now always fetched for the full vault set, so pending queue entries resolve against every vault validator. Vault-membership validation still runs before any consensus lookups, so provided-key validation is unchanged. The now-unused `ConsolidationKeys.all_public_keys` property is removed.