### PR TITLE
Account for pending consolidations in validators funding

### DIFF
--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -10,7 +10,6 @@ from web3.types import Gwei
 from src.common.clients import consensus_client
 from src.common.consensus import get_chain_latest_head
 from src.common.consolidations import get_pending_consolidations
-from src.common.typings import PendingConsolidation
 from src.config.settings import settings
 from src.validators.database import VaultValidatorCrud
 from src.validators.event_processors import get_latest_vault_v2_validator_public_keys
@@ -24,6 +23,7 @@ EXITING_STATUSES = [
 logger = logging.getLogger(__name__)
 
 
+# pylint: disable-next=too-many-locals
 async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     """
     Retrieves the consensus balances of vault validators eligible for funding.
@@ -38,8 +38,7 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     fundable set rather than guessed at.
     """
     vault_public_keys = {v.public_key for v in VaultValidatorCrud().get_vault_validators()}
-    non_finalized_public_keys = await get_latest_vault_v2_validator_public_keys(settings.vault)
-    vault_public_keys.update(non_finalized_public_keys)
+    vault_public_keys.update(await get_latest_vault_v2_validator_public_keys(settings.vault))
     if not vault_public_keys:
         return {}
 
@@ -48,26 +47,38 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     slot = str(chain_head.slot)
     consensus_validators = await fetch_consensus_validators(list(vault_public_keys), slot=slot)
     pending_consolidations = await get_pending_consolidations(chain_head, consensus_validators)
-    incoming_balances, non_fundable_public_keys = _fold_pending_consolidations(
-        consensus_validators, pending_consolidations
-    )
 
-    # Filter compounding and remove exiting/withdrawn/non-fundable validators, as they are
-    # not eligible for funding. Consolidation targets get the incoming source balance
-    # added on top of their own.
+    # Filter compounding and remove exiting/withdrawn validators, as they are not
+    # eligible for funding.
     validators_balances: dict[HexStr, Gwei] = {}
     ineligible_public_keys: set[HexStr] = set()
+    index_to_validator: dict[int, ConsensusValidator] = {}
     for validator in consensus_validators:
-        if (
-            validator.is_compounding
-            and validator.status not in EXITING_STATUSES
-            and validator.public_key not in non_fundable_public_keys
-        ):
-            validators_balances[validator.public_key] = Gwei(
-                validator.balance + incoming_balances[validator.index]
-            )
+        index_to_validator[validator.index] = validator
+        if validator.is_compounding and validator.status not in EXITING_STATUSES:
+            validators_balances[validator.public_key] = validator.balance
         else:
             ineligible_public_keys.add(validator.public_key)
+
+    # Adjust for pending consolidations: a source keeps compounding until the
+    # consolidation is processed, so it must never be funded; the target should be
+    # funded against the balance it will actually hold once the consolidation lands
+    # (its own balance plus the incoming source balance). If the source's balance
+    # can't be determined, conservatively drop the target instead of guessing.
+    for cons in pending_consolidations:
+        target = index_to_validator.get(cons.target_index)
+        source = index_to_validator.get(cons.source_index)
+        if source is None:
+            if target is not None:
+                validators_balances.pop(target.public_key, None)
+                ineligible_public_keys.add(target.public_key)
+        else:
+            validators_balances.pop(source.public_key, None)
+            ineligible_public_keys.add(source.public_key)
+            if target is not None and target.public_key in validators_balances:
+                validators_balances[target.public_key] = Gwei(
+                    validators_balances[target.public_key] + source.balance
+                )
 
     # Keys not yet known to the consensus node are eligible too,
     # their balances come solely from pending deposits.
@@ -140,39 +151,3 @@ async def fetch_consensus_validators(
             validators.append(ConsensusValidator.from_consensus_data(beacon_validator))
 
     return validators
-
-
-def _fold_pending_consolidations(
-    consensus_validators: list[ConsensusValidator],
-    pending_consolidations: list[PendingConsolidation],
-) -> tuple[defaultdict[int, Gwei], set[HexStr]]:
-    """
-    Sums each pending consolidation's source balance onto its target's incoming balance,
-    since that is what the target will actually hold once the consolidation is processed.
-    Also reports public keys that must be excluded from the fundable set: consolidation
-    sources (always, since they keep compounding until processed), and targets whose
-    source balance is unknown (conservatively excluded rather than guessed at).
-    """
-    index_to_balance: dict[int, Gwei] = {val.index: val.balance for val in consensus_validators}
-    index_to_public_key: dict[int, HexStr] = {
-        val.index: val.public_key for val in consensus_validators
-    }
-
-    incoming_balances: defaultdict[int, Gwei] = defaultdict(lambda: Gwei(0))
-    non_fundable_public_keys: set[HexStr] = set()
-    for cons in pending_consolidations:
-        source_public_key = index_to_public_key.get(cons.source_index)
-        if source_public_key is not None:
-            non_fundable_public_keys.add(source_public_key)
-
-        source_balance = index_to_balance.get(cons.source_index)
-        if source_balance is None:
-            target_public_key = index_to_public_key.get(cons.target_index)
-            if target_public_key is not None:
-                non_fundable_public_keys.add(target_public_key)
-            continue
-        incoming_balances[cons.target_index] = Gwei(
-            incoming_balances[cons.target_index] + source_balance
-        )
-
-    return incoming_balances, non_fundable_public_keys

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -8,6 +8,9 @@ from sw_utils.consensus import EXITED_STATUSES
 from web3.types import Gwei
 
 from src.common.clients import consensus_client
+from src.common.consensus import get_chain_latest_head
+from src.common.consolidations import get_pending_consolidations
+from src.common.typings import PendingConsolidation
 from src.config.settings import settings
 from src.validators.database import VaultValidatorCrud
 from src.validators.event_processors import get_latest_vault_v2_validator_public_keys
@@ -24,8 +27,15 @@ logger = logging.getLogger(__name__)
 async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     """
     Retrieves the consensus balances of vault validators eligible for funding.
-    Includes balances from pending deposits
-    that have not yet been processed by the consensus node.
+    Includes balances from pending deposits that have not yet been processed by the
+    consensus node.
+
+    Pending consolidations are folded in too: a consolidation source keeps compounding
+    until it is processed, so it is excluded from the fundable set entirely, and its
+    balance is credited onto the target instead of the target's raw (pre-consolidation)
+    balance, since that is what the target will actually hold once the consolidation
+    lands. If a source's balance can't be determined, the target is dropped from the
+    fundable set rather than guessed at.
     """
     vault_public_keys = {v.public_key for v in VaultValidatorCrud().get_vault_validators()}
     non_finalized_public_keys = await get_latest_vault_v2_validator_public_keys(settings.vault)
@@ -33,20 +43,21 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     if not vault_public_keys:
         return {}
 
-    # Fetch consensus validators
-    consensus_block = await consensus_client.get_block('head')
-    slot = consensus_block['data']['message']['slot']
+    # Fetch consensus validators and pending consolidations from one consistent snapshot
+    chain_head = await get_chain_latest_head()
+    slot = str(chain_head.slot)
     consensus_validators = await fetch_consensus_validators(list(vault_public_keys), slot=slot)
+    pending_consolidations = await get_pending_consolidations(chain_head, consensus_validators)
+    incoming_balances, unfundable_target_public_keys, consolidating_source_public_keys = (
+        _fold_pending_consolidations(consensus_validators, pending_consolidations)
+    )
 
-    # Filter compounding and remove exiting/withdrawn validators,
-    # as they are not eligible for funding
-    validators_balances: dict[HexStr, Gwei] = {}
-    ineligible_public_keys: set[HexStr] = set()
-    for validator in consensus_validators:
-        if validator.is_compounding and validator.status not in EXITING_STATUSES:
-            validators_balances[validator.public_key] = validator.balance
-        else:
-            ineligible_public_keys.add(validator.public_key)
+    # Filter compounding and remove exiting/withdrawn/consolidation-source validators,
+    # as they are not eligible for funding. Consolidation targets get the incoming
+    # source balance added on top of their own.
+    validators_balances, ineligible_public_keys = _build_fundable_balances(
+        consensus_validators, incoming_balances, consolidating_source_public_keys
+    )
 
     # Keys not yet known to the consensus node are eligible too,
     # their balances come solely from pending deposits.
@@ -56,12 +67,9 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     pending_deposits_amounts = await fetch_compounding_pending_deposits_amounts(
         public_keys=eligible_public_keys, slot=slot
     )
-    for public_key, amount in pending_deposits_amounts.items():
-        validators_balances[public_key] = Gwei(
-            validators_balances.get(public_key, Gwei(0)) + amount
-        )
-
-    return validators_balances
+    return _finalize_validators_balances(
+        validators_balances, pending_deposits_amounts, unfundable_target_public_keys
+    )
 
 
 async def fetch_compounding_pending_deposits_amounts(
@@ -119,3 +127,76 @@ async def fetch_consensus_validators(
             validators.append(ConsensusValidator.from_consensus_data(beacon_validator))
 
     return validators
+
+
+def _fold_pending_consolidations(
+    consensus_validators: list[ConsensusValidator],
+    pending_consolidations: list[PendingConsolidation],
+) -> tuple[defaultdict[int, Gwei], set[HexStr], set[HexStr]]:
+    """
+    Sums each pending consolidation's source balance onto its target's incoming balance,
+    since that is what the target will actually hold once the consolidation is processed.
+    Also reports which public keys must be excluded from the fundable set: consolidation
+    sources (always, since they keep compounding until processed), and targets whose
+    source balance is unknown (conservatively excluded rather than guessed at).
+    """
+    index_to_balance: dict[int, Gwei] = {val.index: val.balance for val in consensus_validators}
+    index_to_public_key: dict[int, HexStr] = {
+        val.index: val.public_key for val in consensus_validators
+    }
+
+    incoming_balances: defaultdict[int, Gwei] = defaultdict(lambda: Gwei(0))
+    unfundable_target_public_keys: set[HexStr] = set()
+    consolidating_source_public_keys: set[HexStr] = set()
+    for cons in pending_consolidations:
+        source_public_key = index_to_public_key.get(cons.source_index)
+        if source_public_key is not None:
+            consolidating_source_public_keys.add(source_public_key)
+
+        source_balance = index_to_balance.get(cons.source_index)
+        if source_balance is None:
+            target_public_key = index_to_public_key.get(cons.target_index)
+            if target_public_key is not None:
+                unfundable_target_public_keys.add(target_public_key)
+            continue
+        incoming_balances[cons.target_index] = Gwei(
+            incoming_balances[cons.target_index] + source_balance
+        )
+
+    return incoming_balances, unfundable_target_public_keys, consolidating_source_public_keys
+
+
+def _build_fundable_balances(
+    consensus_validators: list[ConsensusValidator],
+    incoming_balances: defaultdict[int, Gwei],
+    consolidating_source_public_keys: set[HexStr],
+) -> tuple[dict[HexStr, Gwei], set[HexStr]]:
+    validators_balances: dict[HexStr, Gwei] = {}
+    ineligible_public_keys: set[HexStr] = set(consolidating_source_public_keys)
+    for validator in consensus_validators:
+        if validator.public_key in consolidating_source_public_keys:
+            continue
+        if validator.is_compounding and validator.status not in EXITING_STATUSES:
+            validators_balances[validator.public_key] = Gwei(
+                validator.balance + incoming_balances[validator.index]
+            )
+        else:
+            ineligible_public_keys.add(validator.public_key)
+
+    return validators_balances, ineligible_public_keys
+
+
+def _finalize_validators_balances(
+    validators_balances: dict[HexStr, Gwei],
+    pending_deposits_amounts: dict[HexStr, Gwei],
+    unfundable_target_public_keys: set[HexStr],
+) -> dict[HexStr, Gwei]:
+    for public_key, amount in pending_deposits_amounts.items():
+        validators_balances[public_key] = Gwei(
+            validators_balances.get(public_key, Gwei(0)) + amount
+        )
+
+    for target_public_key in unfundable_target_public_keys:
+        validators_balances.pop(target_public_key, None)
+
+    return validators_balances

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -48,16 +48,26 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     slot = str(chain_head.slot)
     consensus_validators = await fetch_consensus_validators(list(vault_public_keys), slot=slot)
     pending_consolidations = await get_pending_consolidations(chain_head, consensus_validators)
-    incoming_balances, unfundable_target_public_keys, consolidating_source_public_keys = (
-        _fold_pending_consolidations(consensus_validators, pending_consolidations)
+    incoming_balances, non_fundable_public_keys = _fold_pending_consolidations(
+        consensus_validators, pending_consolidations
     )
 
-    # Filter compounding and remove exiting/withdrawn/consolidation-source validators,
-    # as they are not eligible for funding. Consolidation targets get the incoming
-    # source balance added on top of their own.
-    validators_balances, ineligible_public_keys = _build_fundable_balances(
-        consensus_validators, incoming_balances, consolidating_source_public_keys
-    )
+    # Filter compounding and remove exiting/withdrawn/non-fundable validators, as they are
+    # not eligible for funding. Consolidation targets get the incoming source balance
+    # added on top of their own.
+    validators_balances: dict[HexStr, Gwei] = {}
+    ineligible_public_keys: set[HexStr] = set()
+    for validator in consensus_validators:
+        if (
+            validator.is_compounding
+            and validator.status not in EXITING_STATUSES
+            and validator.public_key not in non_fundable_public_keys
+        ):
+            validators_balances[validator.public_key] = Gwei(
+                validator.balance + incoming_balances[validator.index]
+            )
+        else:
+            ineligible_public_keys.add(validator.public_key)
 
     # Keys not yet known to the consensus node are eligible too,
     # their balances come solely from pending deposits.
@@ -67,9 +77,12 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     pending_deposits_amounts = await fetch_compounding_pending_deposits_amounts(
         public_keys=eligible_public_keys, slot=slot
     )
-    return _finalize_validators_balances(
-        validators_balances, pending_deposits_amounts, unfundable_target_public_keys
-    )
+    for public_key, amount in pending_deposits_amounts.items():
+        validators_balances[public_key] = Gwei(
+            validators_balances.get(public_key, Gwei(0)) + amount
+        )
+
+    return validators_balances
 
 
 async def fetch_compounding_pending_deposits_amounts(
@@ -132,11 +145,11 @@ async def fetch_consensus_validators(
 def _fold_pending_consolidations(
     consensus_validators: list[ConsensusValidator],
     pending_consolidations: list[PendingConsolidation],
-) -> tuple[defaultdict[int, Gwei], set[HexStr], set[HexStr]]:
+) -> tuple[defaultdict[int, Gwei], set[HexStr]]:
     """
     Sums each pending consolidation's source balance onto its target's incoming balance,
     since that is what the target will actually hold once the consolidation is processed.
-    Also reports which public keys must be excluded from the fundable set: consolidation
+    Also reports public keys that must be excluded from the fundable set: consolidation
     sources (always, since they keep compounding until processed), and targets whose
     source balance is unknown (conservatively excluded rather than guessed at).
     """
@@ -146,57 +159,20 @@ def _fold_pending_consolidations(
     }
 
     incoming_balances: defaultdict[int, Gwei] = defaultdict(lambda: Gwei(0))
-    unfundable_target_public_keys: set[HexStr] = set()
-    consolidating_source_public_keys: set[HexStr] = set()
+    non_fundable_public_keys: set[HexStr] = set()
     for cons in pending_consolidations:
         source_public_key = index_to_public_key.get(cons.source_index)
         if source_public_key is not None:
-            consolidating_source_public_keys.add(source_public_key)
+            non_fundable_public_keys.add(source_public_key)
 
         source_balance = index_to_balance.get(cons.source_index)
         if source_balance is None:
             target_public_key = index_to_public_key.get(cons.target_index)
             if target_public_key is not None:
-                unfundable_target_public_keys.add(target_public_key)
+                non_fundable_public_keys.add(target_public_key)
             continue
         incoming_balances[cons.target_index] = Gwei(
             incoming_balances[cons.target_index] + source_balance
         )
 
-    return incoming_balances, unfundable_target_public_keys, consolidating_source_public_keys
-
-
-def _build_fundable_balances(
-    consensus_validators: list[ConsensusValidator],
-    incoming_balances: defaultdict[int, Gwei],
-    consolidating_source_public_keys: set[HexStr],
-) -> tuple[dict[HexStr, Gwei], set[HexStr]]:
-    validators_balances: dict[HexStr, Gwei] = {}
-    ineligible_public_keys: set[HexStr] = set(consolidating_source_public_keys)
-    for validator in consensus_validators:
-        if validator.public_key in consolidating_source_public_keys:
-            continue
-        if validator.is_compounding and validator.status not in EXITING_STATUSES:
-            validators_balances[validator.public_key] = Gwei(
-                validator.balance + incoming_balances[validator.index]
-            )
-        else:
-            ineligible_public_keys.add(validator.public_key)
-
-    return validators_balances, ineligible_public_keys
-
-
-def _finalize_validators_balances(
-    validators_balances: dict[HexStr, Gwei],
-    pending_deposits_amounts: dict[HexStr, Gwei],
-    unfundable_target_public_keys: set[HexStr],
-) -> dict[HexStr, Gwei]:
-    for public_key, amount in pending_deposits_amounts.items():
-        validators_balances[public_key] = Gwei(
-            validators_balances.get(public_key, Gwei(0)) + amount
-        )
-
-    for target_public_key in unfundable_target_public_keys:
-        validators_balances.pop(target_public_key, None)
-
-    return validators_balances
+    return incoming_balances, non_fundable_public_keys

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -28,14 +28,7 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     """
     Retrieves the consensus balances of vault validators eligible for funding.
     Includes balances from pending deposits that have not yet been processed by the
-    consensus node.
-
-    Pending consolidations are folded in too: a consolidation source keeps compounding
-    until it is processed, so it is excluded from the fundable set entirely, and its
-    balance is credited onto the target instead of the target's raw (pre-consolidation)
-    balance, since that is what the target will actually hold once the consolidation
-    lands. If a source's balance can't be determined, the target is dropped from the
-    fundable set rather than guessed at.
+    consensus node. Accounts for pending consolidations.
     """
     vault_public_keys = {v.public_key for v in VaultValidatorCrud().get_vault_validators()}
     vault_public_keys.update(await get_latest_vault_v2_validator_public_keys(settings.vault))
@@ -60,11 +53,8 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
         else:
             ineligible_public_keys.add(validator.public_key)
 
-    # Adjust for pending consolidations: a source keeps compounding until the
-    # consolidation is processed, so it must never be funded; the target should be
-    # funded against the balance it will actually hold once the consolidation lands
-    # (its own balance plus the incoming source balance). If the source's balance
-    # can't be determined, conservatively drop the target instead of guessing.
+    # Exclude pending consolidation sources from funding and credit their balances
+    # to the targets; drop targets whose source balance is unknown.
     for cons in pending_consolidations:
         target = index_to_validator.get(cons.target_index)
         source = index_to_validator.get(cons.source_index)

--- a/src/validators/tests/test_consensus.py
+++ b/src/validators/tests/test_consensus.py
@@ -1,9 +1,19 @@
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
+from sw_utils import ValidatorStatus
 from sw_utils.tests import faker
+from web3.types import Gwei
 
+from src.common.tests.factories import create_chain_head
 from src.common.tests.utils import ether_to_gwei
-from src.validators.consensus import fetch_pending_deposits_amounts
+from src.common.typings import PendingConsolidation
+from src.validators.consensus import (
+    fetch_funding_validators_balances,
+    fetch_pending_deposits_amounts,
+)
+from src.validators.tests.factories import create_consensus_validator
+from src.validators.typings import ConsensusValidator, VaultValidator
 
 
 async def test_fetch_pending_deposits_amounts_empty_public_keys():
@@ -95,3 +105,178 @@ async def test_fetch_pending_deposits_amounts_counts_regardless_of_credentials_p
         result = await fetch_pending_deposits_amounts(public_keys={pub_key}, slot='100')
 
     assert result == {pub_key: ether_to_gwei(30)}
+
+
+async def test_fetch_funding_validators_balances_adds_pending_consolidation_source_balance(
+    vault_validator_crud,
+):
+    """A pending consolidation's source balance is credited to the target, since that is
+    what the target will actually hold once the consolidation is processed."""
+    target_balance = ether_to_gwei(40)
+    source_balance = ether_to_gwei(20)
+    source = create_consensus_validator(
+        index=1, balance=source_balance, is_compounding=True, activation_epoch=1
+    )
+    target = create_consensus_validator(
+        index=2, balance=target_balance, is_compounding=True, activation_epoch=1
+    )
+
+    vault_validator_crud.save_vault_validators(
+        [
+            VaultValidator(public_key=source.public_key, block_number=1),
+            VaultValidator(public_key=target.public_key, block_number=2),
+        ]
+    )
+
+    pending_consolidations = [
+        PendingConsolidation(source_index=source.index, target_index=target.index)
+    ]
+
+    with patch_funding_dependencies(
+        consensus_validators=[source, target],
+        pending_consolidations=pending_consolidations,
+    ):
+        result = await fetch_funding_validators_balances()
+
+    assert result == {target.public_key: Gwei(target_balance + source_balance)}
+
+
+async def test_fetch_funding_validators_balances_excludes_consolidation_source(
+    vault_validator_crud,
+):
+    """A pending consolidation's source keeps compounding until it is processed, so it
+    would otherwise pass the eligibility filter; it must be excluded from the fundable set."""
+    source = create_consensus_validator(
+        index=1, balance=ether_to_gwei(20), is_compounding=True, activation_epoch=1
+    )
+    target = create_consensus_validator(
+        index=2, balance=ether_to_gwei(40), is_compounding=True, activation_epoch=1
+    )
+
+    vault_validator_crud.save_vault_validators(
+        [
+            VaultValidator(public_key=source.public_key, block_number=1),
+            VaultValidator(public_key=target.public_key, block_number=2),
+        ]
+    )
+
+    pending_consolidations = [
+        PendingConsolidation(source_index=source.index, target_index=target.index)
+    ]
+
+    with patch_funding_dependencies(
+        consensus_validators=[source, target],
+        pending_consolidations=pending_consolidations,
+    ):
+        result = await fetch_funding_validators_balances()
+
+    assert source.public_key not in result
+
+
+async def test_fetch_funding_validators_balances_excludes_target_when_source_balance_unknown(
+    vault_validator_crud,
+):
+    """If a pending consolidation's source isn't among the vault's fetched consensus
+    validators, its balance can't be determined; the target is dropped from the fundable
+    set instead of guessing its post-consolidation balance."""
+    target = create_consensus_validator(
+        index=2, balance=ether_to_gwei(40), is_compounding=True, activation_epoch=1
+    )
+
+    vault_validator_crud.save_vault_validators(
+        [VaultValidator(public_key=target.public_key, block_number=1)]
+    )
+
+    # source_index has no matching validator in the fetched set
+    pending_consolidations = [PendingConsolidation(source_index=999, target_index=target.index)]
+
+    with patch_funding_dependencies(
+        consensus_validators=[target],
+        pending_consolidations=pending_consolidations,
+    ):
+        result = await fetch_funding_validators_balances()
+
+    assert result == {}
+
+
+async def test_fetch_funding_validators_balances_no_consolidations_baseline(
+    vault_validator_crud, compounding_creds
+):
+    """Baseline behavior is unchanged when there are no pending consolidations: pending
+    deposits are added to balances, and exiting/non-compounding validators are excluded."""
+    active = create_consensus_validator(
+        index=1,
+        balance=ether_to_gwei(40),
+        is_compounding=True,
+        activation_epoch=1,
+        status=ValidatorStatus.ACTIVE_ONGOING,
+    )
+    exiting = create_consensus_validator(
+        index=2,
+        balance=ether_to_gwei(50),
+        is_compounding=True,
+        activation_epoch=1,
+        status=ValidatorStatus.ACTIVE_EXITING,
+    )
+    non_compounding = create_consensus_validator(
+        index=3, balance=ether_to_gwei(32), is_compounding=False, activation_epoch=1
+    )
+
+    vault_validator_crud.save_vault_validators(
+        [
+            VaultValidator(public_key=active.public_key, block_number=1),
+            VaultValidator(public_key=exiting.public_key, block_number=2),
+            VaultValidator(public_key=non_compounding.public_key, block_number=3),
+        ]
+    )
+
+    pending_deposit_amount = ether_to_gwei(5)
+    pending_deposits = [
+        {
+            'pubkey': active.public_key,
+            'amount': str(pending_deposit_amount),
+            'withdrawal_credentials': compounding_creds,
+        },
+    ]
+
+    with patch_funding_dependencies(
+        consensus_validators=[active, exiting, non_compounding],
+        pending_deposits=pending_deposits,
+    ):
+        result = await fetch_funding_validators_balances()
+
+    assert result == {active.public_key: Gwei(ether_to_gwei(40) + pending_deposit_amount)}
+
+
+@contextmanager
+def patch_funding_dependencies(
+    consensus_validators: list[ConsensusValidator],
+    pending_consolidations: list[PendingConsolidation] | None = None,
+    pending_deposits: list[dict] | None = None,
+):
+    mock_consensus = AsyncMock()
+    mock_consensus.get_pending_deposits.return_value = pending_deposits or []
+    with (
+        patch(
+            'src.validators.consensus.get_latest_vault_v2_validator_public_keys',
+            new_callable=AsyncMock,
+            return_value=set(),
+        ),
+        patch(
+            'src.validators.consensus.get_chain_latest_head',
+            new_callable=AsyncMock,
+            return_value=create_chain_head(slot=100),
+        ),
+        patch(
+            'src.validators.consensus.fetch_consensus_validators',
+            new_callable=AsyncMock,
+            return_value=consensus_validators,
+        ),
+        patch(
+            'src.validators.consensus.get_pending_consolidations',
+            new_callable=AsyncMock,
+            return_value=pending_consolidations or [],
+        ),
+        patch('src.validators.consensus.consensus_client', mock_consensus),
+    ):
+        yield

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -7,6 +7,7 @@ from sw_utils import ValidatorStatus
 from sw_utils.tests import faker
 from web3.types import Gwei
 
+from src.common.tests.factories import create_chain_head
 from src.common.tests.utils import ether_to_gwei
 from src.common.typings import ValidatorType
 from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI, settings
@@ -209,6 +210,27 @@ class TestProcessFunding:
 
     @staticmethod
     @contextmanager
+    def patch_chain_head_and_consolidations(slot: int = 100):
+        """fetch_funding_validators_balances now derives its snapshot from
+        get_chain_latest_head and folds in pending consolidations; tests exercising the
+        real function stub both so they only need to mock the beacon
+        validator/pending-deposit lookups."""
+        with (
+            patch(
+                'src.validators.consensus.get_chain_latest_head',
+                new_callable=AsyncMock,
+                return_value=create_chain_head(slot=slot),
+            ),
+            patch(
+                'src.validators.consensus.get_pending_consolidations',
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            yield
+
+    @staticmethod
+    @contextmanager
     def patch_get_latest_vault_v2_validator_public_keys(return_value=None):
         with patch(
             'src.validators.consensus.get_latest_vault_v2_validator_public_keys',
@@ -408,13 +430,13 @@ class TestProcessFunding:
         ]
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
         mock_consensus.get_pending_deposits.return_value = []
 
         with (
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
@@ -477,7 +499,6 @@ class TestProcessFunding:
         ]
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
         mock_consensus.get_pending_deposits.return_value = [
             {
@@ -490,6 +511,7 @@ class TestProcessFunding:
         with (
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
@@ -533,7 +555,6 @@ class TestProcessFunding:
         ]
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
         mock_consensus.get_pending_deposits.return_value = [
             {
@@ -546,6 +567,7 @@ class TestProcessFunding:
         with (
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
@@ -604,7 +626,6 @@ class TestProcessFunding:
         ]
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
         mock_consensus.get_pending_deposits.return_value = [
             {
@@ -617,6 +638,7 @@ class TestProcessFunding:
         with (
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
@@ -645,7 +667,6 @@ class TestProcessFunding:
         )
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         # Validator is not present in the consensus state yet
         mock_consensus.get_validators_by_ids.return_value = {'data': []}
         mock_consensus.get_pending_deposits.return_value = [
@@ -659,6 +680,7 @@ class TestProcessFunding:
         with (
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
@@ -708,7 +730,6 @@ class TestProcessFunding:
         ]
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         # pub_key_v1_pending is not present in the consensus state yet
         mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
         mock_consensus.get_pending_deposits.return_value = [
@@ -722,6 +743,7 @@ class TestProcessFunding:
         with (
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
@@ -752,12 +774,12 @@ class TestProcessFunding:
         )
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         mock_consensus.get_validators_by_ids.return_value = {'data': []}
         mock_consensus.get_pending_deposits.return_value = []
 
         with (
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(None) as mock_fund,
@@ -813,13 +835,13 @@ class TestProcessFunding:
         ]
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
         mock_consensus.get_pending_deposits.return_value = []
 
         with (
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
@@ -857,12 +879,12 @@ class TestProcessFunding:
         ]
 
         mock_consensus = AsyncMock()
-        mock_consensus.get_block.return_value = {'data': {'message': {'slot': '100'}}}
         mock_consensus.get_validators_by_ids.return_value = {'data': consensus_validators_data}
         mock_consensus.get_pending_deposits.return_value = []
 
         with (
             self.patch_get_latest_vault_v2_validator_public_keys({pub_key}),
+            self.patch_chain_head_and_consolidations(),
             patch('src.validators.consensus.consensus_client', mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,


### PR DESCRIPTION
## Description

`fetch_funding_validators_balances` folds pending deposits into vault validator balances but ignored pending consolidations, causing two issues in the automatic funding task:

- **Target over-fill**: a pending consolidation moves the source's balance onto the target. Funding saw only the target's current balance, overstated its remaining capacity, and topped it up — once the consolidation is processed, the target exceeds `max_validator_balance_gwei`.
- **Source waste**: a consolidation source stays active and compounding until the consolidation is processed, so it passed the eligibility filter and could be funded; the top-up then rides into the target (over-filling it further) or is postponed and swept back by the consensus layer if it lands after the source exits.

The fix reuses `get_pending_consolidations` (already used by the withdrawal subtask), so both CL-queue and EL-request-queue consolidations are covered, and reads validators, pending deposits, and pending consolidations from a single chain-head snapshot:

- consolidation sources are excluded from the fundable set (and from pending-deposit accounting);
- each target's balance is credited with its incoming source balances, so funding capacity reflects the post-consolidation balance;
- a target whose source balance cannot be resolved is conservatively dropped from the fundable set instead of guessing.