### PR TITLE
Reject pending validators as consolidation targets

### DIFF
--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -114,7 +114,7 @@ class ConsolidationManager(ABC):
         # Target validator must be:
         - in the vault
         - not exiting
-        - active for at least SHARD_COMMITTEE_PERIOD epochs
+        - active
         - not consolidating to another validator
         - a compounding validator
 
@@ -206,13 +206,15 @@ class ConsolidationSelector(ConsolidationManager):
                 continue
             if val.public_key in self.exclude_public_keys:
                 continue
-            if val.activation_epoch > self.max_activation_epoch:
+            if val.activation_epoch > self.chain_head.epoch:
                 continue
             target_validators.append(val)
 
             # additional filters for source validators
             # Source validator must be non-compounding
             if val.is_compounding:
+                continue
+            if val.activation_epoch > self.max_activation_epoch:
                 continue
             # Source validator cannot be in any ongoing consolidations (either as source or target)
             if val.index in self.consolidating_target_indexes:
@@ -351,23 +353,28 @@ class ConsolidationChecker(ConsolidationManager):
             raise ConsolidationError(
                 f'Target validator {self.target_public_key} is involved in another consolidation.'
             )
-        if target_validator.activation_epoch > self.max_activation_epoch:
-            raise ConsolidationError(
-                f'Validator {self.target_public_key} is not active enough for consolidation. '
-                f'It must be active for at least '
-                f'{settings.network_config.SHARD_COMMITTEE_PERIOD} epochs before consolidation.'
-            )
 
         if self.is_switch_to_compounding():
             if target_validator.is_compounding:
                 raise ConsolidationError(
                     f'Target validator {self.target_public_key} is already a compounding validator.'
                 )
+            # switch the 0x01 to 0x02
+            if target_validator.activation_epoch > self.max_activation_epoch:
+                raise ConsolidationError(
+                    f'Validator {self.target_public_key} is not active enough for consolidation. '
+                    f'It must be active for at least '
+                    f'{settings.network_config.SHARD_COMMITTEE_PERIOD} epochs before consolidation.'
+                )
         else:
             if not target_validator.is_compounding:
                 raise ConsolidationError(
                     f'The target validator {self.target_public_key} '
                     f'is not a compounding validator.'
+                )
+            if target_validator.activation_epoch > self.chain_head.epoch:
+                raise ConsolidationError(
+                    f'Target validator {self.target_public_key} is not active.'
                 )
         return target_validator
 

--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 
 from eth_typing import HexStr
-from sw_utils import PENDING_STATUSES, ChainHead
+from sw_utils import ChainHead
 from web3.types import Gwei
 
 from src.common.consolidations import get_pending_consolidations
@@ -114,6 +114,7 @@ class ConsolidationManager(ABC):
         # Target validator must be:
         - in the vault
         - not exiting
+        - active for at least SHARD_COMMITTEE_PERIOD epochs
         - not consolidating to another validator
         - a compounding validator
 
@@ -205,14 +206,13 @@ class ConsolidationSelector(ConsolidationManager):
                 continue
             if val.public_key in self.exclude_public_keys:
                 continue
-            if val.status not in PENDING_STATUSES:
-                target_validators.append(val)
+            if val.activation_epoch > self.max_activation_epoch:
+                continue
+            target_validators.append(val)
 
             # additional filters for source validators
             # Source validator must be non-compounding
             if val.is_compounding:
-                continue
-            if val.activation_epoch > self.max_activation_epoch:
                 continue
             # Source validator cannot be in any ongoing consolidations (either as source or target)
             if val.index in self.consolidating_target_indexes:
@@ -351,29 +351,23 @@ class ConsolidationChecker(ConsolidationManager):
             raise ConsolidationError(
                 f'Target validator {self.target_public_key} is involved in another consolidation.'
             )
+        if target_validator.activation_epoch > self.max_activation_epoch:
+            raise ConsolidationError(
+                f'Validator {self.target_public_key} is not active enough for consolidation. '
+                f'It must be active for at least '
+                f'{settings.network_config.SHARD_COMMITTEE_PERIOD} epochs before consolidation.'
+            )
 
         if self.is_switch_to_compounding():
             if target_validator.is_compounding:
                 raise ConsolidationError(
                     f'Target validator {self.target_public_key} is already a compounding validator.'
                 )
-            # switch the 0x01 to 0x02
-            if target_validator.activation_epoch > self.max_activation_epoch:
-                raise ConsolidationError(
-                    f'Validator {self.target_public_key} is not active enough for consolidation. '
-                    f'It must be active for at least '
-                    f'{settings.network_config.SHARD_COMMITTEE_PERIOD} epochs before consolidation.'
-                )
         else:
             if not target_validator.is_compounding:
                 raise ConsolidationError(
                     f'The target validator {self.target_public_key} '
                     f'is not a compounding validator.'
-                )
-            if target_validator.status in PENDING_STATUSES:
-                raise ConsolidationError(
-                    f'Target validator {self.target_public_key} is not active '
-                    f'(status {target_validator.status.value}).'
                 )
         return target_validator
 

--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -205,8 +205,6 @@ class ConsolidationSelector(ConsolidationManager):
                 continue
             if val.public_key in self.exclude_public_keys:
                 continue
-            # Target must have activated (spec is_active_validator); pending validators
-            # are silently dropped by the CL if used as target.
             if val.status not in PENDING_STATUSES:
                 target_validators.append(val)
 
@@ -372,8 +370,6 @@ class ConsolidationChecker(ConsolidationManager):
                     f'The target validator {self.target_public_key} '
                     f'is not a compounding validator.'
                 )
-            # Spec requires both source and target to be active (is_active_validator);
-            # a pending target is silently dropped by the CL.
             if target_validator.status in PENDING_STATUSES:
                 raise ConsolidationError(
                     f'Target validator {self.target_public_key} is not active '

--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 
 from eth_typing import HexStr
-from sw_utils import ChainHead
+from sw_utils import PENDING_STATUSES, ChainHead
 from web3.types import Gwei
 
 from src.common.consolidations import get_pending_consolidations
@@ -205,7 +205,10 @@ class ConsolidationSelector(ConsolidationManager):
                 continue
             if val.public_key in self.exclude_public_keys:
                 continue
-            target_validators.append(val)
+            # Target must have activated (spec is_active_validator); pending validators
+            # are silently dropped by the CL if used as target.
+            if val.status not in PENDING_STATUSES:
+                target_validators.append(val)
 
             # additional filters for source validators
             # Source validator must be non-compounding
@@ -368,6 +371,13 @@ class ConsolidationChecker(ConsolidationManager):
                 raise ConsolidationError(
                     f'The target validator {self.target_public_key} '
                     f'is not a compounding validator.'
+                )
+            # Spec requires both source and target to be active (is_active_validator);
+            # a pending target is silently dropped by the CL.
+            if target_validator.status in PENDING_STATUSES:
+                raise ConsolidationError(
+                    f'Target validator {self.target_public_key} is not active '
+                    f'(status {target_validator.status.value}).'
                 )
         return target_validator
 

--- a/src/validators/tests/factories.py
+++ b/src/validators/tests/factories.py
@@ -22,7 +22,7 @@ def create_consensus_validator(
     public_key: HexStr | None = None,
     index: int | None = None,
     balance: Gwei | None = None,
-    status: ValidatorStatus | None = None,
+    status: ValidatorStatus = ValidatorStatus.ACTIVE_ONGOING,
     activation_epoch: int | None = None,
     is_compounding: bool = True,
 ) -> ConsensusValidator:

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -378,7 +378,7 @@ class TestConsolidationSelector:
         )
         pending_target = create_consensus_validator(
             index=11,
-            activation_epoch=1,
+            activation_epoch=settings.network_config.FAR_FUTURE_EPOCH,
             is_compounding=True,
             status=ValidatorStatus.PENDING_QUEUED,
             balance=ether_to_gwei(1.0),
@@ -407,7 +407,7 @@ class TestConsolidationSelector:
         )
         pending_target = create_consensus_validator(
             index=11,
-            activation_epoch=1,
+            activation_epoch=settings.network_config.FAR_FUTURE_EPOCH,
             is_compounding=True,
             status=ValidatorStatus.PENDING_QUEUED,
         )
@@ -417,6 +417,31 @@ class TestConsolidationSelector:
             consensus_validators=consensus_validators,
         )
         result = selector.get_target_source()
+        assert result == [(source_validator, source_validator)]
+
+    def test_excludes_young_target(self):
+        """A compounding target that hasn't been active long enough must be excluded,
+        even though it would otherwise be picked as the top-up target."""
+        epoch = 1000
+        source_validator = create_consensus_validator(
+            index=10,
+            activation_epoch=1,
+            is_compounding=False,
+        )
+        young_target = create_consensus_validator(
+            index=11,
+            activation_epoch=epoch - settings.network_config.SHARD_COMMITTEE_PERIOD + 1,
+            is_compounding=True,
+        )
+        consensus_validators = [source_validator, young_target]
+        selector = create_manager(
+            chain_head=create_chain_head(epoch),
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+        result = selector.get_target_source()
+        # Falls back to switching the source from 0x01 to 0x02 since the only 0x02
+        # candidate is too young to be used as target
         assert result == [(source_validator, source_validator)]
 
     def test_excludes_validator_in_target_indexes_as_source(self):
@@ -893,7 +918,7 @@ class TestConsolidationChecker:
             target_public_key=target_pk,
         )
 
-        epoch = 10
+        epoch = 1000
         consensus_validators = [
             create_consensus_validator(
                 public_key=source_pk,
@@ -922,8 +947,8 @@ class TestConsolidationChecker:
             selector.get_target_source()
 
     def test_rejects_pending_target(self):
-        """A target that has not yet activated must be rejected per the spec's
-        is_active_validator requirement, even though it is compounding."""
+        """A target that is still pending (activation_epoch far in the future) is rejected
+        by the same minimum-activation-epoch check applied to source validators."""
         source_pk = faker.validator_public_key()
         target_pk = faker.validator_public_key()
         consolidation_keys = ConsolidationKeys(
@@ -939,7 +964,7 @@ class TestConsolidationChecker:
             ),
             create_consensus_validator(
                 public_key=target_pk,
-                activation_epoch=1,
+                activation_epoch=settings.network_config.FAR_FUTURE_EPOCH,
                 is_compounding=True,
                 status=ValidatorStatus.PENDING_QUEUED,
             ),
@@ -952,7 +977,43 @@ class TestConsolidationChecker:
 
         with pytest.raises(
             ConsolidationError,
-            match=f'Target validator {target_pk} is not active',
+            match=f'Validator {target_pk} is not active enough for consolidation.',
+        ):
+            selector.get_target_source()
+
+    def test_rejects_young_target(self):
+        """An active target that hasn't been active long enough (activation_epoch within
+        SHARD_COMMITTEE_PERIOD of chain head) must be rejected, same as a too-young source."""
+        source_pk = faker.validator_public_key()
+        target_pk = faker.validator_public_key()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source_pk],
+            target_public_key=target_pk,
+        )
+
+        epoch = 1000
+        consensus_validators = [
+            create_consensus_validator(
+                public_key=source_pk,
+                activation_epoch=1,
+                is_compounding=False,
+            ),
+            create_consensus_validator(
+                public_key=target_pk,
+                activation_epoch=epoch - settings.network_config.SHARD_COMMITTEE_PERIOD + 1,
+                is_compounding=True,
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            chain_head=create_chain_head(epoch),
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+
+        with pytest.raises(
+            ConsolidationError,
+            match=f'Validator {target_pk} is not active enough for consolidation.',
         ):
             selector.get_target_source()
 

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -419,9 +419,9 @@ class TestConsolidationSelector:
         result = selector.get_target_source()
         assert result == [(source_validator, source_validator)]
 
-    def test_excludes_young_target(self):
-        """A compounding target that hasn't been active long enough must be excluded,
-        even though it would otherwise be picked as the top-up target."""
+    def test_allows_young_target(self):
+        """A compounding target that is active but younger than SHARD_COMMITTEE_PERIOD is
+        still a valid target per spec — only sources require the longer activation window."""
         epoch = 1000
         source_validator = create_consensus_validator(
             index=10,
@@ -440,9 +440,7 @@ class TestConsolidationSelector:
             consensus_validators=consensus_validators,
         )
         result = selector.get_target_source()
-        # Falls back to switching the source from 0x01 to 0x02 since the only 0x02
-        # candidate is too young to be used as target
-        assert result == [(source_validator, source_validator)]
+        assert result == [(young_target, source_validator)]
 
     def test_excludes_validator_in_target_indexes_as_source(self):
         """Test that source validator is excluded if it's in consolidating_target_indexes"""
@@ -918,7 +916,7 @@ class TestConsolidationChecker:
             target_public_key=target_pk,
         )
 
-        epoch = 1000
+        epoch = 10
         consensus_validators = [
             create_consensus_validator(
                 public_key=source_pk,
@@ -947,8 +945,8 @@ class TestConsolidationChecker:
             selector.get_target_source()
 
     def test_rejects_pending_target(self):
-        """A target that is still pending (activation_epoch far in the future) is rejected
-        by the same minimum-activation-epoch check applied to source validators."""
+        """A target that is still pending (activation_epoch far in the future, i.e. not yet
+        activated) is rejected — a target must merely be activated, per spec."""
         source_pk = faker.validator_public_key()
         target_pk = faker.validator_public_key()
         consolidation_keys = ConsolidationKeys(
@@ -977,13 +975,14 @@ class TestConsolidationChecker:
 
         with pytest.raises(
             ConsolidationError,
-            match=f'Validator {target_pk} is not active enough for consolidation.',
+            match=f'Target validator {target_pk} is not active.',
         ):
             selector.get_target_source()
 
-    def test_rejects_young_target(self):
+    def test_allows_young_target(self):
         """An active target that hasn't been active long enough (activation_epoch within
-        SHARD_COMMITTEE_PERIOD of chain head) must be rejected, same as a too-young source."""
+        SHARD_COMMITTEE_PERIOD of chain head) is still a valid target per spec — only sources
+        require the longer activation window."""
         source_pk = faker.validator_public_key()
         target_pk = faker.validator_public_key()
         consolidation_keys = ConsolidationKeys(
@@ -1010,12 +1009,8 @@ class TestConsolidationChecker:
             vault_validators=[v.public_key for v in consensus_validators],
             consensus_validators=consensus_validators,
         )
-
-        with pytest.raises(
-            ConsolidationError,
-            match=f'Validator {target_pk} is not active enough for consolidation.',
-        ):
-            selector.get_target_source()
+        result = selector.get_target_source()
+        assert result == [(consensus_validators[1], consensus_validators[0])]
 
     def test_max_balance_accounts_for_pending_incoming_consolidations(self):
         """Balance check must include pending incoming consolidation balances to the target."""

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -368,6 +368,57 @@ class TestConsolidationSelector:
             # is less than target 1's effective balance (32 + 32 = 64 ETH)
             assert result == [(consensus_validators[1], consensus_validators[2])]
 
+    def test_picks_active_target_over_pending_target_with_smaller_balance(self):
+        """A pending (not-yet-active) 0x02 validator must never be chosen as target,
+        even if its balance is smaller than an active 0x02 candidate's."""
+        source_validator = create_consensus_validator(
+            index=10,
+            activation_epoch=1,
+            is_compounding=False,
+        )
+        pending_target = create_consensus_validator(
+            index=11,
+            activation_epoch=1,
+            is_compounding=True,
+            status=ValidatorStatus.PENDING_QUEUED,
+            balance=ether_to_gwei(1.0),
+        )
+        active_target = create_consensus_validator(
+            index=12,
+            activation_epoch=1,
+            is_compounding=True,
+            balance=ether_to_gwei(32.3),
+        )
+        consensus_validators = [source_validator, pending_target, active_target]
+        selector = create_manager(
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+        result = selector.get_target_source()
+        assert result == [(active_target, source_validator)]
+
+    def test_switches_source_when_only_target_candidate_is_pending(self):
+        """If the only 0x02 validator in the vault is still pending, it must be treated
+        as ineligible, falling back to switching the 0x01 source to 0x02."""
+        source_validator = create_consensus_validator(
+            index=10,
+            activation_epoch=1,
+            is_compounding=False,
+        )
+        pending_target = create_consensus_validator(
+            index=11,
+            activation_epoch=1,
+            is_compounding=True,
+            status=ValidatorStatus.PENDING_QUEUED,
+        )
+        consensus_validators = [source_validator, pending_target]
+        selector = create_manager(
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+        result = selector.get_target_source()
+        assert result == [(source_validator, source_validator)]
+
     def test_excludes_validator_in_target_indexes_as_source(self):
         """Test that source validator is excluded if it's in consolidating_target_indexes"""
         consensus_validators = [
@@ -867,6 +918,41 @@ class TestConsolidationChecker:
         with pytest.raises(
             ConsolidationError,
             match=f'Validator {consensus_validators[0].public_key} is not active enough for consolidation.',
+        ):
+            selector.get_target_source()
+
+    def test_rejects_pending_target(self):
+        """A target that has not yet activated must be rejected per the spec's
+        is_active_validator requirement, even though it is compounding."""
+        source_pk = faker.validator_public_key()
+        target_pk = faker.validator_public_key()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source_pk],
+            target_public_key=target_pk,
+        )
+
+        consensus_validators = [
+            create_consensus_validator(
+                public_key=source_pk,
+                activation_epoch=1,
+                is_compounding=False,
+            ),
+            create_consensus_validator(
+                public_key=target_pk,
+                activation_epoch=1,
+                is_compounding=True,
+                status=ValidatorStatus.PENDING_QUEUED,
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+
+        with pytest.raises(
+            ConsolidationError,
+            match=f'Target validator {target_pk} is not active',
         ):
             selector.get_target_source()
 


### PR DESCRIPTION
## Description

The consensus layer's `process_consolidation_request` requires both source and target validators to be active and silently drops the request otherwise — with the EL request fee already paid. The operator checked exiting statuses but never that the target had actually activated: a freshly-deposited 0x02 validator still in the activation queue (`PENDING_INITIALIZED`/`PENDING_QUEUED`) passed validation. The auto-selector could even prefer it, since it picks the compounding target with the smallest balance.

Eligibility now follows the spec with two separate rules:

- **Source** (unchanged): active for at least `SHARD_COMMITTEE_PERIOD` epochs.
- **Target** (new): must be activated (`activation_epoch <= chain_head.epoch`) — recently activated targets remain eligible, matching the consensus layer's `is_active_validator` requirement exactly.

`ConsolidationChecker` rejects a not-yet-activated target with a clear error in non-switch mode (the switch branch keeps the stricter source rule, since a switch target is the source per spec); `ConsolidationSelector` excludes not-yet-activated validators from target candidates, falling back to switching the oldest 0x01 validator when no eligible 0x02 target exists. Test factory now defaults consensus validators to `ACTIVE_ONGOING` instead of no status.