### PR TITLE
Reject empty source public keys file in consolidate command

### DIFF
--- a/src/validators/commands/consolidate.py
+++ b/src/validators/commands/consolidate.py
@@ -238,7 +238,7 @@ def consolidate(
 
     if source_public_keys and exclude_public_keys:
         raise click.ClickException(
-            '--exclude-public-keys-file and source public keys are mutually exclusive.'
+            '--exclude-public-keys-file and --source-public-keys are mutually exclusive.'
         )
 
     operator_config = OperatorConfig(vault, Path(data_dir))

--- a/src/validators/commands/consolidate.py
+++ b/src/validators/commands/consolidate.py
@@ -226,6 +226,8 @@ def consolidate(
 
     if source_public_keys_file:
         source_public_keys = _load_public_keys(source_public_keys_file)
+        if not source_public_keys:
+            raise click.ClickException(f'No public keys found in {source_public_keys_file}.')
 
     exclude_public_keys: set[HexStr] = set()
 

--- a/src/validators/commands/consolidate.py
+++ b/src/validators/commands/consolidate.py
@@ -233,10 +233,12 @@ def consolidate(
 
     if exclude_public_keys_file:
         exclude_public_keys = set(_load_public_keys(exclude_public_keys_file))
+        if not exclude_public_keys:
+            raise click.ClickException(f'No public keys found in {exclude_public_keys_file}.')
 
     if source_public_keys and exclude_public_keys:
         raise click.ClickException(
-            '--exclude-public-keys and --source-public-keys are mutually exclusive.'
+            '--exclude-public-keys-file and source public keys are mutually exclusive.'
         )
 
     operator_config = OperatorConfig(vault, Path(data_dir))

--- a/src/validators/commands/tests/test_consolidate.py
+++ b/src/validators/commands/tests/test_consolidate.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+from sw_utils.tests import faker
+
+from src.config.networks import HOODI
+from src.config.settings import DEFAULT_MAX_CONSOLIDATION_REQUEST_FEE_GWEI
+from src.validators.commands.consolidate import consolidate
+
+
+def test_empty_source_public_keys_file_raises(
+    vault_address: str,
+    consensus_endpoints: str,
+    execution_endpoints: str,
+    data_dir: Path,
+    tmp_path: Path,
+    runner: CliRunner,
+):
+    empty_source_public_keys_file = tmp_path / 'empty_source_public_keys.txt'
+    empty_source_public_keys_file.touch()
+    target_public_key = faker.validator_public_key()
+
+    args = [
+        '--vault',
+        vault_address,
+        '--network',
+        HOODI,
+        '--consensus-endpoints',
+        consensus_endpoints,
+        '--execution-endpoints',
+        execution_endpoints,
+        '--data-dir',
+        str(data_dir),
+        '--source-public-keys-file',
+        str(empty_source_public_keys_file),
+        '--target-public-key',
+        target_public_key,
+    ]
+    with patch('src.validators.commands.consolidate.main', new_callable=AsyncMock) as mocked_main:
+        result = runner.invoke(consolidate, args)
+        mocked_main.assert_not_called()
+
+    assert result.exit_code != 0
+    assert f'No public keys found in {empty_source_public_keys_file}.' in result.output
+
+
+def test_source_public_keys_file_with_keys_proceeds(
+    vault_address: str,
+    consensus_endpoints: str,
+    execution_endpoints: str,
+    data_dir: Path,
+    tmp_path: Path,
+    runner: CliRunner,
+):
+    source_public_keys = [faker.validator_public_key(), faker.validator_public_key()]
+    source_public_keys_file = tmp_path / 'source_public_keys.txt'
+    source_public_keys_file.write_text('\n'.join(source_public_keys) + '\n')
+    target_public_key = faker.validator_public_key()
+
+    args = [
+        '--vault',
+        vault_address,
+        '--network',
+        HOODI,
+        '--consensus-endpoints',
+        consensus_endpoints,
+        '--execution-endpoints',
+        execution_endpoints,
+        '--data-dir',
+        str(data_dir),
+        '--source-public-keys-file',
+        str(source_public_keys_file),
+        '--target-public-key',
+        target_public_key,
+    ]
+    with patch('src.validators.commands.consolidate.main', new_callable=AsyncMock) as mocked_main:
+        result = runner.invoke(consolidate, args)
+        mocked_main.assert_called_once_with(
+            source_public_keys=source_public_keys,
+            target_public_key=target_public_key,
+            exclude_public_keys=set(),
+            no_switch_consolidation=False,
+            max_consolidation_request_fee_gwei=DEFAULT_MAX_CONSOLIDATION_REQUEST_FEE_GWEI,
+            no_confirm=False,
+        )
+
+    assert result.exit_code == 0
+
+
+def test_source_public_keys_file_blank_line_rejected_at_parse_time(
+    vault_address: str,
+    consensus_endpoints: str,
+    execution_endpoints: str,
+    data_dir: Path,
+    tmp_path: Path,
+    runner: CliRunner,
+):
+    blank_line_source_public_keys_file = tmp_path / 'blank_line_source_public_keys.txt'
+    blank_line_source_public_keys_file.write_text('\n')
+    target_public_key = faker.validator_public_key()
+
+    args = [
+        '--vault',
+        vault_address,
+        '--consensus-endpoints',
+        consensus_endpoints,
+        '--execution-endpoints',
+        execution_endpoints,
+        '--data-dir',
+        str(data_dir),
+        '--source-public-keys-file',
+        str(blank_line_source_public_keys_file),
+        '--target-public-key',
+        target_public_key,
+    ]
+    with patch('src.validators.commands.consolidate.main', new_callable=AsyncMock) as mocked_main:
+        result = runner.invoke(consolidate, args)
+        mocked_main.assert_not_called()
+
+    assert result.exit_code != 0
+    assert 'Invalid validator public key' in result.output

--- a/src/validators/commands/tests/test_consolidate.py
+++ b/src/validators/commands/tests/test_consolidate.py
@@ -103,6 +103,8 @@ def test_source_public_keys_file_blank_line_rejected_at_parse_time(
     args = [
         '--vault',
         vault_address,
+        '--network',
+        HOODI,
         '--consensus-endpoints',
         consensus_endpoints,
         '--execution-endpoints',
@@ -120,3 +122,36 @@ def test_source_public_keys_file_blank_line_rejected_at_parse_time(
 
     assert result.exit_code != 0
     assert 'Invalid validator public key' in result.output
+
+
+def test_empty_exclude_public_keys_file_raises(
+    vault_address: str,
+    consensus_endpoints: str,
+    execution_endpoints: str,
+    data_dir: Path,
+    tmp_path: Path,
+    runner: CliRunner,
+):
+    empty_exclude_public_keys_file = tmp_path / 'empty_exclude_public_keys.txt'
+    empty_exclude_public_keys_file.touch()
+
+    args = [
+        '--vault',
+        vault_address,
+        '--network',
+        HOODI,
+        '--consensus-endpoints',
+        consensus_endpoints,
+        '--execution-endpoints',
+        execution_endpoints,
+        '--data-dir',
+        str(data_dir),
+        '--exclude-public-keys-file',
+        str(empty_exclude_public_keys_file),
+    ]
+    with patch('src.validators.commands.consolidate.main', new_callable=AsyncMock) as mocked_main:
+        result = runner.invoke(consolidate, args)
+        mocked_main.assert_not_called()
+
+    assert result.exit_code != 0
+    assert f'No public keys found in {empty_exclude_public_keys_file}.' in result.output


### PR DESCRIPTION
## Description

An empty `--source-public-keys-file` passed CLI validation (`validate_public_keys_file` iterates lines, so a zero-line file is accepted) and loaded as an empty list. Since `process()` builds `ConsolidationKeys` only when `source_public_keys` is truthy, the command silently fell through to the auto-pick (`ConsolidationSelector`) path — ignoring the user's explicit `--target-public-key` and consolidating validators the user never chose, with no warning.

The consolidate command now raises a clean error when the provided source keys file yields no keys. Files with blank lines were already rejected upfront by the CLI callback, so the check targets the zero-keys case specifically. `validate_public_keys_file` is left unchanged, as it is shared with `--exclude-public-keys-file`, where an empty file is harmless.

Adds the first tests for the consolidate command (`src/validators/commands/tests/test_consolidate.py`).