### PR TITLE
Exclude exiting validators from pending partial withdrawals

### DIFF
--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -245,12 +245,15 @@ async def _get_withdrawals(
     # Find all partial-withdrawable validators, excluding consolidation sources: the CL
     # ignores a consolidation whose source has a pending partial withdrawal, so counting
     # a source's capacity here would both misstate partial_capacity and risk cancelling
-    # the vault's own consolidation.
+    # the vault's own consolidation. Also exclude oracle-exiting validators: they are
+    # still ACTIVE_ONGOING on the CL, but new partial requests for them would pay 0
+    # once their exit_epoch is set.
     partial_validators = [
         v
         for v in consensus_validators
         if v.is_partially_withdrawable(chain_head.epoch)
         and v.index not in consolidation_source_indexes
+        and v.index not in oracle_exit_indexes
     ]
     partial_validator_indexes = {v.index for v in partial_validators}
     partial_capacity = 0

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -37,7 +37,11 @@ from src.validators.exceptions import EmptyRelayerResponseException
 from src.validators.oracles import poll_active_exits
 from src.validators.relayer import RelayerClient
 from src.validators.typings import ConsensusValidator
-from src.withdrawals.assets import CAN_BE_EXITED_STATUSES, get_queued_assets
+from src.withdrawals.assets import (
+    CAN_BE_EXITED_STATUSES,
+    EXITING_STATUSES,
+    get_queued_assets,
+)
 from src.withdrawals.execution import submit_withdraw_validators
 
 logger = logging.getLogger(__name__)
@@ -109,10 +113,12 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
         )
         consolidations = await get_pending_consolidations(chain_head, consensus_validators)
 
-        active_validators = [v for v in consensus_validators if v.status in CAN_BE_EXITED_STATUSES]
+        non_exiting_validators = _filter_non_exiting_validators(
+            consensus_validators, oracle_exiting_validators
+        )
         pending_partial_withdrawals = await get_pending_partial_withdrawals(
             chain_head=chain_head,
-            consensus_validators=active_validators,
+            consensus_validators=non_exiting_validators,
         )
         redemption_assets = await get_redemption_assets(chain_head=chain_head)
 
@@ -368,6 +374,26 @@ def _filter_exitable_validators(
     )
 
     return can_be_exited_validators
+
+
+def _filter_non_exiting_validators(
+    consensus_validators: list[ConsensusValidator],
+    oracle_exiting_validators: list[ConsensusValidator],
+) -> list[ConsensusValidator]:
+    """
+    A CL pending partial withdrawal on a validator whose exit_epoch is set pays 0 and
+    is dequeued without withdrawing, while its full balance is already counted as
+    exiting elsewhere -- exclude such validators so their pending partials aren't
+    double-counted.
+    """
+    oracle_exiting_indexes = {val.index for val in oracle_exiting_validators}
+    return [
+        v
+        for v in consensus_validators
+        if v.status in CAN_BE_EXITED_STATUSES
+        and v.status not in EXITING_STATUSES
+        and v.index not in oracle_exiting_indexes
+    ]
 
 
 async def _fetch_oracle_exiting_validators(

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -245,9 +245,8 @@ async def _get_withdrawals(
     # Find all partial-withdrawable validators, excluding consolidation sources: the CL
     # ignores a consolidation whose source has a pending partial withdrawal, so counting
     # a source's capacity here would both misstate partial_capacity and risk cancelling
-    # the vault's own consolidation. Also exclude oracle-exiting validators: they are
-    # still ACTIVE_ONGOING on the CL, but new partial requests for them would pay 0
-    # once their exit_epoch is set.
+    # the vault's own consolidation. Also exclude oracle-exiting validators, since new
+    # partial requests for them would pay 0 once their exit_epoch is set.
     partial_validators = [
         v
         for v in consensus_validators

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -926,10 +926,8 @@ async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
 async def test_get_withdrawals_excludes_oracle_exiting_from_partial_capacity(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 
-    # v1 is still ACTIVE_ONGOING on the CL but already oracle-exiting: new partial
-    # requests for it would pay 0 once its exit_epoch is set, so it must not inflate
-    # partial_capacity or receive a partial withdrawal. Excluding it drops combined
-    # capacity (8 + 18 ETH) below the 20 ETH request, routing v2 to a full exit instead.
+    # v1 is still ACTIVE_ONGOING on the CL but already oracle-exiting, so it must not
+    # inflate partial_capacity or receive a partial withdrawal; only v2 gets exited.
     chain_head = create_chain_head(epoch=500)
     queued_assets = ether_to_gwei(20)
     consensus_validators = [

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -16,6 +16,7 @@ from src.withdrawals.tasks import (
     _fetch_oracle_exiting_validators,
     _filter_exitable_validators,
     _filter_full_withdrawals,
+    _filter_non_exiting_validators,
     _get_partial_withdrawals,
     _get_withdrawals,
     _is_pending_partial_withdrawals_queue_full,
@@ -1235,6 +1236,36 @@ def test_filter_full_withdrawals():
     }
     assert _filter_full_withdrawals(withdrawals) == ['0x1', '0x3']
     assert _filter_full_withdrawals({}) == []
+
+
+def test_filter_non_exiting_validators():
+    # an exiting validator's index is dropped even though it is in CAN_BE_EXITED_STATUSES
+    validators = [
+        create_consensus_validator(index=1, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+        create_consensus_validator(index=2, status=ValidatorStatus.ACTIVE_EXITING, balance=32),
+    ]
+    result = _filter_non_exiting_validators(validators, oracle_exiting_validators=[])
+    assert [v.index for v in result] == [1]
+
+    # a validator still ACTIVE_ONGOING on the CL but already in the oracle's exiting
+    # set is excluded too, so its pending partial isn't counted on top of the balance
+    # already summed via the oracle-exiting branch
+    validators = [
+        create_consensus_validator(index=1, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+        create_consensus_validator(index=2, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+    ]
+    oracle_exiting_validators = [
+        create_consensus_validator(index=2, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+    ]
+    result = _filter_non_exiting_validators(validators, oracle_exiting_validators)
+    assert [v.index for v in result] == [1]
+
+    # a validator outside CAN_BE_EXITED_STATUSES (e.g. still pending) is also excluded
+    validators = [
+        create_consensus_validator(index=1, status=ValidatorStatus.PENDING_QUEUED, balance=32),
+    ]
+    result = _filter_non_exiting_validators(validators, oracle_exiting_validators=[])
+    assert result == []
 
 
 async def test_fetch_oracle_exiting_validators():

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -923,6 +923,46 @@ async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
     assert result == expected
 
 
+async def test_get_withdrawals_excludes_oracle_exiting_from_partial_capacity(data_dir):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+
+    # v1 is still ACTIVE_ONGOING on the CL but already oracle-exiting: new partial
+    # requests for it would pay 0 once its exit_epoch is set, so it must not inflate
+    # partial_capacity or receive a partial withdrawal. Excluding it drops combined
+    # capacity (8 + 18 ETH) below the 20 ETH request, routing v2 to a full exit instead.
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(20)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            index=1,
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            index=2,
+            balance=ether_to_gwei(50),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes={1},
+        consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
+        pending_deposits={},
+    )
+    expected = {'0x2': ether_to_gwei(0)}
+    assert result == expected
+
+
 async def test_get_withdrawals_boundary_activation_epoch_prefers_partial_over_full_exit(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 


### PR DESCRIPTION
## Description

`withdrawing_assets` double-counted validators that are both exiting and holding a CL pending partial withdrawal. Per Electra semantics, a pending partial withdrawal on a validator whose `exit_epoch` is set pays **0** — it is dequeued without withdrawing anything — while `_calculate_validators_exits_amount` already counts that validator's full balance as arriving.

Example: a validator with a 1 ETH pending partial withdrawal is slashed (or exits manually, or is picked by the oracle for a force exit). The old code counted both the 1 ETH partial and the validator's full ~32 ETH balance, overstating `withdrawing_assets` by 1 ETH; `getExitQueueMissingAssets` then under-reported and the operator under-withdrew for the exit/redemption queue by the same amount.

Pending partial withdrawals are now summed only for validators that are not exiting — excluding both `EXITING_STATUSES` and the oracle's active-exit set. The same exclusion is applied to the partial-withdrawal capacity selection in `_get_withdrawals`, so new EL partial requests are no longer planned against validators the oracle is already exiting. Mirrors stakewise/v3-oracle#644.