### PR TITLE
Add withdrawals tests

### DIFF
--- a/src/common/tests/test_withdrawals.py
+++ b/src/common/tests/test_withdrawals.py
@@ -1,0 +1,75 @@
+from unittest import mock
+
+import pytest
+from web3.types import Wei
+
+from src.common.execution import fake_exponential
+from src.common.tests.factories import create_chain_head
+from src.common.withdrawals import get_withdrawal_request_fee, get_withdrawals_count
+
+
+def test_fake_exponential_known_values():
+    # hand-computed reference vectors for factor * approx(e^(numerator/denominator))
+    assert fake_exponential(1, 0, 1) == 1
+    assert fake_exponential(1, 1, 1) == 2
+    assert fake_exponential(1, 2, 1) == 6
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestGetWithdrawalRequestFee:
+    async def test_zero_excess_returns_min_execution_request_fee(self):
+        with mock.patch(
+            'src.common.withdrawals.get_execution_withdrawals_count',
+            mock.AsyncMock(return_value=0),
+        ), mock.patch('src.common.withdrawals.execution_client', _execution_client_with_excess(0)):
+            fee = await get_withdrawal_request_fee(count=0, gap_count=0)
+
+        assert fee == Wei(1)
+
+    async def test_known_excess_matches_fake_exponential_formula(self):
+        # previous_excess=15, count(2) + gap_count(0) = 2 -> excess = 15 + 2 - target(2) = 15
+        # fake_exponential(MIN_EXECUTION_REQUEST_FEE=1, 15, EXECUTION_REQUEST_FEE_UPDATE_FRACTION=17) == 2
+        with mock.patch(
+            'src.common.withdrawals.get_execution_withdrawals_count',
+            mock.AsyncMock(return_value=0),
+        ), mock.patch('src.common.withdrawals.execution_client', _execution_client_with_excess(15)):
+            fee = await get_withdrawal_request_fee(count=2, gap_count=0)
+
+        assert fee == Wei(2)
+
+    async def test_higher_count_yields_a_higher_or_equal_fee(self):
+        with mock.patch(
+            'src.common.withdrawals.get_execution_withdrawals_count',
+            mock.AsyncMock(return_value=0),
+        ), mock.patch(
+            'src.common.withdrawals.execution_client', _execution_client_with_excess(100)
+        ):
+            low_count_fee = await get_withdrawal_request_fee(count=1)
+            high_count_fee = await get_withdrawal_request_fee(count=5)
+
+        assert high_count_fee > low_count_fee
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestGetWithdrawalsCount:
+    async def test_sums_consensus_list_length_and_execution_count(self):
+        chain_head = create_chain_head()
+        consensus_client_mock = mock.Mock(
+            get_pending_partial_withdrawals=mock.AsyncMock(return_value=[{}, {}, {}])
+        )
+
+        with mock.patch(
+            'src.common.withdrawals.get_execution_withdrawals_count',
+            mock.AsyncMock(return_value=7),
+        ), mock.patch('src.common.withdrawals.consensus_client', consensus_client_mock):
+            result = await get_withdrawals_count(chain_head)
+
+        assert result == 10
+
+
+def _execution_client_with_excess(previous_excess: int) -> mock.Mock:
+    client = mock.Mock()
+    client.eth.get_storage_at = mock.AsyncMock(
+        return_value=previous_excess.to_bytes(32, byteorder='big')
+    )
+    return client

--- a/src/common/tests/test_withdrawals.py
+++ b/src/common/tests/test_withdrawals.py
@@ -9,7 +9,7 @@ from src.common.withdrawals import get_withdrawal_request_fee, get_withdrawals_c
 
 
 def test_fake_exponential_known_values():
-    # hand-computed reference vectors for factor * approx(e^(numerator/denominator))
+    # reference vectors: factor * approx(e^(numerator/denominator))
     assert fake_exponential(1, 0, 1) == 1
     assert fake_exponential(1, 1, 1) == 2
     assert fake_exponential(1, 2, 1) == 6
@@ -27,8 +27,7 @@ class TestGetWithdrawalRequestFee:
         assert fee == Wei(1)
 
     async def test_known_excess_matches_fake_exponential_formula(self):
-        # previous_excess=15, count(2) + gap_count(0) = 2 -> excess = 15 + 2 - target(2) = 15
-        # fake_exponential(MIN_EXECUTION_REQUEST_FEE=1, 15, EXECUTION_REQUEST_FEE_UPDATE_FRACTION=17) == 2
+        # excess = previous_excess(15) + count(2) - target(2) = 15; fake_exponential(1, 15, 17) == 2
         with mock.patch(
             'src.common.withdrawals.get_execution_withdrawals_count',
             mock.AsyncMock(return_value=0),

--- a/src/common/tests/test_withdrawals.py
+++ b/src/common/tests/test_withdrawals.py
@@ -47,7 +47,7 @@ class TestGetWithdrawalRequestFee:
             low_count_fee = await get_withdrawal_request_fee(count=1)
             high_count_fee = await get_withdrawal_request_fee(count=5)
 
-        assert high_count_fee > low_count_fee
+        assert high_count_fee >= low_count_fee
 
 
 @pytest.mark.usefixtures('fake_settings')

--- a/src/withdrawals/tests/test_assets.py
+++ b/src/withdrawals/tests/test_assets.py
@@ -75,7 +75,7 @@ def test_calculate_validators_exits_amount():
 @pytest.mark.usefixtures('fake_settings')
 class TestGetQueuedAssets:
     async def test_missing_assets_wei_truncated_down_to_gwei(self):
-        # 5 gwei + 1 wei of dust must floor to 5 gwei, not round up
+        # 1 wei of dust must floor down, not round up
         missing_assets_wei = Wei(Web3.to_wei(5, 'gwei') + 1)
 
         with _patch(

--- a/src/withdrawals/tests/test_assets.py
+++ b/src/withdrawals/tests/test_assets.py
@@ -1,8 +1,15 @@
+import contextlib
+from unittest import mock
+
+import pytest
 from sw_utils import ValidatorStatus
 from web3 import Web3
+from web3.types import Gwei, Wei
 
+from src.common.tests.factories import create_chain_head
+from src.common.typings import PendingPartialWithdrawal
 from src.validators.tests.factories import create_consensus_validator
-from src.withdrawals.assets import _calculate_validators_exits_amount
+from src.withdrawals.assets import _calculate_validators_exits_amount, get_queued_assets
 
 
 def test_calculate_validators_exits_amount():
@@ -63,3 +70,72 @@ def test_calculate_validators_exits_amount():
         consensus_validators, oracle_exiting_validators, source_consolidations_indexes
     )
     assert result == Web3.to_wei(0, 'gwei')
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestGetQueuedAssets:
+    async def test_missing_assets_wei_truncated_down_to_gwei(self):
+        # 5 gwei + 1 wei of dust must floor to 5 gwei, not round up
+        missing_assets_wei = Wei(Web3.to_wei(5, 'gwei') + 1)
+
+        with _patch(
+            cumulative_tickets=0,
+            missing_assets=missing_assets_wei,
+        ) as mocks:
+            result = await get_queued_assets(
+                consensus_validators=[],
+                oracle_exiting_validators=[],
+                consolidations=[],
+                pending_partial_withdrawals=[],
+                chain_head=create_chain_head(),
+            )
+
+        assert result == Gwei(5)
+        mocks['missing_assets'].assert_awaited_once()
+
+    async def test_withdrawing_assets_sums_pending_partials_and_exiting_validators(self):
+        pending_partial_withdrawals = [
+            PendingPartialWithdrawal(validator_index=1, amount=Gwei(10)),
+            PendingPartialWithdrawal(validator_index=2, amount=Gwei(20)),
+        ]
+        consensus_validators = [
+            create_consensus_validator(
+                index=3, balance=Gwei(32), status=ValidatorStatus.ACTIVE_EXITING
+            ),
+        ]
+        oracle_exiting_validators = [
+            create_consensus_validator(index=4, balance=Gwei(16)),
+        ]
+        expected_withdrawing_assets = Web3.to_wei(10 + 20 + 32 + 16, 'gwei')
+
+        with _patch(cumulative_tickets=0, missing_assets=Wei(0)) as mocks:
+            await get_queued_assets(
+                consensus_validators=consensus_validators,
+                oracle_exiting_validators=oracle_exiting_validators,
+                consolidations=[],
+                pending_partial_withdrawals=pending_partial_withdrawals,
+                chain_head=create_chain_head(),
+            )
+
+        call_kwargs = mocks['missing_assets'].call_args.kwargs
+        params = call_kwargs['exit_queue_missing_assets_params']
+        assert params.withdrawing_assets == expected_withdrawing_assets
+
+
+@contextlib.contextmanager
+def _patch(cumulative_tickets: int, missing_assets: Wei):
+    get_harvest_params_mock = mock.AsyncMock(return_value=None)
+    cumulative_tickets_mock = mock.AsyncMock(return_value=cumulative_tickets)
+    missing_assets_mock = mock.AsyncMock(return_value=missing_assets)
+    with mock.patch(
+        'src.withdrawals.assets.get_harvest_params', get_harvest_params_mock
+    ), mock.patch.multiple(
+        'src.withdrawals.assets.validators_checker_contract',
+        get_exit_queue_cumulative_tickets=cumulative_tickets_mock,
+        get_exit_queue_missing_assets=missing_assets_mock,
+    ):
+        yield {
+            'harvest_params': get_harvest_params_mock,
+            'cumulative_tickets': cumulative_tickets_mock,
+            'missing_assets': missing_assets_mock,
+        }

--- a/src/withdrawals/tests/test_execution.py
+++ b/src/withdrawals/tests/test_execution.py
@@ -1,6 +1,16 @@
-from web3 import Web3
+from unittest import mock
 
-from src.withdrawals.execution import _encode_withdrawals
+import pytest
+from eth_typing import HexStr
+from hexbytes import HexBytes
+from web3 import Web3
+from web3.exceptions import ContractCustomError
+from web3.types import Gwei, Wei
+
+from src.withdrawals.execution import _encode_withdrawals, submit_withdraw_validators
+
+PUBLIC_KEY_1 = '0xb4e334000cd1991b0bcc3adddf2f6d3be32b737ab7728125033da35e9982112ec0a3d8a5a25a1858cf31d51b7305ce7a'
+PUBLIC_KEY_2 = '0xa1e334000cd1991b0bcc3adddf2f6d3be32b737ab7728125033da35e9982112ec0a3d8a5a25a1858cf31d51b7305ce7b'
 
 
 def test_encode_withdrawals():
@@ -9,4 +19,107 @@ def test_encode_withdrawals():
     }
     assert _encode_withdrawals(withdrawals) == Web3.to_bytes(
         hexstr='0xb4e334000cd1991b0bcc3adddf2f6d3be32b737ab7728125033da35e9982112ec0a3d8a5a25a1858cf31d51b7305ce7a00000000000003e8'
+    )
+
+
+def test_encode_withdrawals_concatenates_multiple_validators_in_dict_order():
+    withdrawals = {
+        PUBLIC_KEY_1: Gwei(1000),
+        PUBLIC_KEY_2: Gwei(2000),
+    }
+    encoded = _encode_withdrawals(withdrawals)
+
+    first_entry = Web3.to_bytes(hexstr=PUBLIC_KEY_1) + (1000).to_bytes(8, byteorder='big')
+    second_entry = Web3.to_bytes(hexstr=PUBLIC_KEY_2) + (2000).to_bytes(8, byteorder='big')
+    assert encoded == first_entry + second_entry
+
+
+def test_encode_withdrawals_amount_zero_encodes_as_eight_zero_bytes():
+    # amount=0 is EIP-7002 full-exit semantics, not an error
+    withdrawals = {PUBLIC_KEY_1: Gwei(0)}
+
+    encoded = _encode_withdrawals(withdrawals)
+
+    assert encoded[48:] == b'\x00' * 8
+
+
+def test_encode_withdrawals_large_amount_round_trips():
+    amount_gwei = Gwei(2048 * 10**9)  # 2048 ETH, MAX_EFFECTIVE_BALANCE_ELECTRA
+    withdrawals = {PUBLIC_KEY_1: amount_gwei}
+
+    encoded = _encode_withdrawals(withdrawals)
+
+    assert int.from_bytes(encoded[48:56], byteorder='big') == amount_gwei
+
+
+def test_encode_withdrawals_total_length_is_56_bytes_per_validator():
+    withdrawals = {
+        PUBLIC_KEY_1: Gwei(1),
+        PUBLIC_KEY_2: Gwei(2),
+    }
+
+    encoded = _encode_withdrawals(withdrawals)
+
+    assert len(encoded) == 56 * len(withdrawals)
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestSubmitWithdrawValidators:
+    withdrawals = {PUBLIC_KEY_1: Gwei(1000)}
+    tx_fee = Wei(123)
+    signature = HexStr('0x' + '11' * 65)
+
+    async def test_success_returns_tx_hash_and_passes_tx_fee_as_value(self):
+        tx_hash = HexBytes('0xab')
+        transact = mock.AsyncMock(return_value={'transactionHash': tx_hash})
+        vault_contract = _mock_vault_contract()
+
+        with _patch(vault_contract=vault_contract, transact=transact):
+            result = await submit_withdraw_validators(self.withdrawals, self.tx_fee, self.signature)
+
+        assert result == Web3.to_hex(tx_hash)
+        assert transact.call_args.kwargs['tx_params'] == {'value': self.tx_fee}
+
+    async def test_contract_custom_error_returns_none_without_raising(self):
+        transact = mock.AsyncMock(side_effect=ContractCustomError('reverted', data='0xdeadbeef'))
+        vault_contract = _mock_vault_contract(decoded_error='InvalidValidators()')
+
+        with _patch(vault_contract=vault_contract, transact=transact):
+            result = await submit_withdraw_validators(self.withdrawals, self.tx_fee, self.signature)
+
+        assert result is None
+        vault_contract.decode_custom_error.assert_called_once_with('0xdeadbeef')
+
+    async def test_generic_exception_returns_none_without_raising(self):
+        transact = mock.AsyncMock(side_effect=ValueError('boom'))
+        vault_contract = _mock_vault_contract()
+
+        with _patch(vault_contract=vault_contract, transact=transact):
+            result = await submit_withdraw_validators(self.withdrawals, self.tx_fee, self.signature)
+
+        assert result is None
+
+    async def test_none_tx_receipt_returns_none(self):
+        # tx_manager.transact already returns None on a failed/timed-out receipt
+        transact = mock.AsyncMock(return_value=None)
+        vault_contract = _mock_vault_contract()
+
+        with _patch(vault_contract=vault_contract, transact=transact):
+            result = await submit_withdraw_validators(self.withdrawals, self.tx_fee, self.signature)
+
+        assert result is None
+
+
+def _mock_vault_contract(decoded_error: str | None = None) -> mock.Mock:
+    vault_contract = mock.Mock()
+    vault_contract.functions.withdrawValidators = mock.Mock(return_value=mock.Mock())
+    vault_contract.decode_custom_error = mock.Mock(return_value=decoded_error)
+    return vault_contract
+
+
+def _patch(vault_contract: mock.Mock, transact: mock.AsyncMock):
+    return mock.patch.multiple(
+        'src.withdrawals.execution',
+        VaultContract=mock.Mock(return_value=vault_contract),
+        tx_manager=mock.Mock(transact=transact),
     )

--- a/src/withdrawals/tests/test_execution.py
+++ b/src/withdrawals/tests/test_execution.py
@@ -79,6 +79,10 @@ class TestSubmitWithdrawValidators:
 
         assert result == Web3.to_hex(tx_hash)
         assert transact.call_args.kwargs['tx_params'] == {'value': self.tx_fee}
+        vault_contract.functions.withdrawValidators.assert_called_once_with(
+            _encode_withdrawals(self.withdrawals),
+            Web3.to_bytes(hexstr=self.signature),
+        )
 
     async def test_contract_custom_error_returns_none_without_raising(self):
         transact = mock.AsyncMock(side_effect=ContractCustomError('reverted', data='0xdeadbeef'))

--- a/src/withdrawals/tests/test_execution.py
+++ b/src/withdrawals/tests/test_execution.py
@@ -104,7 +104,7 @@ class TestSubmitWithdrawValidators:
         assert result is None
 
     async def test_none_tx_receipt_returns_none(self):
-        # tx_manager.transact already returns None on a failed/timed-out receipt
+        # transact() returns None on a failed/timed-out receipt
         transact = mock.AsyncMock(return_value=None)
         vault_contract = _mock_vault_contract()
 

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -1336,18 +1336,26 @@ async def test_is_withdrawal_interval_passed_backfill_from_event(data_dir, reset
     assert result is False
 
 
-async def test_get_withdrawals_partial_topup_called_at_most_once(data_dir):
-    """`_get_partial_withdrawals` is invoked at most once per `_get_withdrawals` call
-    (top-branch partials-only path OR a single mid-loop top-up, never both), and
-    whenever it is invoked mid-loop it fully saturates the `queued_assets` it was
-    given, because `partial_capacity` is only ever an underestimate of real capacity
-    at that point.
-    """
+async def test_is_withdrawal_interval_passed_at_exact_boundary(data_dir, reset_app_state):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
-    settings.disable_full_withdrawals = False
-    chain_head = create_chain_head(epoch=500)
+    blocks_interval = WITHDRAWALS_INTERVAL // settings.network_config.SECONDS_PER_BLOCK
+    chain_head = create_chain_head(block_number=100_000, epoch=500)
 
-    scenarios = [
+    app_state = AppState()
+    app_state.partial_withdrawal_block = BlockNumber(chain_head.block_number - blocks_interval)
+
+    mixin = WithdrawalIntervalMixin()
+    result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
+
+    # source uses `>=` (src/withdrawals/tasks.py:68-69): at exactly `blocks_interval` blocks
+    # since the last withdrawal, the interval has not passed yet -- it only passes once
+    # the block number exceeds the interval by at least one block
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    ('queued_assets', 'consensus_validators'),
+    [
         # top-branch call: partial capacity alone is sufficient
         (
             ether_to_gwei(20),
@@ -1435,35 +1443,48 @@ async def test_get_withdrawals_partial_topup_called_at_most_once(data_dir):
                 ),
             ],
         ),
-    ]
+    ],
+    ids=['partials-only', 'single-topup', 'two-validator-topup', 'gate-never-fires'],
+)
+async def test_get_withdrawals_partial_topup_called_at_most_once(
+    data_dir, queued_assets, consensus_validators
+):
+    """`_get_partial_withdrawals` is invoked at most once per `_get_withdrawals` call
+    (top-branch partials-only path OR a single mid-loop top-up, never both), and
+    whenever it is invoked mid-loop it fully saturates the `queued_assets` it was
+    given, because `partial_capacity` is only ever an underestimate of real capacity
+    at that point.
+    """
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+    settings.disable_full_withdrawals = False
+    chain_head = create_chain_head(epoch=500)
 
-    for queued_assets, consensus_validators in scenarios:
-        calls: list[tuple[dict, dict]] = []
+    calls: list[tuple[dict, dict]] = []
 
-        def _spy(**kwargs):  # pylint: disable=cell-var-from-loop
-            result = _get_partial_withdrawals(**kwargs)
-            calls.append((kwargs, result))
-            return result
+    def _spy(**kwargs):
+        result = _get_partial_withdrawals(**kwargs)
+        calls.append((kwargs, result))
+        return result
 
-        with mock.patch('src.withdrawals.tasks._get_partial_withdrawals', side_effect=_spy):
-            await _get_withdrawals(
-                chain_head=chain_head,
-                queued_assets=queued_assets,
-                consensus_validators=consensus_validators,
-                pending_partial_withdrawals=[],
-                validator_min_active_epochs=10,
-                oracle_exit_indexes=set(),
-                consolidation_target_indexes=set(),
-                consolidation_source_indexes=set(),
-                pending_deposits={},
-            )
+    with mock.patch('src.withdrawals.tasks._get_partial_withdrawals', side_effect=_spy):
+        await _get_withdrawals(
+            chain_head=chain_head,
+            queued_assets=queued_assets,
+            consensus_validators=consensus_validators,
+            pending_partial_withdrawals=[],
+            validator_min_active_epochs=10,
+            oracle_exit_indexes=set(),
+            consolidation_target_indexes=set(),
+            consolidation_source_indexes=set(),
+            pending_deposits={},
+        )
 
-        assert len(calls) <= 1
-        if calls:
-            call_kwargs, call_result = calls[0]
-            requested = call_kwargs['queued_assets']
-            covered = sum(call_result.values())
-            assert requested == 0 or covered == requested
+    assert len(calls) <= 1
+    if calls:
+        call_kwargs, call_result = calls[0]
+        requested = call_kwargs['queued_assets']
+        covered = sum(call_result.values())
+        assert requested == 0 or covered == requested
 
 
 async def test_get_withdrawals_pending_deposit_asymmetry_pr_777(data_dir):

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -1487,13 +1487,13 @@ async def test_get_withdrawals_partial_topup_called_at_most_once(
         assert requested == 0 or covered == requested
 
 
-async def test_get_withdrawals_pending_deposit_asymmetry_pr_777(data_dir):
-    """Documents the deliberate #777 trade-off: the exitable-validator sort key credits
+async def test_get_withdrawals_pending_deposit_asymmetry(data_dir):
+    """Documents a deliberate trade-off: `_filter_exitable_validators`'s sort key credits
     pending deposits so a topped-up validator no longer sorts as "cheapest", but
-    `queued_assets` accounting still only ever subtracts a validator's real, current CL
-    balance once it is exited -- pending deposits are never credited even though they
-    eventually land back at the vault too. All validators here are 0x01 (non-compounding)
-    so `partial_capacity` plays no role and the effect is isolated.
+    `_get_withdrawals`'s `queued_assets` accounting still only ever subtracts a validator's
+    real, current CL balance once it is exited -- pending deposits are never credited even
+    though they eventually land back at the vault too. All validators here are 0x01
+    (non-compounding) so `partial_capacity` plays no role and the effect is isolated.
     """
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
     settings.disable_full_withdrawals = False

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -24,8 +24,7 @@ from src.withdrawals.tasks import (
 
 @pytest.fixture
 def reset_app_state():
-    """AppState is a process-wide singleton; drop the cached instance so each test starts
-    from a clean `partial_withdrawal_block`."""
+    """Drop the cached AppState singleton so each test starts with a clean state."""
     Singleton._instances.pop(AppState, None)
     yield
     Singleton._instances.pop(AppState, None)
@@ -1248,12 +1247,11 @@ async def test_fetch_oracle_exiting_validators():
     consensus_validators = [validator_1, validator_2]
     protocol_config = mock.MagicMock()
 
-    # intersection with vault validators only; oracle indexes not in vault are ignored
+    # index 99 isn't a vault validator; filtered out
     with mock.patch('src.withdrawals.tasks.poll_active_exits', return_value=[2, 99]):
         result = await _fetch_oracle_exiting_validators(consensus_validators, protocol_config)
     assert result == [validator_2]
 
-    # empty oracle response
     with mock.patch('src.withdrawals.tasks.poll_active_exits', return_value=[]):
         result = await _fetch_oracle_exiting_validators(consensus_validators, protocol_config)
     assert result == []
@@ -1307,8 +1305,7 @@ async def test_is_withdrawal_interval_passed_backfill_no_events(data_dir, reset_
         result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
 
     assert result is True
-    # no withdrawal events found: state falls back to from_block, not None, so the
-    # lookup isn't repeated on every subsequent block
+    # falls back to from_block, not None, to avoid repeating the lookup every block
     assert app_state.partial_withdrawal_block == from_block
 
 
@@ -1330,8 +1327,7 @@ async def test_is_withdrawal_interval_passed_backfill_from_event(data_dir, reset
         result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
 
     mocked_fetch.assert_awaited_once_with(BlockNumber(chain_head.block_number - blocks_interval))
-    # app state is back-filled from the event even though the interval turns out to have
-    # already passed again by the time of this check
+    # back-filled from the event even though the interval has passed again by now
     assert app_state.partial_withdrawal_block == backfilled_block
     assert result is False
 
@@ -1347,16 +1343,15 @@ async def test_is_withdrawal_interval_passed_at_exact_boundary(data_dir, reset_a
     mixin = WithdrawalIntervalMixin()
     result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
 
-    # source uses `>=` (src/withdrawals/tasks.py:68-69): at exactly `blocks_interval` blocks
-    # since the last withdrawal, the interval has not passed yet -- it only passes once
-    # the block number exceeds the interval by at least one block
+    # _is_withdrawal_interval_passed uses `>=`, so the interval hasn't passed yet at
+    # exactly blocks_interval blocks
     assert result is False
 
 
 @pytest.mark.parametrize(
     ('queued_assets', 'consensus_validators'),
     [
-        # top-branch call: partial capacity alone is sufficient
+        # top-branch: partial capacity alone is sufficient
         (
             ether_to_gwei(20),
             [
@@ -1376,7 +1371,7 @@ async def test_is_withdrawal_interval_passed_at_exact_boundary(data_dir, reset_a
                 ),
             ],
         ),
-        # mid-loop top-up after a single full exit
+        # mid-loop top-up after one full exit
         (
             ether_to_gwei(50),
             [
@@ -1396,7 +1391,7 @@ async def test_is_withdrawal_interval_passed_at_exact_boundary(data_dir, reset_a
                 ),
             ],
         ),
-        # mid-loop top-up spanning two remaining validators
+        # mid-loop top-up spans two validators
         (
             ether_to_gwei(86),
             [
@@ -1423,7 +1418,7 @@ async def test_is_withdrawal_interval_passed_at_exact_boundary(data_dir, reset_a
                 ),
             ],
         ),
-        # capacity never catches up with queued_assets -> gate never fires
+        # capacity never catches up with queued_assets
         (
             ether_to_gwei(100),
             [
@@ -1449,11 +1444,9 @@ async def test_is_withdrawal_interval_passed_at_exact_boundary(data_dir, reset_a
 async def test_get_withdrawals_partial_topup_called_at_most_once(
     data_dir, queued_assets, consensus_validators
 ):
-    """`_get_partial_withdrawals` is invoked at most once per `_get_withdrawals` call
-    (top-branch partials-only path OR a single mid-loop top-up, never both), and
-    whenever it is invoked mid-loop it fully saturates the `queued_assets` it was
-    given, because `partial_capacity` is only ever an underestimate of real capacity
-    at that point.
+    """`_get_partial_withdrawals` runs at most once per `_get_withdrawals` call, and a
+    mid-loop call always fully saturates `queued_assets` since `partial_capacity` only
+    ever underestimates real capacity at that point.
     """
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
     settings.disable_full_withdrawals = False
@@ -1488,12 +1481,10 @@ async def test_get_withdrawals_partial_topup_called_at_most_once(
 
 
 async def test_get_withdrawals_pending_deposit_asymmetry(data_dir):
-    """Documents a deliberate trade-off: `_filter_exitable_validators`'s sort key credits
-    pending deposits so a topped-up validator no longer sorts as "cheapest", but
-    `_get_withdrawals`'s `queued_assets` accounting still only ever subtracts a validator's
-    real, current CL balance once it is exited -- pending deposits are never credited even
-    though they eventually land back at the vault too. All validators here are 0x01
-    (non-compounding) so `partial_capacity` plays no role and the effect is isolated.
+    """`_filter_exitable_validators`'s sort key credits pending deposits, but
+    `_get_withdrawals`'s `queued_assets` subtraction only ever uses real CL balance --
+    deposits are never credited even once landed. Validators are 0x01 so
+    `partial_capacity` is not a factor.
     """
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
     settings.disable_full_withdrawals = False
@@ -1528,10 +1519,7 @@ async def test_get_withdrawals_pending_deposit_asymmetry(data_dir):
         consolidation_source_indexes=set(),
         pending_deposits={'0x1': ether_to_gwei(50)},
     )
-    # '0x1' sorts first (10 + 50 = 60 ETH effective, versus '0x2' at 70 ETH) and is exited
-    # first, but only its real 10 ETH balance is subtracted from queued_assets -- the 50 ETH
-    # pending deposit is not credited. That leaves 2 ETH still needed, so '0x2' (70 ETH, no
-    # pending deposits) is exited too, even though '0x1' alone would have more than covered
-    # the queue once its deposit lands. Both validators end up fully exited.
+    # '0x1' (10+50 effective) exits first but only 10 ETH counts against queued_assets,
+    # so '0x2' exits too
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
     assert result == expected

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -2,19 +2,33 @@ from unittest import mock
 
 import pytest
 from sw_utils import ValidatorStatus
+from web3.types import BlockNumber
 
+from src.common.app_state import AppState
 from src.common.tests.factories import create_chain_head
 from src.common.tests.utils import ether_to_gwei
-from src.common.typings import PendingPartialWithdrawal
+from src.common.typings import PendingPartialWithdrawal, Singleton
 from src.config.networks import HOODI
-from src.config.settings import settings
+from src.config.settings import WITHDRAWALS_INTERVAL, settings
 from src.validators.tests.factories import create_consensus_validator
 from src.withdrawals.tasks import (
+    WithdrawalIntervalMixin,
+    _fetch_oracle_exiting_validators,
     _filter_exitable_validators,
+    _filter_full_withdrawals,
     _get_partial_withdrawals,
     _get_withdrawals,
     _is_pending_partial_withdrawals_queue_full,
 )
+
+
+@pytest.fixture
+def reset_app_state():
+    """AppState is a process-wide singleton; drop the cached instance so each test starts
+    from a clean `partial_withdrawal_block`."""
+    Singleton._instances.pop(AppState, None)
+    yield
+    Singleton._instances.pop(AppState, None)
 
 
 def test_get_partial_withdrawals():
@@ -230,7 +244,6 @@ def test_get_partial_withdrawals():
     assert result == expected
 
 
-@pytest.mark.asyncio
 async def test_get_withdrawals(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 
@@ -816,7 +829,6 @@ async def test_get_withdrawals(data_dir):
     assert result == {}
 
 
-@pytest.mark.asyncio
 async def test_get_withdrawals_non_compounding_exit_does_not_reduce_partial_capacity(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 
@@ -871,7 +883,6 @@ async def test_get_withdrawals_non_compounding_exit_does_not_reduce_partial_capa
     assert result == expected
 
 
-@pytest.mark.asyncio
 async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 
@@ -1215,3 +1226,291 @@ def test_filter_exitable_validators():
         pending_deposits={},
     )
     assert len(result) == 0
+
+
+def test_filter_full_withdrawals():
+    withdrawals = {
+        '0x1': ether_to_gwei(0),
+        '0x2': ether_to_gwei(5),
+        '0x3': ether_to_gwei(0),
+    }
+    assert _filter_full_withdrawals(withdrawals) == ['0x1', '0x3']
+    assert _filter_full_withdrawals({}) == []
+
+
+async def test_fetch_oracle_exiting_validators():
+    validator_1 = create_consensus_validator(
+        public_key='0x1', index=1, status=ValidatorStatus.ACTIVE_ONGOING, balance=ether_to_gwei(32)
+    )
+    validator_2 = create_consensus_validator(
+        public_key='0x2', index=2, status=ValidatorStatus.ACTIVE_ONGOING, balance=ether_to_gwei(32)
+    )
+    consensus_validators = [validator_1, validator_2]
+    protocol_config = mock.MagicMock()
+
+    # intersection with vault validators only; oracle indexes not in vault are ignored
+    with mock.patch('src.withdrawals.tasks.poll_active_exits', return_value=[2, 99]):
+        result = await _fetch_oracle_exiting_validators(consensus_validators, protocol_config)
+    assert result == [validator_2]
+
+    # empty oracle response
+    with mock.patch('src.withdrawals.tasks.poll_active_exits', return_value=[]):
+        result = await _fetch_oracle_exiting_validators(consensus_validators, protocol_config)
+    assert result == []
+
+
+async def test_is_withdrawal_interval_passed_not_reached(data_dir, reset_app_state):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+    blocks_interval = WITHDRAWALS_INTERVAL // settings.network_config.SECONDS_PER_BLOCK
+    chain_head = create_chain_head(block_number=100_000, epoch=500)
+
+    app_state = AppState()
+    app_state.partial_withdrawal_block = BlockNumber(
+        chain_head.block_number - blocks_interval + 1000
+    )
+
+    mixin = WithdrawalIntervalMixin()
+    result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
+
+    assert result is False
+
+
+async def test_is_withdrawal_interval_passed_reached(data_dir, reset_app_state):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+    blocks_interval = WITHDRAWALS_INTERVAL // settings.network_config.SECONDS_PER_BLOCK
+    chain_head = create_chain_head(block_number=100_000, epoch=500)
+
+    app_state = AppState()
+    app_state.partial_withdrawal_block = BlockNumber(
+        chain_head.block_number - blocks_interval - 1000
+    )
+
+    mixin = WithdrawalIntervalMixin()
+    result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
+
+    assert result is True
+
+
+async def test_is_withdrawal_interval_passed_backfill_no_events(data_dir, reset_app_state):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+    blocks_interval = WITHDRAWALS_INTERVAL // settings.network_config.SECONDS_PER_BLOCK
+    chain_head = create_chain_head(block_number=100_000, epoch=500)
+    from_block = BlockNumber(chain_head.block_number - blocks_interval)
+
+    app_state = AppState()
+    assert app_state.partial_withdrawal_block is None
+
+    mixin = WithdrawalIntervalMixin()
+    with mock.patch.object(
+        WithdrawalIntervalMixin, '_fetch_last_withdrawals_block', return_value=None
+    ):
+        result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
+
+    assert result is True
+    # no withdrawal events found: state falls back to from_block, not None, so the
+    # lookup isn't repeated on every subsequent block
+    assert app_state.partial_withdrawal_block == from_block
+
+
+async def test_is_withdrawal_interval_passed_backfill_from_event(data_dir, reset_app_state):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+    blocks_interval = WITHDRAWALS_INTERVAL // settings.network_config.SECONDS_PER_BLOCK
+    chain_head = create_chain_head(block_number=100_000, epoch=500)
+    backfilled_block = BlockNumber(chain_head.block_number - blocks_interval + 1500)
+
+    app_state = AppState()
+    assert app_state.partial_withdrawal_block is None
+
+    mixin = WithdrawalIntervalMixin()
+    with mock.patch.object(
+        WithdrawalIntervalMixin,
+        '_fetch_last_withdrawals_block',
+        return_value=backfilled_block,
+    ) as mocked_fetch:
+        result = await mixin._is_withdrawal_interval_passed(app_state, chain_head)
+
+    mocked_fetch.assert_awaited_once_with(BlockNumber(chain_head.block_number - blocks_interval))
+    # app state is back-filled from the event even though the interval turns out to have
+    # already passed again by the time of this check
+    assert app_state.partial_withdrawal_block == backfilled_block
+    assert result is False
+
+
+async def test_get_withdrawals_partial_topup_called_at_most_once(data_dir):
+    """`_get_partial_withdrawals` is invoked at most once per `_get_withdrawals` call
+    (top-branch partials-only path OR a single mid-loop top-up, never both), and
+    whenever it is invoked mid-loop it fully saturates the `queued_assets` it was
+    given, because `partial_capacity` is only ever an underestimate of real capacity
+    at that point.
+    """
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+    settings.disable_full_withdrawals = False
+    chain_head = create_chain_head(epoch=500)
+
+    scenarios = [
+        # top-branch call: partial capacity alone is sufficient
+        (
+            ether_to_gwei(20),
+            [
+                create_consensus_validator(
+                    public_key='0x1',
+                    index=1,
+                    balance=ether_to_gwei(40),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=200,
+                ),
+                create_consensus_validator(
+                    public_key='0x2',
+                    index=2,
+                    balance=ether_to_gwei(50),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=200,
+                ),
+            ],
+        ),
+        # mid-loop top-up after a single full exit
+        (
+            ether_to_gwei(50),
+            [
+                create_consensus_validator(
+                    public_key='0x1',
+                    index=1,
+                    balance=ether_to_gwei(40),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=90,
+                ),
+                create_consensus_validator(
+                    public_key='0x2',
+                    index=2,
+                    balance=ether_to_gwei(43),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=85,
+                ),
+            ],
+        ),
+        # mid-loop top-up spanning two remaining validators
+        (
+            ether_to_gwei(86),
+            [
+                create_consensus_validator(
+                    public_key='0x1',
+                    index=1,
+                    balance=ether_to_gwei(40),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=90,
+                ),
+                create_consensus_validator(
+                    public_key='0x2',
+                    index=2,
+                    balance=ether_to_gwei(50),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=85,
+                ),
+                create_consensus_validator(
+                    public_key='0x3',
+                    index=3,
+                    balance=ether_to_gwei(60),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=80,
+                ),
+            ],
+        ),
+        # capacity never catches up with queued_assets -> gate never fires
+        (
+            ether_to_gwei(100),
+            [
+                create_consensus_validator(
+                    public_key='0x1',
+                    index=1,
+                    balance=ether_to_gwei(40),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=90,
+                ),
+                create_consensus_validator(
+                    public_key='0x2',
+                    index=2,
+                    balance=ether_to_gwei(50),
+                    status=ValidatorStatus.ACTIVE_ONGOING,
+                    activation_epoch=85,
+                ),
+            ],
+        ),
+    ]
+
+    for queued_assets, consensus_validators in scenarios:
+        calls: list[tuple[dict, dict]] = []
+
+        def _spy(**kwargs):  # pylint: disable=cell-var-from-loop
+            result = _get_partial_withdrawals(**kwargs)
+            calls.append((kwargs, result))
+            return result
+
+        with mock.patch('src.withdrawals.tasks._get_partial_withdrawals', side_effect=_spy):
+            await _get_withdrawals(
+                chain_head=chain_head,
+                queued_assets=queued_assets,
+                consensus_validators=consensus_validators,
+                pending_partial_withdrawals=[],
+                validator_min_active_epochs=10,
+                oracle_exit_indexes=set(),
+                consolidation_target_indexes=set(),
+                consolidation_source_indexes=set(),
+                pending_deposits={},
+            )
+
+        assert len(calls) <= 1
+        if calls:
+            call_kwargs, call_result = calls[0]
+            requested = call_kwargs['queued_assets']
+            covered = sum(call_result.values())
+            assert requested == 0 or covered == requested
+
+
+async def test_get_withdrawals_pending_deposit_asymmetry_pr_777(data_dir):
+    """Documents the deliberate #777 trade-off: the exitable-validator sort key credits
+    pending deposits so a topped-up validator no longer sorts as "cheapest", but
+    `queued_assets` accounting still only ever subtracts a validator's real, current CL
+    balance once it is exited -- pending deposits are never credited even though they
+    eventually land back at the vault too. All validators here are 0x01 (non-compounding)
+    so `partial_capacity` plays no role and the effect is isolated.
+    """
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+    settings.disable_full_withdrawals = False
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(12)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            index=1,
+            balance=ether_to_gwei(10),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+            is_compounding=False,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            index=2,
+            balance=ether_to_gwei(70),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=85,
+            is_compounding=False,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes=set(),
+        consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
+        pending_deposits={'0x1': ether_to_gwei(50)},
+    )
+    # '0x1' sorts first (10 + 50 = 60 ETH effective, versus '0x2' at 70 ETH) and is exited
+    # first, but only its real 10 ETH balance is subtracted from queued_assets -- the 50 ETH
+    # pending deposit is not credited. That leaves 2 ETH still needed, so '0x2' (70 ETH, no
+    # pending deposits) is exited too, even though '0x1' alone would have more than covered
+    # the queue once its deposit lands. Both validators end up fully exited.
+    expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
+    assert result == expected


### PR DESCRIPTION
## Description

Adds test coverage for the withdrawals flow:

- `src/common/tests/test_withdrawals.py` (new): `fake_exponential` reference vectors, `get_withdrawal_request_fee` (zero/known excess, fee monotonicity), and `get_withdrawals_count`.
- `src/withdrawals/tests/test_assets.py`: `get_queued_assets` — wei-to-gwei truncation of missing assets and withdrawing-assets aggregation from pending partials plus exiting validators.
- `src/withdrawals/tests/test_execution.py`: `_encode_withdrawals` (multi-validator concatenation, zero-amount full-exit encoding, large amounts, entry length) and `submit_withdraw_validators` (success path, contract/generic error handling, failed receipt).
- `src/withdrawals/tests/test_tasks.py`: `_filter_full_withdrawals`, `_fetch_oracle_exiting_validators`, `WithdrawalIntervalMixin._is_withdrawal_interval_passed` (interval checks and event back-fill), and `_get_withdrawals` partial top-up/pending-deposit behavior.