### PR TITLE
Exclude oracle-exiting validators from partial withdrawals

### DIFF
--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -239,12 +239,14 @@ async def _get_withdrawals(
     # Find all partial-withdrawable validators, excluding consolidation sources: the CL
     # ignores a consolidation whose source has a pending partial withdrawal, so counting
     # a source's capacity here would both misstate partial_capacity and risk cancelling
-    # the vault's own consolidation.
+    # the vault's own consolidation. Also exclude oracle-exiting validators: a partial
+    # on them is either dropped by the CL or blocks their exit.
     partial_validators = [
         v
         for v in consensus_validators
         if v.is_partially_withdrawable(chain_head.epoch)
         and v.index not in consolidation_source_indexes
+        and v.index not in oracle_exit_indexes
     ]
     partial_validator_indexes = {v.index for v in partial_validators}
     partial_capacity = 0

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -922,6 +922,45 @@ async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
     assert result == expected
 
 
+async def test_get_withdrawals_excludes_oracle_exiting_validators_from_partials(data_dir):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+
+    # v1 is oracle-exiting but still ACTIVE_ONGOING on the CL and has the largest
+    # balance, so it would be picked first by balance-descending sort. It must be
+    # excluded from partial selection entirely, leaving v2 to cover the request.
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(5)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            index=1,
+            balance=ether_to_gwei(100),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            index=2,
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes={1},
+        consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
+        pending_deposits={},
+    )
+    expected = {'0x2': ether_to_gwei(5)}
+    assert result == expected
+
+
 async def test_get_withdrawals_boundary_activation_epoch_prefers_partial_over_full_exit(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 


### PR DESCRIPTION
## Description

Validators whose exit is in flight via oracles are still `ACTIVE_ONGOING` on the consensus layer, so they passed `is_partially_withdrawable`, inflated `partial_capacity`, and — being typically the largest by balance — were picked first for partial withdrawals in `_get_withdrawals`. This is harmful in both orderings:

- If the exit lands first, the CL drops the partial request (`process_withdrawal_request` ignores validators with `exit_epoch` set) — the request fee is spent and the exit queue stays undercovered.
- If the partial lands first, the pending partial withdrawal blocks the oracles' voluntary exit (the CL rejects exits while `pending_balance_to_withdraw > 0`), delaying it until the partial is processed.

Exclude `oracle_exit_indexes` from `partial_validators`, mirroring the exclusion already applied on the full-exit path in `_filter_exitable_validators`. Status-exiting validators were already excluded via the `ACTIVE_ONGOING` check in `is_partially_withdrawable`; oracle-exiting ones were the remaining gap.