### PR TITLE
Verify source withdrawal address matches the vault

### DIFF
--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -281,8 +281,9 @@ class ConsolidationChecker(ConsolidationManager):
             # Validate the source validator withdrawal address matches the vault
             if source_validator.withdrawal_address != settings.vault:
                 raise ConsolidationError(
-                    f'Validator {source_validator.public_key} withdrawal address '
-                    f'does not match the vault address.'
+                    f'Validator {source_public_key} withdrawal address '
+                    f'{source_validator.withdrawal_address} does not match '
+                    f'the vault address {settings.vault}.'
                 )
 
             # Validate the source validator has been active long enough
@@ -370,7 +371,8 @@ class ConsolidationChecker(ConsolidationManager):
             if target_validator.withdrawal_address != settings.vault:
                 raise ConsolidationError(
                     f'Validator {self.target_public_key} withdrawal address '
-                    f'does not match the vault address.'
+                    f'{target_validator.withdrawal_address} does not match '
+                    f'the vault address {settings.vault}.'
                 )
             # switch the 0x01 to 0x02
             if target_validator.activation_epoch > self.max_activation_epoch:

--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -106,6 +106,7 @@ class ConsolidationManager(ABC):
         - unique
         - in the vault
         - not exiting
+        - withdrawal address matches the vault
         - active for at least SHARD_COMMITTEE_PERIOD epochs
         - not consolidating to another validator
         - not consolidating from another validator
@@ -121,6 +122,7 @@ class ConsolidationManager(ABC):
         - source and target public keys are the same
         - in the vault
         - not exiting
+        - withdrawal address matches the vault
         - active for at least SHARD_COMMITTEE_PERIOD epochs
         """
         raise NotImplementedError()
@@ -211,6 +213,8 @@ class ConsolidationSelector(ConsolidationManager):
             # Source validator must be non-compounding
             if val.is_compounding:
                 continue
+            if val.withdrawal_address != settings.vault:
+                continue
             if val.activation_epoch > self.max_activation_epoch:
                 continue
             # Source validator cannot be in any ongoing consolidations (either as source or target)
@@ -272,6 +276,13 @@ class ConsolidationChecker(ConsolidationManager):
                 raise ConsolidationError(
                     f'Validator {source_public_key} is in exiting '
                     f'status {source_validator.status.value}.'
+                )
+
+            # Validate the source validator withdrawal address matches the vault
+            if source_validator.withdrawal_address != settings.vault:
+                raise ConsolidationError(
+                    f'Validator {source_validator.public_key} withdrawal address '
+                    f'does not match the vault address.'
                 )
 
             # Validate the source validator has been active long enough
@@ -355,6 +366,11 @@ class ConsolidationChecker(ConsolidationManager):
             if target_validator.is_compounding:
                 raise ConsolidationError(
                     f'Target validator {self.target_public_key} is already a compounding validator.'
+                )
+            if target_validator.withdrawal_address != settings.vault:
+                raise ConsolidationError(
+                    f'Validator {self.target_public_key} withdrawal address '
+                    f'does not match the vault address.'
                 )
             # switch the 0x01 to 0x02
             if target_validator.activation_epoch > self.max_activation_epoch:

--- a/src/validators/tests/factories.py
+++ b/src/validators/tests/factories.py
@@ -1,21 +1,18 @@
-import random
-import string
-
-from eth_typing import HexStr
+from eth_typing import ChecksumAddress, HexStr
 from sw_utils import ValidatorStatus
 from sw_utils.tests import faker
 from web3.types import Gwei
 
-from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI
+from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI, settings
 from src.validators.typings import ConsensusValidator
 
 
-def fake_non_compound_credentials() -> HexStr:
-    return HexStr('0x01' + '0' * 22 + ''.join(random.choices('abcdef' + string.digits, k=40)))
+def fake_non_compound_credentials(withdrawal_address: ChecksumAddress) -> HexStr:
+    return HexStr('0x01' + '0' * 22 + withdrawal_address[2:].lower())
 
 
-def fake_compound_credentials() -> HexStr:
-    return HexStr('0x02' + '0' * 22 + ''.join(random.choices('abcdef' + string.digits, k=40)))
+def fake_compound_credentials(withdrawal_address: ChecksumAddress) -> HexStr:
+    return HexStr('0x02' + '0' * 22 + withdrawal_address[2:].lower())
 
 
 def create_consensus_validator(
@@ -25,14 +22,21 @@ def create_consensus_validator(
     status: ValidatorStatus | None = None,
     activation_epoch: int | None = None,
     is_compounding: bool = True,
+    withdrawal_address: ChecksumAddress | None = None,
 ) -> ConsensusValidator:
+    # settings.vault is unset in tests that don't use the fake_settings fixture
+    withdrawal_address = (
+        withdrawal_address or getattr(settings, 'vault', None) or faker.eth_address()
+    )
     return ConsensusValidator(
         public_key=public_key or faker.validator_public_key(),
         status=status,
         index=index,
         balance=balance or MIN_ACTIVATION_BALANCE_GWEI,
         withdrawal_credentials=(
-            fake_compound_credentials() if is_compounding else fake_non_compound_credentials()
+            fake_compound_credentials(withdrawal_address)
+            if is_compounding
+            else fake_non_compound_credentials(withdrawal_address)
         ),
         activation_epoch=activation_epoch,
     )

--- a/src/validators/tests/factories.py
+++ b/src/validators/tests/factories.py
@@ -7,14 +7,6 @@ from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI, settings
 from src.validators.typings import ConsensusValidator
 
 
-def fake_non_compound_credentials(withdrawal_address: ChecksumAddress) -> HexStr:
-    return HexStr('0x01' + '0' * 22 + withdrawal_address[2:].lower())
-
-
-def fake_compound_credentials(withdrawal_address: ChecksumAddress) -> HexStr:
-    return HexStr('0x02' + '0' * 22 + withdrawal_address[2:].lower())
-
-
 def create_consensus_validator(
     public_key: HexStr | None = None,
     index: int | None = None,
@@ -34,9 +26,17 @@ def create_consensus_validator(
         index=index,
         balance=balance or MIN_ACTIVATION_BALANCE_GWEI,
         withdrawal_credentials=(
-            fake_compound_credentials(withdrawal_address)
+            _build_compound_credentials(withdrawal_address)
             if is_compounding
-            else fake_non_compound_credentials(withdrawal_address)
+            else _build_non_compound_credentials(withdrawal_address)
         ),
         activation_epoch=activation_epoch,
     )
+
+
+def _build_non_compound_credentials(withdrawal_address: ChecksumAddress) -> HexStr:
+    return HexStr('0x01' + '0' * 22 + withdrawal_address[2:].lower())
+
+
+def _build_compound_credentials(withdrawal_address: ChecksumAddress) -> HexStr:
+    return HexStr('0x02' + '0' * 22 + withdrawal_address[2:].lower())

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from unittest.mock import patch
 
@@ -850,9 +851,14 @@ class TestConsolidationChecker:
             consensus_validators=consensus_validators,
         )
 
+        source_validator = consensus_validators[0]
         with pytest.raises(
             ConsolidationError,
-            match=f'Validator {source_pk} withdrawal address does not match the vault address.',
+            match=re.escape(
+                f'Validator {source_pk} withdrawal address '
+                f'{source_validator.withdrawal_address} does not match '
+                f'the vault address {settings.vault}.'
+            ),
         ):
             selector.get_target_source()
 
@@ -877,9 +883,85 @@ class TestConsolidationChecker:
             consensus_validators=consensus_validators,
         )
 
+        target_validator = consensus_validators[0]
         with pytest.raises(
             ConsolidationError,
-            match=f'Validator {pk} withdrawal address does not match the vault address.',
+            match=re.escape(
+                f'Validator {pk} withdrawal address '
+                f'{target_validator.withdrawal_address} does not match '
+                f'the vault address {settings.vault}.'
+            ),
+        ):
+            selector.get_target_source()
+
+    def test_plain_consolidation_ignores_target_withdrawal_address(self):
+        """Only the source validators' withdrawal address must match the vault; the spec
+        does not check the target's credential address for a plain consolidation."""
+        source_pk = faker.validator_public_key()
+        target_pk = faker.validator_public_key()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source_pk],
+            target_public_key=target_pk,
+        )
+
+        consensus_validators = [
+            create_consensus_validator(
+                public_key=source_pk,
+                activation_epoch=1,
+                is_compounding=False,
+            ),
+            create_consensus_validator(
+                public_key=target_pk,
+                activation_epoch=1,
+                is_compounding=True,
+                withdrawal_address=faker.eth_address(),
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+        result = selector.get_target_source()
+        assert result == [(consensus_validators[1], consensus_validators[0])]
+
+    def test_rejects_bls_credential_source(self):
+        source_pk = faker.validator_public_key()
+        target_pk = faker.validator_public_key()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source_pk],
+            target_public_key=target_pk,
+        )
+
+        source_validator = create_consensus_validator(
+            public_key=source_pk,
+            activation_epoch=1,
+            is_compounding=False,
+        )
+        source_validator.withdrawal_credentials = HexStr(
+            '0x00' + '0' * 22 + faker.eth_address()[2:].lower()
+        )
+        consensus_validators = [
+            source_validator,
+            create_consensus_validator(
+                public_key=target_pk,
+                activation_epoch=1,
+                is_compounding=True,
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+
+        with pytest.raises(
+            ConsolidationError,
+            match=re.escape(
+                f'Validator {source_pk} withdrawal address '
+                f'{source_validator.withdrawal_address} does not match '
+                f'the vault address {settings.vault}.'
+            ),
         ):
             selector.get_target_source()
 

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -368,6 +368,29 @@ class TestConsolidationSelector:
             # is less than target 1's effective balance (32 + 32 = 64 ETH)
             assert result == [(consensus_validators[1], consensus_validators[2])]
 
+    def test_excludes_source_with_mismatched_withdrawal_address(self):
+        consensus_validators = [
+            create_consensus_validator(
+                index=10,
+                activation_epoch=1,
+                is_compounding=False,
+                withdrawal_address=faker.eth_address(),
+            ),
+            create_consensus_validator(
+                index=11,
+                activation_epoch=1,
+                is_compounding=False,
+            ),
+        ]
+        selector = create_manager(
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+        result = selector.get_target_source()
+        # Validator 10's credentials point elsewhere, so only validator 11 is
+        # a valid source candidate and switches from 0x01 to 0x02
+        assert result == [(consensus_validators[1], consensus_validators[1])]
+
     def test_excludes_validator_in_target_indexes_as_source(self):
         """Test that source validator is excluded if it's in consolidating_target_indexes"""
         consensus_validators = [
@@ -797,6 +820,66 @@ class TestConsolidationChecker:
                 f'Target validator {target_pk} is in exiting status '
                 f'{ValidatorStatus.ACTIVE_SLASHED.value}.'
             ),
+        ):
+            selector.get_target_source()
+
+    def test_rejects_source_with_mismatched_withdrawal_address(self):
+        source_pk = faker.validator_public_key()
+        target_pk = faker.validator_public_key()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[source_pk],
+            target_public_key=target_pk,
+        )
+
+        consensus_validators = [
+            create_consensus_validator(
+                public_key=source_pk,
+                activation_epoch=1,
+                is_compounding=False,
+                withdrawal_address=faker.eth_address(),
+            ),
+            create_consensus_validator(
+                public_key=target_pk,
+                activation_epoch=1,
+                is_compounding=True,
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+
+        with pytest.raises(
+            ConsolidationError,
+            match=f'Validator {source_pk} withdrawal address does not match the vault address.',
+        ):
+            selector.get_target_source()
+
+    def test_rejects_switch_target_with_mismatched_withdrawal_address(self):
+        pk = faker.validator_public_key()
+        consolidation_keys = ConsolidationKeys(
+            source_public_keys=[pk],
+            target_public_key=pk,
+        )
+
+        consensus_validators = [
+            create_consensus_validator(
+                public_key=pk,
+                activation_epoch=1,
+                is_compounding=False,
+                withdrawal_address=faker.eth_address(),
+            ),
+        ]
+        selector = create_manager(
+            consolidation_keys=consolidation_keys,
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+
+        with pytest.raises(
+            ConsolidationError,
+            match=f'Validator {pk} withdrawal address does not match the vault address.',
         ):
             selector.get_target_source()
 

--- a/src/validators/typings.py
+++ b/src/validators/typings.py
@@ -63,7 +63,7 @@ class ConsensusValidator:
 
     @property
     def withdrawal_address(self) -> ChecksumAddress:
-        return Web3.to_checksum_address('0x' + self.withdrawal_credentials[-40:])
+        return Web3.to_checksum_address(self.withdrawal_credentials[-40:])
 
     @property
     def withdrawal_capacity(self) -> Gwei:

--- a/src/validators/typings.py
+++ b/src/validators/typings.py
@@ -4,6 +4,7 @@ from typing import NewType
 from eth_typing import BlockNumber, BLSSignature, ChecksumAddress, HexStr
 from eth_utils import add_0x_prefix
 from sw_utils import ValidatorStatus
+from web3 import Web3
 from web3.types import Gwei, Wei
 
 from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI, settings
@@ -59,6 +60,10 @@ class ConsensusValidator:
     @property
     def is_compounding(self) -> bool:
         return self.withdrawal_credentials.startswith('0x02')
+
+    @property
+    def withdrawal_address(self) -> ChecksumAddress:
+        return Web3.to_checksum_address('0x' + self.withdrawal_credentials[-40:])
 
     @property
     def withdrawal_capacity(self) -> Gwei:


### PR DESCRIPTION
## Description

Per EIP-7251 `process_consolidation_request`, the consensus layer requires the source validator's `withdrawal_credentials` execution address to equal the request's `source_address` — for both consolidations and switch-to-compounding requests. Our requests use the vault as `source_address`, but the operator never compared the credential address to the vault: vault membership is checked only via contract event logs, which can diverge from live CL credential state. A mismatched source passes all app checks, the transaction succeeds, the fee is burned, and the CL silently drops the request while the CLI reports success.

Changes:
- `ConsensusValidator.withdrawal_address` property extracts the execution address from `withdrawal_credentials`.
- `ConsolidationChecker`: raises `ConsolidationError` when a source validator's (or switch target's) withdrawal address does not match the vault. The non-switch target branch is unchanged — the spec does not check the target's credential address.
- `ConsolidationSelector`: source candidates with a non-vault withdrawal address are skipped; the target candidate list is unaffected.

The check also implicitly covers the spec's `has_execution_withdrawal_credentials` requirement, since 0x00/BLS credentials cannot contain the vault address.