### PR TITLE
Verify target withdrawal address matches the vault in consolidations

### DIFF
--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -113,6 +113,7 @@ class ConsolidationManager(ABC):
         - active
         - not consolidating to another validator
         - a compounding validator
+        - withdrawal address matches the vault
 
         # For switch from 0x01 to 0x02:
         - source and target public keys are the same
@@ -205,13 +206,16 @@ class ConsolidationSelector(ConsolidationManager):
                 continue
             if val.activation_epoch > self.chain_head.epoch:
                 continue
+            # A mismatched target is executed by the CL and moves the sources' balance
+            # into a validator the vault cannot withdraw from, unlike a mismatched source
+            # which the CL silently ignores.
+            if val.withdrawal_address != settings.vault:
+                continue
             target_validators.append(val)
 
             # additional filters for source validators
             # Source validator must be non-compounding
             if val.is_compounding:
-                continue
-            if val.withdrawal_address != settings.vault:
                 continue
             if val.activation_epoch > self.max_activation_epoch:
                 continue
@@ -388,6 +392,13 @@ class ConsolidationChecker(ConsolidationManager):
             if target_validator.activation_epoch > self.chain_head.epoch:
                 raise ConsolidationError(
                     f'Target validator {self.target_public_key} is not active.'
+                )
+            # Unlike a mismatched source, a mismatched target is executed by the CL
+            if target_validator.withdrawal_address != settings.vault:
+                raise ConsolidationError(
+                    f'Validator {self.target_public_key} withdrawal address '
+                    f'{target_validator.withdrawal_address} does not match '
+                    f'the vault address {settings.vault}.'
                 )
         return target_validator
 

--- a/src/validators/consolidation_manager.py
+++ b/src/validators/consolidation_manager.py
@@ -206,9 +206,6 @@ class ConsolidationSelector(ConsolidationManager):
                 continue
             if val.activation_epoch > self.chain_head.epoch:
                 continue
-            # A mismatched target is executed by the CL and moves the sources' balance
-            # into a validator the vault cannot withdraw from, unlike a mismatched source
-            # which the CL silently ignores.
             if val.withdrawal_address != settings.vault:
                 continue
             target_validators.append(val)
@@ -393,7 +390,6 @@ class ConsolidationChecker(ConsolidationManager):
                 raise ConsolidationError(
                     f'Target validator {self.target_public_key} is not active.'
                 )
-            # Unlike a mismatched source, a mismatched target is executed by the CL
             if target_validator.withdrawal_address != settings.vault:
                 raise ConsolidationError(
                     f'Validator {self.target_public_key} withdrawal address '

--- a/src/validators/tests/test_consolidation_manager.py
+++ b/src/validators/tests/test_consolidation_manager.py
@@ -393,6 +393,32 @@ class TestConsolidationSelector:
         # a valid source candidate and switches from 0x01 to 0x02
         assert result == [(consensus_validators[1], consensus_validators[1])]
 
+    def test_excludes_target_with_mismatched_withdrawal_address(self):
+        """A mismatched target is executed by the CL (unlike a mismatched source, which the
+        CL silently ignores), moving the sources' balance into a validator the vault cannot
+        withdraw from, so it must be excluded from the target candidates entirely."""
+        consensus_validators = [
+            create_consensus_validator(
+                index=10,
+                activation_epoch=1,
+                is_compounding=False,
+            ),
+            create_consensus_validator(
+                index=11,
+                activation_epoch=1,
+                is_compounding=True,
+                withdrawal_address=faker.eth_address(),
+            ),
+        ]
+        selector = create_manager(
+            vault_validators=[v.public_key for v in consensus_validators],
+            consensus_validators=consensus_validators,
+        )
+        result = selector.get_target_source()
+        # Validator 11's credentials point elsewhere, so it can't be a target candidate;
+        # falls back to switching validator 10 from 0x01 to 0x02
+        assert result == [(consensus_validators[0], consensus_validators[0])]
+
     def test_picks_active_target_over_pending_target_with_smaller_balance(self):
         """A pending (not-yet-active) 0x02 validator must never be chosen as target,
         even if its balance is smaller than an active 0x02 candidate's."""
@@ -969,9 +995,10 @@ class TestConsolidationChecker:
         ):
             selector.get_target_source()
 
-    def test_plain_consolidation_ignores_target_withdrawal_address(self):
-        """Only the source validators' withdrawal address must match the vault; the spec
-        does not check the target's credential address for a plain consolidation."""
+    def test_rejects_plain_consolidation_target_with_mismatched_withdrawal_address(self):
+        """A mismatched target is executed by the CL (unlike a mismatched source, which the
+        CL silently ignores), moving the sources' balance into a validator the vault cannot
+        withdraw from. The target's withdrawal address must therefore match the vault too."""
         source_pk = faker.validator_public_key()
         target_pk = faker.validator_public_key()
         consolidation_keys = ConsolidationKeys(
@@ -997,8 +1024,17 @@ class TestConsolidationChecker:
             vault_validators=[v.public_key for v in consensus_validators],
             consensus_validators=consensus_validators,
         )
-        result = selector.get_target_source()
-        assert result == [(consensus_validators[1], consensus_validators[0])]
+
+        target_validator = consensus_validators[1]
+        with pytest.raises(
+            ConsolidationError,
+            match=re.escape(
+                f'Validator {target_pk} withdrawal address '
+                f'{target_validator.withdrawal_address} does not match '
+                f'the vault address {settings.vault}.'
+            ),
+        ):
+            selector.get_target_source()
 
     def test_rejects_bls_credential_source(self):
         source_pk = faker.validator_public_key()


### PR DESCRIPTION
## Description

Consolidation sources are checked for a vault-matching withdrawal address, but plain-consolidation targets were not. The consensus layer silently ignores a consolidation whose source withdrawal address does not match the request, while a consolidation into a target with foreign withdrawal credentials is executed — moving the sources' balance into a validator the vault cannot withdraw from.

- `ConsolidationSelector._find_validators_candidates`: exclude validators whose withdrawal address does not match the vault from target candidacy (the check now covers both source and target roles).
- `ConsolidationChecker._validate_target_validator`: reject a plain-consolidation target whose withdrawal address does not match the vault, consistent with the existing source check.