### PR TITLE
Add unmatched boosted shares to kept shares across vaults

### DIFF
--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -482,7 +482,6 @@ class TestGetWindowRedeemedShares:
                 new=AsyncMock(return_value=[active_position]),
             ),
             patch(f'{self.MODULE}.iter_processed_shares', new=fake_iter_processed_shares),
-            patch(f'{self.MODULE}.os_token_redeemer_contract.nonce', new=AsyncMock(return_value=5)),
             patch(f'{self.MODULE}.execution_client', new=AsyncMock()) as execution_client_mock,
         ):
             execution_client_mock.eth.get_block.return_value = {'number': BlockNumber(150)}
@@ -491,26 +490,6 @@ class TestGetWindowRedeemedShares:
             )
 
         assert result == {(vault_1, owner_1): Wei(30)}
-
-    async def test_raises_when_nonce_at_snapshot_differs_from_new_file_nonce(self):
-        # nonce changed between snapshot_block and the read here, so the active file no
-        # longer matches the snapshot.
-        vault_1 = faker.eth_address()
-        owner_1 = faker.eth_address()
-        active_position = make_position(vault=vault_1, owner=owner_1, leaf_shares=1000)
-        new_positions = [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(700))]
-
-        with (
-            patch(
-                f'{self.MODULE}.fetch_positions_from_ipfs',
-                new=AsyncMock(return_value=[active_position]),
-            ),
-            patch(f'{self.MODULE}.os_token_redeemer_contract.nonce', new=AsyncMock(return_value=6)),
-        ):
-            with pytest.raises(RuntimeError):
-                await get_window_redeemed_shares(
-                    new_positions, nonce=5, snapshot_block=BlockNumber(100)
-                )
 
 
 def test_subtract_window_redeemed_shares_clamps_and_drops_zero():
@@ -526,20 +505,8 @@ def test_subtract_window_redeemed_shares_clamps_and_drops_zero():
         # exceeds the leaf's own shares: clamp at zero instead of going negative
         (vault_1, owner_2): Wei(999),
     }
-    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares, Wei(0))
+    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares)
     assert result == [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(60))]
-
-
-def test_subtract_window_redeemed_shares_drops_positions_below_dust_threshold():
-    vault_1 = faker.eth_address()
-    owner_1 = faker.eth_address()
-    positions = [
-        OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(100)),
-    ]
-    # leaves 10 shares, below the dust threshold enforced when the positions were built
-    window_redeemed_shares = {(vault_1, owner_1): Wei(90)}
-    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares, Wei(20))
-    assert result == []
 
 
 @pytest.mark.usefixtures('_init_config')

--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+from eth_typing import BlockNumber
 from sw_utils import OsTokenConverter
 from sw_utils.tests import faker
 from web3 import Web3
@@ -12,10 +13,13 @@ from src.config.networks import MAINNET, NETWORKS
 from src.config.settings import settings
 from src.redemptions.commands.update_redeemable_positions import (
     _reduce_boosted_amount,
+    _subtract_window_redeemed_shares,
     calculate_boost_os_token_shares,
     create_os_token_positions,
+    get_window_redeemed_shares,
     update_redeemable_positions,
 )
+from src.redemptions.tests.factories import make_position
 from src.redemptions.typings import (
     Allocator,
     LeverageStrategyPosition,
@@ -378,6 +382,75 @@ def test_reduces_boosted_amount():
     ]
 
 
+class TestGetWindowRedeemedShares:
+    MODULE = 'src.redemptions.commands.update_redeemable_positions'
+
+    async def test_no_active_positions_returns_empty(self):
+        with patch(f'{self.MODULE}.fetch_positions_from_ipfs', new=AsyncMock(return_value=[])):
+            result = await get_window_redeemed_shares([], nonce=5, snapshot_block=BlockNumber(100))
+        assert result == {}
+
+    async def test_no_matching_vault_owner_returns_empty(self):
+        vault_1 = faker.eth_address()
+        owner_1 = faker.eth_address()
+        other_vault = faker.eth_address()
+        active_position = make_position(vault=other_vault, owner=owner_1)
+        new_positions = [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(1000))]
+
+        with patch(
+            f'{self.MODULE}.fetch_positions_from_ipfs',
+            new=AsyncMock(return_value=[active_position]),
+        ):
+            result = await get_window_redeemed_shares(
+                new_positions, nonce=5, snapshot_block=BlockNumber(100)
+            )
+        assert result == {}
+
+    async def test_subtracts_shares_redeemed_after_snapshot(self):
+        vault_1 = faker.eth_address()
+        owner_1 = faker.eth_address()
+        active_position = make_position(vault=vault_1, owner=owner_1, leaf_shares=1000)
+        new_positions = [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(700))]
+
+        async def fake_iter_processed_shares(positions, nonce, block_number):
+            # more shares processed at the later ("latest") read than at the snapshot block
+            value = Wei(60) if block_number == BlockNumber(100) else Wei(90)
+            for _ in positions:
+                yield value
+
+        with (
+            patch(
+                f'{self.MODULE}.fetch_positions_from_ipfs',
+                new=AsyncMock(return_value=[active_position]),
+            ),
+            patch(f'{self.MODULE}.iter_processed_shares', new=fake_iter_processed_shares),
+            patch(f'{self.MODULE}.execution_client', new=AsyncMock()) as execution_client_mock,
+        ):
+            execution_client_mock.eth.get_block.return_value = {'number': BlockNumber(150)}
+            result = await get_window_redeemed_shares(
+                new_positions, nonce=5, snapshot_block=BlockNumber(100)
+            )
+
+        assert result == {(vault_1, owner_1): Wei(30)}
+
+
+def test_subtract_window_redeemed_shares_clamps_and_drops_zero():
+    vault_1 = faker.eth_address()
+    owner_1 = faker.eth_address()
+    owner_2 = faker.eth_address()
+    positions = [
+        OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(100)),
+        OsTokenPosition(owner=owner_2, vault=vault_1, leaf_shares=Wei(50)),
+    ]
+    window_redeemed_shares = {
+        (vault_1, owner_1): Wei(40),
+        # exceeds the leaf's own shares: clamp at zero instead of going negative
+        (vault_1, owner_2): Wei(999),
+    }
+    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares)
+    assert result == [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(60))]
+
+
 @pytest.mark.usefixtures('_init_config')
 class TestUpdateOsTokenPositions:
     @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
@@ -493,6 +566,7 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -544,6 +618,7 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -556,6 +631,98 @@ class TestUpdateOsTokenPositions:
                 '0x9b4419ebea301ed07e591b477e69499f35e4c3cd69538c2f22a6a014b06e5bbd'
                 in result.output.strip()
             )
+
+    @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
+    async def test_window_redeemed_shares_are_subtracted(
+        self,
+        vault_address: str,
+        execution_endpoints: str,
+        runner: CliRunner,
+    ):
+        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
+        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
+        allocators = [
+            Allocator(
+                address=address_1,
+                vault_os_token_positions=[
+                    VaultOsTokenPosition(
+                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
+                    ),
+                ],
+            ),
+        ]
+        leverage_positions: list[LeverageStrategyPosition] = []
+        os_token_holders: dict[ChecksumAddress, Wei] = {}
+        mock_protocol_data = []
+        os_token_converter = OsTokenConverter(110, 100)
+        args = [
+            '--network',
+            MAINNET,
+            '--execution-endpoints',
+            execution_endpoints,
+            '--verbose',
+        ]
+        with (
+            patch_latest_block(11),
+            patch_os_token_redeemer_contract_nonce(6),
+            patch_os_token_contract_address(os_token_contract_address),
+            patch_os_token_converter(os_token_converter),
+            patch_api_client(mock_protocol_data),
+            patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch_window_redeemed_shares({(vault_1, address_1): Web3.to_wei(4, 'ether')}),
+            patch_ipfs_client() as mock_upload_json,
+            patch_startup_check(),
+        ):
+            result = runner.invoke(update_redeemable_positions, args, input='\n')
+            assert result.exit_code == 0
+            mock_upload_json.assert_called_once_with(
+                [{'owner': address_1, 'vault': vault_1, 'leaf_shares': '6000000000000000000'}]
+            )
+
+    @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
+    async def test_window_redeemed_shares_drop_fully_redeemed_position(
+        self,
+        vault_address: str,
+        execution_endpoints: str,
+        runner: CliRunner,
+    ):
+        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
+        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
+        allocators = [
+            Allocator(
+                address=address_1,
+                vault_os_token_positions=[
+                    VaultOsTokenPosition(
+                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
+                    ),
+                ],
+            ),
+        ]
+        leverage_positions: list[LeverageStrategyPosition] = []
+        os_token_holders: dict[ChecksumAddress, Wei] = {}
+        mock_protocol_data = []
+        os_token_converter = OsTokenConverter(110, 100)
+        args = [
+            '--network',
+            MAINNET,
+            '--execution-endpoints',
+            execution_endpoints,
+            '--verbose',
+        ]
+        with (
+            patch_latest_block(11),
+            patch_os_token_redeemer_contract_nonce(6),
+            patch_os_token_contract_address(os_token_contract_address),
+            patch_os_token_converter(os_token_converter),
+            patch_api_client(mock_protocol_data),
+            patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch_window_redeemed_shares({(vault_1, address_1): Web3.to_wei(10, 'ether')}),
+            patch_ipfs_client() as mock_upload_json,
+            patch_startup_check(),
+        ):
+            result = runner.invoke(update_redeemable_positions, args, input='\n')
+            assert result.exit_code == 0
+            mock_upload_json.assert_not_called()
 
     @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
     async def test_min_leaf_shares(
@@ -597,6 +764,7 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -644,6 +812,7 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -720,6 +889,15 @@ def patch_ipfs_client():
         'src.redemptions.commands.update_redeemable_positions.build_ipfs_upload_clients', mock_build
     ):
         yield mock_upload_json
+
+
+@contextlib.contextmanager
+def patch_window_redeemed_shares(shares_map=None):
+    with patch(
+        'src.redemptions.commands.update_redeemable_positions.get_window_redeemed_shares',
+        new=AsyncMock(return_value=shares_map or {}),
+    ):
+        yield
 
 
 @contextlib.contextmanager

--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -332,7 +332,7 @@ def test_reduces_boosted_amount():
         )
     ]
     boost_ostoken_shares = {}
-    result = _reduce_boosted_amount(allocators, boost_ostoken_shares)
+    result, residual = _reduce_boosted_amount(allocators, boost_ostoken_shares)
     assert result == [
         Allocator(
             address=address_1,
@@ -342,6 +342,7 @@ def test_reduces_boosted_amount():
             ],
         )
     ]
+    assert residual == {}
     # basic reduction
     allocators = [
         Allocator(
@@ -364,7 +365,7 @@ def test_reduces_boosted_amount():
         (address_2, vault_2): Wei(1500),
     }
 
-    result = _reduce_boosted_amount(allocators, boost_ostoken_shares)
+    result, residual = _reduce_boosted_amount(allocators, boost_ostoken_shares)
     assert result == [
         Allocator(
             address=address_1,
@@ -380,6 +381,63 @@ def test_reduces_boosted_amount():
             ],
         ),
     ]
+    assert residual == {}
+
+
+def test_reduces_boosted_amount_cross_vault_residual():
+    address_1 = faker.eth_address()
+    vault_1 = faker.eth_address()
+    vault_2 = faker.eth_address()
+
+    # boosted at vault_2, but the user only minted at vault_1: no same-vault mint to
+    # match against, so the full boosted amount becomes a residual for the user.
+    allocators = [
+        Allocator(
+            address=address_1,
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault_1, minted_shares=Wei(1000), ltv=0.5),
+            ],
+        ),
+    ]
+    boost_ostoken_shares = {(address_1, vault_2): Wei(400)}
+
+    result, residual = _reduce_boosted_amount(allocators, boost_ostoken_shares)
+    assert result == [
+        Allocator(
+            address=address_1,
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault_1, minted_shares=Wei(1000), ltv=0.5),
+            ],
+        ),
+    ]
+    assert residual == {address_1: Wei(400)}
+
+
+def test_reduces_boosted_amount_excess_over_same_vault_mint_becomes_residual():
+    address_1 = faker.eth_address()
+    vault_1 = faker.eth_address()
+
+    # boosted amount exceeds the same-vault mint: match what fits, carry the rest as residual.
+    allocators = [
+        Allocator(
+            address=address_1,
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault_1, minted_shares=Wei(300), ltv=0.5),
+            ],
+        ),
+    ]
+    boost_ostoken_shares = {(address_1, vault_1): Wei(500)}
+
+    result, residual = _reduce_boosted_amount(allocators, boost_ostoken_shares)
+    assert result == [
+        Allocator(
+            address=address_1,
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault_1, minted_shares=Wei(0), ltv=0.5),
+            ],
+        ),
+    ]
+    assert residual == {address_1: Wei(200)}
 
 
 class TestGetWindowRedeemedShares:
@@ -723,6 +781,65 @@ class TestUpdateOsTokenPositions:
             result = runner.invoke(update_redeemable_positions, args, input='\n')
             assert result.exit_code == 0
             mock_upload_json.assert_not_called()
+
+    @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
+    async def test_cross_vault_boost_reduces_redeemable_amount(
+        self,
+        vault_address: str,
+        execution_endpoints: str,
+        runner: CliRunner,
+    ):
+        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
+        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
+        vault_2 = Web3.to_checksum_address('0xe8Ea1025b49D2B51C536cFBc0833F021ba4c6903')
+        allocators = [
+            Allocator(
+                address=address_1,
+                vault_os_token_positions=[
+                    VaultOsTokenPosition(
+                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
+                    ),
+                ],
+            ),
+        ]
+        # boosted into a leverage strategy keyed to vault_2, where the user never minted
+        leverage_positions = [
+            LeverageStrategyPosition(
+                user=address_1,
+                vault=vault_2,
+                proxy=Web3.to_checksum_address(faker.eth_address()),
+                os_token_shares=Web3.to_wei(3, 'ether'),
+                exiting_os_token_shares=Wei(0),
+                assets=Wei(0),
+                exiting_assets=Wei(0),
+            ),
+        ]
+        os_token_holders: dict[ChecksumAddress, Wei] = {}
+        mock_protocol_data = []
+        os_token_converter = OsTokenConverter(110, 100)
+        args = [
+            '--network',
+            MAINNET,
+            '--execution-endpoints',
+            execution_endpoints,
+            '--verbose',
+        ]
+        with (
+            patch_latest_block(11),
+            patch_os_token_redeemer_contract_nonce(6),
+            patch_os_token_contract_address(os_token_contract_address),
+            patch_os_token_converter(os_token_converter),
+            patch_api_client(mock_protocol_data),
+            patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch_window_redeemed_shares(),
+            patch_ipfs_client() as mock_upload_json,
+            patch_startup_check(),
+        ):
+            result = runner.invoke(update_redeemable_positions, args, input='\n')
+            assert result.exit_code == 0
+            mock_upload_json.assert_called_once_with(
+                [{'owner': address_1, 'vault': vault_1, 'leaf_shares': '7000000000000000000'}]
+            )
 
     @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
     async def test_min_leaf_shares(

--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
-from eth_typing import BlockNumber
 from sw_utils import OsTokenConverter
 from sw_utils.tests import faker
 from web3 import Web3
@@ -13,13 +12,10 @@ from src.config.networks import MAINNET, NETWORKS
 from src.config.settings import settings
 from src.redemptions.commands.update_redeemable_positions import (
     _reduce_boosted_amount,
-    _subtract_window_redeemed_shares,
     calculate_boost_os_token_shares,
     create_os_token_positions,
-    get_window_redeemed_shares,
     update_redeemable_positions,
 )
-from src.redemptions.tests.factories import make_position
 from src.redemptions.typings import (
     Allocator,
     LeverageStrategyPosition,
@@ -440,75 +436,6 @@ def test_reduces_boosted_amount_excess_over_same_vault_mint_becomes_residual():
     assert residual == {address_1: Wei(200)}
 
 
-class TestGetWindowRedeemedShares:
-    MODULE = 'src.redemptions.commands.update_redeemable_positions'
-
-    async def test_no_active_positions_returns_empty(self):
-        with patch(f'{self.MODULE}.fetch_positions_from_ipfs', new=AsyncMock(return_value=[])):
-            result = await get_window_redeemed_shares([], nonce=5, snapshot_block=BlockNumber(100))
-        assert result == {}
-
-    async def test_no_matching_vault_owner_returns_empty(self):
-        vault_1 = faker.eth_address()
-        owner_1 = faker.eth_address()
-        other_vault = faker.eth_address()
-        active_position = make_position(vault=other_vault, owner=owner_1)
-        new_positions = [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(1000))]
-
-        with patch(
-            f'{self.MODULE}.fetch_positions_from_ipfs',
-            new=AsyncMock(return_value=[active_position]),
-        ):
-            result = await get_window_redeemed_shares(
-                new_positions, nonce=5, snapshot_block=BlockNumber(100)
-            )
-        assert result == {}
-
-    async def test_subtracts_shares_redeemed_after_snapshot(self):
-        vault_1 = faker.eth_address()
-        owner_1 = faker.eth_address()
-        active_position = make_position(vault=vault_1, owner=owner_1, leaf_shares=1000)
-        new_positions = [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(700))]
-
-        async def fake_iter_processed_shares(positions, nonce, block_number):
-            # more shares processed at the later ("latest") read than at the snapshot block
-            value = Wei(60) if block_number == BlockNumber(100) else Wei(90)
-            for _ in positions:
-                yield value
-
-        with (
-            patch(
-                f'{self.MODULE}.fetch_positions_from_ipfs',
-                new=AsyncMock(return_value=[active_position]),
-            ),
-            patch(f'{self.MODULE}.iter_processed_shares', new=fake_iter_processed_shares),
-            patch(f'{self.MODULE}.execution_client', new=AsyncMock()) as execution_client_mock,
-        ):
-            execution_client_mock.eth.get_block.return_value = {'number': BlockNumber(150)}
-            result = await get_window_redeemed_shares(
-                new_positions, nonce=5, snapshot_block=BlockNumber(100)
-            )
-
-        assert result == {(vault_1, owner_1): Wei(30)}
-
-
-def test_subtract_window_redeemed_shares_clamps_and_drops_zero():
-    vault_1 = faker.eth_address()
-    owner_1 = faker.eth_address()
-    owner_2 = faker.eth_address()
-    positions = [
-        OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(100)),
-        OsTokenPosition(owner=owner_2, vault=vault_1, leaf_shares=Wei(50)),
-    ]
-    window_redeemed_shares = {
-        (vault_1, owner_1): Wei(40),
-        # exceeds the leaf's own shares: clamp at zero instead of going negative
-        (vault_1, owner_2): Wei(999),
-    }
-    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares)
-    assert result == [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(60))]
-
-
 @pytest.mark.usefixtures('_init_config')
 class TestUpdateOsTokenPositions:
     @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
@@ -624,7 +551,6 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
-            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -676,7 +602,6 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
-            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -689,98 +614,6 @@ class TestUpdateOsTokenPositions:
                 '0x9b4419ebea301ed07e591b477e69499f35e4c3cd69538c2f22a6a014b06e5bbd'
                 in result.output.strip()
             )
-
-    @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
-    async def test_window_redeemed_shares_are_subtracted(
-        self,
-        vault_address: str,
-        execution_endpoints: str,
-        runner: CliRunner,
-    ):
-        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
-        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
-        allocators = [
-            Allocator(
-                address=address_1,
-                vault_os_token_positions=[
-                    VaultOsTokenPosition(
-                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
-                    ),
-                ],
-            ),
-        ]
-        leverage_positions: list[LeverageStrategyPosition] = []
-        os_token_holders: dict[ChecksumAddress, Wei] = {}
-        mock_protocol_data = []
-        os_token_converter = OsTokenConverter(110, 100)
-        args = [
-            '--network',
-            MAINNET,
-            '--execution-endpoints',
-            execution_endpoints,
-            '--verbose',
-        ]
-        with (
-            patch_latest_block(11),
-            patch_os_token_redeemer_contract_nonce(6),
-            patch_os_token_contract_address(os_token_contract_address),
-            patch_os_token_converter(os_token_converter),
-            patch_api_client(mock_protocol_data),
-            patch_graph_calls(allocators, leverage_positions, os_token_holders),
-            patch_window_redeemed_shares({(vault_1, address_1): Web3.to_wei(4, 'ether')}),
-            patch_ipfs_client() as mock_upload_json,
-            patch_startup_check(),
-        ):
-            result = runner.invoke(update_redeemable_positions, args, input='\n')
-            assert result.exit_code == 0
-            mock_upload_json.assert_called_once_with(
-                [{'owner': address_1, 'vault': vault_1, 'leaf_shares': '6000000000000000000'}]
-            )
-
-    @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
-    async def test_window_redeemed_shares_drop_fully_redeemed_position(
-        self,
-        vault_address: str,
-        execution_endpoints: str,
-        runner: CliRunner,
-    ):
-        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
-        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
-        allocators = [
-            Allocator(
-                address=address_1,
-                vault_os_token_positions=[
-                    VaultOsTokenPosition(
-                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
-                    ),
-                ],
-            ),
-        ]
-        leverage_positions: list[LeverageStrategyPosition] = []
-        os_token_holders: dict[ChecksumAddress, Wei] = {}
-        mock_protocol_data = []
-        os_token_converter = OsTokenConverter(110, 100)
-        args = [
-            '--network',
-            MAINNET,
-            '--execution-endpoints',
-            execution_endpoints,
-            '--verbose',
-        ]
-        with (
-            patch_latest_block(11),
-            patch_os_token_redeemer_contract_nonce(6),
-            patch_os_token_contract_address(os_token_contract_address),
-            patch_os_token_converter(os_token_converter),
-            patch_api_client(mock_protocol_data),
-            patch_graph_calls(allocators, leverage_positions, os_token_holders),
-            patch_window_redeemed_shares({(vault_1, address_1): Web3.to_wei(10, 'ether')}),
-            patch_ipfs_client() as mock_upload_json,
-            patch_startup_check(),
-        ):
-            result = runner.invoke(update_redeemable_positions, args, input='\n')
-            assert result.exit_code == 0
-            mock_upload_json.assert_not_called()
 
     @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
     async def test_cross_vault_boost_reduces_redeemable_amount(
@@ -831,7 +664,6 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
-            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -881,7 +713,6 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
-            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -929,7 +760,6 @@ class TestUpdateOsTokenPositions:
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
             patch_graph_calls(allocators, leverage_positions, os_token_holders),
-            patch_window_redeemed_shares(),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -1006,15 +836,6 @@ def patch_ipfs_client():
         'src.redemptions.commands.update_redeemable_positions.build_ipfs_upload_clients', mock_build
     ):
         yield mock_upload_json
-
-
-@contextlib.contextmanager
-def patch_window_redeemed_shares(shares_map=None):
-    with patch(
-        'src.redemptions.commands.update_redeemable_positions.get_window_redeemed_shares',
-        new=AsyncMock(return_value=shares_map or {}),
-    ):
-        yield
 
 
 @contextlib.contextmanager

--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -482,6 +482,7 @@ class TestGetWindowRedeemedShares:
                 new=AsyncMock(return_value=[active_position]),
             ),
             patch(f'{self.MODULE}.iter_processed_shares', new=fake_iter_processed_shares),
+            patch(f'{self.MODULE}.os_token_redeemer_contract.nonce', new=AsyncMock(return_value=5)),
             patch(f'{self.MODULE}.execution_client', new=AsyncMock()) as execution_client_mock,
         ):
             execution_client_mock.eth.get_block.return_value = {'number': BlockNumber(150)}
@@ -490,6 +491,27 @@ class TestGetWindowRedeemedShares:
             )
 
         assert result == {(vault_1, owner_1): Wei(30)}
+
+    async def test_raises_when_nonce_at_snapshot_differs_from_new_file_nonce(self):
+        # a setRedeemablePositions call landed between snapshot_block and the point where
+        # the caller read the "latest" nonce: the active file no longer matches the
+        # snapshot, so leaf hashes computed with the stale nonce would be wrong.
+        vault_1 = faker.eth_address()
+        owner_1 = faker.eth_address()
+        active_position = make_position(vault=vault_1, owner=owner_1, leaf_shares=1000)
+        new_positions = [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(700))]
+
+        with (
+            patch(
+                f'{self.MODULE}.fetch_positions_from_ipfs',
+                new=AsyncMock(return_value=[active_position]),
+            ),
+            patch(f'{self.MODULE}.os_token_redeemer_contract.nonce', new=AsyncMock(return_value=6)),
+        ):
+            with pytest.raises(RuntimeError):
+                await get_window_redeemed_shares(
+                    new_positions, nonce=5, snapshot_block=BlockNumber(100)
+                )
 
 
 def test_subtract_window_redeemed_shares_clamps_and_drops_zero():
@@ -505,8 +527,20 @@ def test_subtract_window_redeemed_shares_clamps_and_drops_zero():
         # exceeds the leaf's own shares: clamp at zero instead of going negative
         (vault_1, owner_2): Wei(999),
     }
-    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares)
+    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares, Wei(0))
     assert result == [OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(60))]
+
+
+def test_subtract_window_redeemed_shares_drops_positions_below_dust_threshold():
+    vault_1 = faker.eth_address()
+    owner_1 = faker.eth_address()
+    positions = [
+        OsTokenPosition(owner=owner_1, vault=vault_1, leaf_shares=Wei(100)),
+    ]
+    # leaves 10 shares, below the dust threshold enforced when the positions were built
+    window_redeemed_shares = {(vault_1, owner_1): Wei(90)}
+    result = _subtract_window_redeemed_shares(positions, window_redeemed_shares, Wei(20))
+    assert result == []
 
 
 @pytest.mark.usefixtures('_init_config')

--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -493,9 +493,8 @@ class TestGetWindowRedeemedShares:
         assert result == {(vault_1, owner_1): Wei(30)}
 
     async def test_raises_when_nonce_at_snapshot_differs_from_new_file_nonce(self):
-        # a setRedeemablePositions call landed between snapshot_block and the point where
-        # the caller read the "latest" nonce: the active file no longer matches the
-        # snapshot, so leaf hashes computed with the stale nonce would be wrong.
+        # nonce changed between snapshot_block and the read here, so the active file no
+        # longer matches the snapshot.
         vault_1 = faker.eth_address()
         owner_1 = faker.eth_address()
         active_position = make_position(vault=vault_1, owner=owner_1, leaf_shares=1000)

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -242,7 +242,7 @@ async def process(
         leverage_positions=leverage_positions,
         os_token_converter=os_token_converter,
     )
-    allocators = _reduce_boosted_amount(allocators, boost_os_token_shares)
+    allocators, residual_boosted_shares = _reduce_boosted_amount(allocators, boost_os_token_shares)
 
     # filter zero positions. Filter before kept shares calculation to reduce api calls
     min_minted_shares = Web3.to_wei(min_os_token_position_amount_gwei, 'gwei')
@@ -265,6 +265,11 @@ async def process(
         api_config,
     )
     logger.info('Fetched kept tokens for %s addresses...', len(address_to_minted_shares))
+    # boosted shares that couldn't be matched to a same-vault mint are still not sold by the
+    # user; keep them out of redeemable amounts by treating them as kept, spread across the
+    # user's remaining vault positions by the proportional split below.
+    for address, residual in residual_boosted_shares.items():
+        kept_shares[address] = Wei(kept_shares[address] + residual)
 
     os_token_positions = create_os_token_positions(allocators, kept_shares, min_minted_shares)
     if not os_token_positions:
@@ -471,13 +476,29 @@ async def get_window_redeemed_shares(
 def _reduce_boosted_amount(
     allocators: list[Allocator],
     boost_os_token_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
-) -> list[Allocator]:
-    for allocator in allocators:
-        for vault_share in allocator.vault_os_token_positions:
-            key = allocator.address, vault_share.address
-            boosted_amount = boost_os_token_shares.get(key, Wei(0))
-            vault_share.minted_shares = Wei(max(0, vault_share.minted_shares - boosted_amount))
-    return allocators
+) -> tuple[list[Allocator], dict[ChecksumAddress, Wei]]:
+    """
+    osToken is fungible, so a user's boosted shares aren't necessarily minted at the same
+    vault the leverage strategy borrows against. Match against the same-vault mint first;
+    whatever can't be matched there is returned as a per-user residual instead of being
+    dropped, so the caller can still exclude it from redeemable amounts (as kept shares).
+    """
+    allocators_by_address = {a.address: a for a in allocators}
+    residual_boosted_shares: defaultdict[ChecksumAddress, Wei] = defaultdict(lambda: Wei(0))
+    for (user, vault), boosted_amount in boost_os_token_shares.items():
+        allocator = allocators_by_address.get(user)
+        vault_share = None
+        if allocator is not None:
+            vault_share = next(
+                (vs for vs in allocator.vault_os_token_positions if vs.address == vault), None
+            )
+        matched = min(vault_share.minted_shares, boosted_amount) if vault_share else Wei(0)
+        if vault_share is not None and matched:
+            vault_share.minted_shares = Wei(vault_share.minted_shares - matched)
+        residual = Wei(boosted_amount - matched)
+        if residual:
+            residual_boosted_shares[user] = Wei(residual_boosted_shares[user] + residual)
+    return allocators, residual_boosted_shares
 
 
 def _subtract_window_redeemed_shares(

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -265,9 +265,8 @@ async def process(
         api_config,
     )
     logger.info('Fetched kept tokens for %s addresses...', len(address_to_minted_shares))
-    # boosted shares that couldn't be matched to a same-vault mint are still not sold by the
-    # user; keep them out of redeemable amounts by treating them as kept, spread across the
-    # user's remaining vault positions by the proportional split below.
+    # unmatched boosted shares are still held by the user, so keep them out of redeemable
+    # amounts by treating them as kept.
     for address, residual in residual_boosted_shares.items():
         kept_shares[address] = Wei(kept_shares[address] + residual)
 
@@ -447,15 +446,10 @@ async def get_window_redeemed_shares(
     snapshot_block: BlockNumber,
 ) -> dict[tuple[ChecksumAddress, ChecksumAddress], Wei]:
     """
-    The currently active positions file keeps being redeemed against while this new file
-    is built and (manually, possibly hours later) submitted, but the new file's leaves
-    reset processed shares to zero since the leaf hash includes the nonce. For each
-    (vault, owner) shared with the active file, return the shares processed against it
-    strictly after `snapshot_block` so they can be subtracted from the new leaf and not
-    counted redeemable twice. `nonce` is the current on-chain nonce, read before this
-    run's `setRedeemablePositions` call increments it, matching the active file's leaves.
-    Aborts if the on-chain nonce at `snapshot_block` differs from `nonce`, which means a
-    new file went active in between and the snapshot no longer matches the active file.
+    Returns, for each (vault, owner) shared with the currently active positions file, the
+    shares processed against it strictly after `snapshot_block`, so they can be subtracted
+    from the new leaf instead of being counted redeemable twice. Aborts if the on-chain nonce
+    has changed since `snapshot_block`, since the active file no longer matches the snapshot.
     """
     new_keys = {(p.vault, p.owner) for p in new_positions}
     active_positions = await fetch_positions_from_ipfs(block_number=snapshot_block)
@@ -491,10 +485,9 @@ def _reduce_boosted_amount(
     boost_os_token_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
 ) -> tuple[list[Allocator], dict[ChecksumAddress, Wei]]:
     """
-    osToken is fungible, so a user's boosted shares aren't necessarily minted at the same
-    vault the leverage strategy borrows against. Match against the same-vault mint first;
-    whatever can't be matched there is returned as a per-user residual instead of being
-    dropped, so the caller can still exclude it from redeemable amounts (as kept shares).
+    osToken is fungible, so boosted shares aren't necessarily minted at the same vault the
+    leverage strategy borrows against. Match against the same-vault mint first; return
+    whatever can't be matched there as a per-user residual instead of dropping it.
     """
     allocators_by_address = {a.address: a for a in allocators}
     residual_boosted_shares: defaultdict[ChecksumAddress, Wei] = defaultdict(lambda: Wei(0))

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -282,7 +282,7 @@ async def process(
     )
     if window_redeemed_shares:
         os_token_positions = _subtract_window_redeemed_shares(
-            os_token_positions, window_redeemed_shares
+            os_token_positions, window_redeemed_shares, min_minted_shares
         )
     if not os_token_positions:
         logger.info('No redeemable os token positions to upload, exiting...')
@@ -316,6 +316,10 @@ async def process(
         ],
     )
     click.echo(f'Generated Merkle Tree root: {tree.root}')
+    click.echo(
+        'Submit this root promptly: redemptions processed after this point are not '
+        'subtracted from the amounts above.'
+    )
 
 
 # pylint: disable-next=too-many-locals
@@ -450,12 +454,21 @@ async def get_window_redeemed_shares(
     strictly after `snapshot_block` so they can be subtracted from the new leaf and not
     counted redeemable twice. `nonce` is the current on-chain nonce, read before this
     run's `setRedeemablePositions` call increments it, matching the active file's leaves.
+    Aborts if the on-chain nonce at `snapshot_block` differs from `nonce`, which means a
+    new file went active in between and the snapshot no longer matches the active file.
     """
     new_keys = {(p.vault, p.owner) for p in new_positions}
     active_positions = await fetch_positions_from_ipfs(block_number=snapshot_block)
     matching_positions = [p for p in active_positions if (p.vault, p.owner) in new_keys]
     if not matching_positions:
         return {}
+
+    snapshot_nonce = await os_token_redeemer_contract.nonce(snapshot_block)
+    if snapshot_nonce != nonce:
+        raise RuntimeError(
+            'Active redeemable positions file changed since the snapshot block; rerun to '
+            'rebuild against the currently active file.'
+        )
 
     latest_block = await execution_client.eth.get_block('latest')
     snapshot_processed = [
@@ -504,13 +517,14 @@ def _reduce_boosted_amount(
 def _subtract_window_redeemed_shares(
     positions: list[OsTokenPosition],
     window_redeemed_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
+    min_minted_shares: Wei,
 ) -> list[OsTokenPosition]:
     adjusted_positions = []
     for position in positions:
         redeemed = window_redeemed_shares.get((position.vault, position.owner))
         if redeemed:
             position.leaf_shares = Wei(max(0, position.leaf_shares - redeemed))
-        if position.leaf_shares > 0:
+        if position.leaf_shares > 0 and position.leaf_shares >= min_minted_shares:
             adjusted_positions.append(position)
     return adjusted_positions
 

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -4,7 +4,6 @@ import sys
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import cast
 
 import click
 from eth_typing import BlockNumber, ChecksumAddress
@@ -48,7 +47,6 @@ from src.redemptions.typings import (
     ApiConfig,
     LeverageStrategyPosition,
     OsTokenPosition,
-    VaultOsTokenPosition,
 )
 
 logger = logging.getLogger(__name__)
@@ -437,12 +435,9 @@ def _reduce_boosted_amount(
         allocator = allocators_by_address.get(user)
         if allocator is None:
             continue
-        vault_share = next(
-            (vs for vs in allocator.vault_os_token_positions if vs.address == vault), None
-        )
+        vault_share = allocator.get_vault_position(vault)
         matched = min(vault_share.minted_shares, boosted_amount) if vault_share else Wei(0)
-        if matched:
-            vault_share = cast(VaultOsTokenPosition, vault_share)
+        if vault_share and matched:
             vault_share.minted_shares = Wei(vault_share.minted_shares - matched)
         residual = Wei(boosted_amount - matched)
         if residual:

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -4,6 +4,7 @@ import sys
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import cast
 
 import click
 from eth_typing import BlockNumber, ChecksumAddress
@@ -47,6 +48,7 @@ from src.redemptions.typings import (
     ApiConfig,
     LeverageStrategyPosition,
     OsTokenPosition,
+    VaultOsTokenPosition,
 )
 
 logger = logging.getLogger(__name__)
@@ -433,13 +435,14 @@ def _reduce_boosted_amount(
     residual_boosted_shares: defaultdict[ChecksumAddress, Wei] = defaultdict(lambda: Wei(0))
     for (user, vault), boosted_amount in boost_os_token_shares.items():
         allocator = allocators_by_address.get(user)
-        vault_share = None
-        if allocator is not None:
-            vault_share = next(
-                (vs for vs in allocator.vault_os_token_positions if vs.address == vault), None
-            )
+        if allocator is None:
+            continue
+        vault_share = next(
+            (vs for vs in allocator.vault_os_token_positions if vs.address == vault), None
+        )
         matched = min(vault_share.minted_shares, boosted_amount) if vault_share else Wei(0)
-        if vault_share is not None and matched:
+        if matched:
+            vault_share = cast(VaultOsTokenPosition, vault_share)
             vault_share.minted_shares = Wei(vault_share.minted_shares - matched)
         residual = Wei(boosted_amount - matched)
         if residual:

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -36,10 +36,6 @@ from src.redemptions.api_client import (
     APIClient,
 )
 from src.redemptions.contracts import os_token_redeemer_contract
-from src.redemptions.fetch_positions import (
-    fetch_positions_from_ipfs,
-    iter_processed_shares,
-)
 from src.redemptions.graph import (
     graph_get_leverage_positions,
     graph_get_os_token_holders,
@@ -274,19 +270,6 @@ async def process(
     if not os_token_positions:
         logger.info('No redeemable os token positions to upload, exiting...')
         return
-
-    nonce = await os_token_redeemer_contract.nonce()
-    window_redeemed_shares = await get_window_redeemed_shares(
-        os_token_positions, nonce, block_number
-    )
-    if window_redeemed_shares:
-        os_token_positions = _subtract_window_redeemed_shares(
-            os_token_positions, window_redeemed_shares
-        )
-    if not os_token_positions:
-        logger.info('No redeemable os token positions to upload, exiting...')
-        return
-
     total_redeemable = sum(p.leaf_shares for p in os_token_positions)
     logger.info(
         'Created %(count)s redeemable os token positions. '
@@ -304,6 +287,7 @@ async def process(
     click.echo(f'Redeemable os token positions uploaded to IPFS: hash={ipfs_hash}')
 
     # calculate merkle root
+    nonce = await os_token_redeemer_contract.nonce()
     leaves = [r.merkle_leaf(nonce) for r in os_token_positions]
     tree = StandardMerkleTree.of(
         leaves,
@@ -436,42 +420,6 @@ def create_os_token_positions(
     return os_token_positions
 
 
-async def get_window_redeemed_shares(
-    new_positions: list[OsTokenPosition],
-    nonce: int,
-    snapshot_block: BlockNumber,
-) -> dict[tuple[ChecksumAddress, ChecksumAddress], Wei]:
-    """
-    The currently active positions file keeps being redeemed against while this new file
-    is built and (manually, possibly hours later) submitted, but the new file's leaves
-    reset processed shares to zero since the leaf hash includes the nonce. For each
-    (vault, owner) shared with the active file, return the shares processed against it
-    strictly after `snapshot_block` so they can be subtracted from the new leaf and not
-    counted redeemable twice. `nonce` is the current on-chain nonce, read before this
-    run's `setRedeemablePositions` call increments it, matching the active file's leaves.
-    """
-    new_keys = {(p.vault, p.owner) for p in new_positions}
-    active_positions = await fetch_positions_from_ipfs(block_number=snapshot_block)
-    matching_positions = [p for p in active_positions if (p.vault, p.owner) in new_keys]
-    if not matching_positions:
-        return {}
-
-    latest_block = await execution_client.eth.get_block('latest')
-    snapshot_processed = [
-        shares async for shares in iter_processed_shares(matching_positions, nonce, snapshot_block)
-    ]
-    current_processed = [
-        shares
-        async for shares in iter_processed_shares(matching_positions, nonce, latest_block['number'])
-    ]
-    return {
-        (position.vault, position.owner): Wei(max(0, current - snapshot))
-        for position, snapshot, current in zip(
-            matching_positions, snapshot_processed, current_processed
-        )
-    }
-
-
 def _reduce_boosted_amount(
     allocators: list[Allocator],
     boost_os_token_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
@@ -497,20 +445,6 @@ def _reduce_boosted_amount(
         if residual:
             residual_boosted_shares[user] = Wei(residual_boosted_shares[user] + residual)
     return allocators, residual_boosted_shares
-
-
-def _subtract_window_redeemed_shares(
-    positions: list[OsTokenPosition],
-    window_redeemed_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
-) -> list[OsTokenPosition]:
-    adjusted_positions = []
-    for position in positions:
-        redeemed = window_redeemed_shares.get((position.vault, position.owner))
-        if redeemed:
-            position.leaf_shares = Wei(max(0, position.leaf_shares - redeemed))
-        if position.leaf_shares > 0:
-            adjusted_positions.append(position)
-    return adjusted_positions
 
 
 async def _startup_check() -> None:

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -281,7 +281,7 @@ async def process(
     )
     if window_redeemed_shares:
         os_token_positions = _subtract_window_redeemed_shares(
-            os_token_positions, window_redeemed_shares, min_minted_shares
+            os_token_positions, window_redeemed_shares
         )
     if not os_token_positions:
         logger.info('No redeemable os token positions to upload, exiting...')
@@ -315,10 +315,6 @@ async def process(
         ],
     )
     click.echo(f'Generated Merkle Tree root: {tree.root}')
-    click.echo(
-        'Submit this root promptly: redemptions processed after this point are not '
-        'subtracted from the amounts above.'
-    )
 
 
 # pylint: disable-next=too-many-locals
@@ -446,23 +442,19 @@ async def get_window_redeemed_shares(
     snapshot_block: BlockNumber,
 ) -> dict[tuple[ChecksumAddress, ChecksumAddress], Wei]:
     """
-    Returns, for each (vault, owner) shared with the currently active positions file, the
-    shares processed against it strictly after `snapshot_block`, so they can be subtracted
-    from the new leaf instead of being counted redeemable twice. Aborts if the on-chain nonce
-    has changed since `snapshot_block`, since the active file no longer matches the snapshot.
+    The currently active positions file keeps being redeemed against while this new file
+    is built and (manually, possibly hours later) submitted, but the new file's leaves
+    reset processed shares to zero since the leaf hash includes the nonce. For each
+    (vault, owner) shared with the active file, return the shares processed against it
+    strictly after `snapshot_block` so they can be subtracted from the new leaf and not
+    counted redeemable twice. `nonce` is the current on-chain nonce, read before this
+    run's `setRedeemablePositions` call increments it, matching the active file's leaves.
     """
     new_keys = {(p.vault, p.owner) for p in new_positions}
     active_positions = await fetch_positions_from_ipfs(block_number=snapshot_block)
     matching_positions = [p for p in active_positions if (p.vault, p.owner) in new_keys]
     if not matching_positions:
         return {}
-
-    snapshot_nonce = await os_token_redeemer_contract.nonce(snapshot_block)
-    if snapshot_nonce != nonce:
-        raise RuntimeError(
-            'Active redeemable positions file changed since the snapshot block; rerun to '
-            'rebuild against the currently active file.'
-        )
 
     latest_block = await execution_client.eth.get_block('latest')
     snapshot_processed = [
@@ -510,14 +502,13 @@ def _reduce_boosted_amount(
 def _subtract_window_redeemed_shares(
     positions: list[OsTokenPosition],
     window_redeemed_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
-    min_minted_shares: Wei,
 ) -> list[OsTokenPosition]:
     adjusted_positions = []
     for position in positions:
         redeemed = window_redeemed_shares.get((position.vault, position.owner))
         if redeemed:
             position.leaf_shares = Wei(max(0, position.leaf_shares - redeemed))
-        if position.leaf_shares > 0 and position.leaf_shares >= min_minted_shares:
+        if position.leaf_shares > 0:
             adjusted_positions.append(position)
     return adjusted_positions
 

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -36,6 +36,10 @@ from src.redemptions.api_client import (
     APIClient,
 )
 from src.redemptions.contracts import os_token_redeemer_contract
+from src.redemptions.fetch_positions import (
+    fetch_positions_from_ipfs,
+    iter_processed_shares,
+)
 from src.redemptions.graph import (
     graph_get_leverage_positions,
     graph_get_os_token_holders,
@@ -266,6 +270,19 @@ async def process(
     if not os_token_positions:
         logger.info('No redeemable os token positions to upload, exiting...')
         return
+
+    nonce = await os_token_redeemer_contract.nonce()
+    window_redeemed_shares = await get_window_redeemed_shares(
+        os_token_positions, nonce, block_number
+    )
+    if window_redeemed_shares:
+        os_token_positions = _subtract_window_redeemed_shares(
+            os_token_positions, window_redeemed_shares
+        )
+    if not os_token_positions:
+        logger.info('No redeemable os token positions to upload, exiting...')
+        return
+
     total_redeemable = sum(p.leaf_shares for p in os_token_positions)
     logger.info(
         'Created %(count)s redeemable os token positions. '
@@ -283,7 +300,6 @@ async def process(
     click.echo(f'Redeemable os token positions uploaded to IPFS: hash={ipfs_hash}')
 
     # calculate merkle root
-    nonce = await os_token_redeemer_contract.nonce()
     leaves = [r.merkle_leaf(nonce) for r in os_token_positions]
     tree = StandardMerkleTree.of(
         leaves,
@@ -416,6 +432,42 @@ def create_os_token_positions(
     return os_token_positions
 
 
+async def get_window_redeemed_shares(
+    new_positions: list[OsTokenPosition],
+    nonce: int,
+    snapshot_block: BlockNumber,
+) -> dict[tuple[ChecksumAddress, ChecksumAddress], Wei]:
+    """
+    The currently active positions file keeps being redeemed against while this new file
+    is built and (manually, possibly hours later) submitted, but the new file's leaves
+    reset processed shares to zero since the leaf hash includes the nonce. For each
+    (vault, owner) shared with the active file, return the shares processed against it
+    strictly after `snapshot_block` so they can be subtracted from the new leaf and not
+    counted redeemable twice. `nonce` is the current on-chain nonce, read before this
+    run's `setRedeemablePositions` call increments it, matching the active file's leaves.
+    """
+    new_keys = {(p.vault, p.owner) for p in new_positions}
+    active_positions = await fetch_positions_from_ipfs(block_number=snapshot_block)
+    matching_positions = [p for p in active_positions if (p.vault, p.owner) in new_keys]
+    if not matching_positions:
+        return {}
+
+    latest_block = await execution_client.eth.get_block('latest')
+    snapshot_processed = [
+        shares async for shares in iter_processed_shares(matching_positions, nonce, snapshot_block)
+    ]
+    current_processed = [
+        shares
+        async for shares in iter_processed_shares(matching_positions, nonce, latest_block['number'])
+    ]
+    return {
+        (position.vault, position.owner): Wei(max(0, current - snapshot))
+        for position, snapshot, current in zip(
+            matching_positions, snapshot_processed, current_processed
+        )
+    }
+
+
 def _reduce_boosted_amount(
     allocators: list[Allocator],
     boost_os_token_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
@@ -426,6 +478,20 @@ def _reduce_boosted_amount(
             boosted_amount = boost_os_token_shares.get(key, Wei(0))
             vault_share.minted_shares = Wei(max(0, vault_share.minted_shares - boosted_amount))
     return allocators
+
+
+def _subtract_window_redeemed_shares(
+    positions: list[OsTokenPosition],
+    window_redeemed_shares: dict[tuple[ChecksumAddress, ChecksumAddress], Wei],
+) -> list[OsTokenPosition]:
+    adjusted_positions = []
+    for position in positions:
+        redeemed = window_redeemed_shares.get((position.vault, position.owner))
+        if redeemed:
+            position.leaf_shares = Wei(max(0, position.leaf_shares - redeemed))
+        if position.leaf_shares > 0:
+            adjusted_positions.append(position)
+    return adjusted_positions
 
 
 async def _startup_check() -> None:

--- a/src/redemptions/typings.py
+++ b/src/redemptions/typings.py
@@ -29,6 +29,9 @@ class Allocator:
             return {}
         return {s.address: s.minted_shares / total for s in self.vault_os_token_positions}
 
+    def get_vault_position(self, vault: ChecksumAddress) -> VaultOsTokenPosition | None:
+        return next((vs for vs in self.vault_os_token_positions if vs.address == vault), None)
+
 
 @dataclass
 class LeverageStrategyPosition:


### PR DESCRIPTION
## Description

Boost reduction in `update-redeemable-positions` was keyed by (user, leverage-strategy vault), but osToken is fungible — `LeverageStrategy.deposit` accepts osETH minted anywhere. Example: a user mints 50 osETH in vault A and boosts it into a strategy keyed to vault B; their wallet balance is 0 (the osETH sits under the strategy proxy) and the DeBank client intentionally skips StakeWise protocol positions, so kept shares came out as 0 and the entire vault-A mint became a redeemable leaf — boost-locked osETH was treated as sold. The on-chain `osTokenPositions(owner)` cap doesn't protect here since the mint position genuinely exists, so this produced wrongful forced redemptions. The same keying also dropped the residual for multi-vault minters whose boost exceeded their same-vault mints, via the `max(0, ...)` clamp.

Boosted shares are now aggregated per user across all vaults, and any residual left after matching same-vault mints is added to the user's kept shares instead of being dropped.