### PR TITLE
Add build_consensus_validators builder

### DIFF
--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -1,3 +1,5 @@
+from eth_typing import HexStr
+
 INVALID_ORACLES_REQUEST = 'Invalid oracles request'
 NOT_ENOUGH_ORACLE_APPROVALS = 'Not enough oracle approvals received'
 
@@ -12,3 +14,23 @@ class NotEnoughOracleApprovalsError(ValueError):
         super().__init__(NOT_ENOUGH_ORACLE_APPROVALS)
         self.num_votes = num_votes
         self.threshold = threshold
+
+
+class MissingConsolidationDataError(RuntimeError):
+    """
+    Raised when code that relies on consolidation data gets validators built without
+    `with_consolidations=True`: treating the missing data as "not consolidating" would
+    silently include consolidation sources and targets.
+    """
+
+    MESSAGE = (
+        'Consolidation data is not loaded for validator {}. '
+        'Build the validators with `with_consolidations=True`.'
+    )
+
+    def __init__(self, public_key: HexStr):
+        super().__init__()
+        self.public_key = public_key
+
+    def __str__(self) -> str:
+        return self.MESSAGE.format(self.public_key)

--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -1,5 +1,3 @@
-from eth_typing import HexStr
-
 INVALID_ORACLES_REQUEST = 'Invalid oracles request'
 NOT_ENOUGH_ORACLE_APPROVALS = 'Not enough oracle approvals received'
 
@@ -14,23 +12,3 @@ class NotEnoughOracleApprovalsError(ValueError):
         super().__init__(NOT_ENOUGH_ORACLE_APPROVALS)
         self.num_votes = num_votes
         self.threshold = threshold
-
-
-class MissingConsolidationDataError(RuntimeError):
-    """
-    Raised when code that relies on consolidation data gets validators built without
-    `with_consolidations=True`: treating the missing data as "not consolidating" would
-    silently include consolidation sources and targets.
-    """
-
-    MESSAGE = (
-        'Consolidation data is not loaded for validator {}. '
-        'Build the validators with `with_consolidations=True`.'
-    )
-
-    def __init__(self, public_key: HexStr):
-        super().__init__()
-        self.public_key = public_key
-
-    def __str__(self) -> str:
-        return self.MESSAGE.format(self.public_key)

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from dataclasses import replace
 from itertools import batched
-from typing import Collection
+from typing import Collection, cast
 
 from eth_typing import HexStr
 from sw_utils import ChainHead, ValidatorStatus
@@ -12,7 +12,6 @@ from web3.types import Gwei
 from src.common.clients import consensus_client
 from src.common.consensus import get_chain_latest_head
 from src.common.consolidations import get_pending_consolidations
-from src.common.exceptions import MissingConsolidationDataError
 from src.common.typings import PendingConsolidation
 from src.config.settings import settings
 from src.validators.database import VaultValidatorCrud
@@ -51,13 +50,11 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
 
     validators_balances: dict[HexStr, Gwei] = {}
     for validator in validators:
-        consolidation_data = validator.consolidation_data
-        if consolidation_data is None:
-            raise MissingConsolidationDataError(validator.public_key)
-
         # Non-compounding and exiting/withdrawn validators are not eligible for funding.
         if not validator.is_compounding or validator.status in EXITING_STATUSES:
             continue
+
+        consolidation_data = cast(ValidatorConsolidationData, validator.consolidation_data)
 
         # Consolidation sources are drained into their targets, so they are not funded.
         if consolidation_data.is_source:

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -12,11 +12,12 @@ from web3.types import Gwei
 from src.common.clients import consensus_client
 from src.common.consensus import get_chain_latest_head
 from src.common.consolidations import get_pending_consolidations
+from src.common.exceptions import MissingConsolidationDataError
 from src.common.typings import PendingConsolidation
 from src.config.settings import settings
 from src.validators.database import VaultValidatorCrud
 from src.validators.event_processors import get_latest_vault_v2_validator_public_keys
-from src.validators.typings import ConsensusValidator
+from src.validators.typings import ConsensusValidator, ValidatorConsolidationData
 
 EXITING_STATUSES = [
     ValidatorStatus.ACTIVE_EXITING,
@@ -50,23 +51,27 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
 
     validators_balances: dict[HexStr, Gwei] = {}
     for validator in validators:
+        consolidation_data = validator.consolidation_data
+        if consolidation_data is None:
+            raise MissingConsolidationDataError(validator.public_key)
+
         # Non-compounding and exiting/withdrawn validators are not eligible for funding.
         if not validator.is_compounding or validator.status in EXITING_STATUSES:
             continue
 
         # Consolidation sources are drained into their targets, so they are not funded.
-        if validator.is_consolidation_source:
+        if consolidation_data.is_source:
             continue
 
         # Drop targets whose source balance is unknown instead of guessing
         # their post-consolidation balance.
-        if validator.is_consolidation_target and validator.target_consolidation_balance is None:
+        if consolidation_data.is_target and consolidation_data.target_balance is None:
             continue
 
         validators_balances[validator.public_key] = Gwei(
             validator.balance
             + (validator.pending_balance or 0)
-            + (validator.target_consolidation_balance or 0)
+            + (consolidation_data.target_balance or 0)
         )
 
     return validators_balances
@@ -91,10 +96,8 @@ async def build_consensus_validators(
     (0x02) withdrawal credentials: non-0x02 deposits are still processed by the CL, but they
     never contribute fundable compounding balance.
 
-    ``with_consolidations`` fills in ``is_consolidation_source``, ``is_consolidation_target``
-    and ``target_consolidation_balance``. The latter is the total balance the target will
-    receive from its pending consolidation sources; it stays ``None`` when at least one of
-    the sources is not among the fetched validators, i.e. its balance is unknown.
+    ``with_consolidations`` fills in ``consolidation_data``, which stays ``None`` when the
+    data was not requested.
     """
     if not public_keys:
         return []
@@ -116,6 +119,17 @@ async def build_consensus_validators(
             slot=slot,
             compounding_deposits_only=compounding_deposits_only,
         )
+        if with_consolidations:
+            # Fill in empty consolidation data for consistency with the rest of the
+            # returned validators. Validators that are not in the beacon state yet
+            # can't take part in consolidations.
+            new_validators = [
+                replace(
+                    val,
+                    consolidation_data=ValidatorConsolidationData(is_source=False, is_target=False),
+                )
+                for val in new_validators
+            ]
         validators += new_validators
 
     return validators
@@ -125,8 +139,9 @@ def _apply_pending_consolidations(
     validators: list[ConsensusValidator], pending_consolidations: list[PendingConsolidation]
 ) -> list[ConsensusValidator]:
     """
-    Returns a copy of ``validators``, in the same order, with the consolidation fields
-    filled in.
+    Returns a copy of ``validators``, in the same order, with ``consolidation_data``
+    filled in. ``target_balance`` stays ``None`` when at least one of the target's sources
+    is not among the fetched validators, i.e. its balance is unknown.
     """
     index_to_validator = {val.index: val for val in validators}
 
@@ -152,17 +167,21 @@ def _apply_pending_consolidations(
                 target_balances[cons.target_index] + source.balance
             )
 
-    return [
-        replace(
-            val,
-            is_consolidation_source=val.index in source_indexes,
-            is_consolidation_target=val.index in target_indexes,
-            target_consolidation_balance=(
-                None if val.index in unknown_source_targets else target_balances.get(val.index)
-            ),
+    enriched_validators = []
+    for val in validators:
+        if val.index in unknown_source_targets:
+            target_balance = None
+        else:
+            target_balance = target_balances.get(val.index)
+
+        consolidation_data = ValidatorConsolidationData(
+            is_source=val.index in source_indexes,
+            is_target=val.index in target_indexes,
+            target_balance=target_balance,
         )
-        for val in validators
-    ]
+        enriched_validators.append(replace(val, consolidation_data=consolidation_data))
+
+    return enriched_validators
 
 
 async def apply_pending_deposits(

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -1,15 +1,17 @@
 import logging
 from collections import defaultdict
 from itertools import batched
+from typing import Collection
 
 from eth_typing import HexStr
-from sw_utils import ValidatorStatus
+from sw_utils import ChainHead, ValidatorStatus
 from sw_utils.consensus import EXITED_STATUSES
 from web3.types import Gwei
 
 from src.common.clients import consensus_client
 from src.common.consensus import get_chain_latest_head
 from src.common.consolidations import get_pending_consolidations
+from src.common.typings import PendingConsolidation
 from src.config.settings import settings
 from src.validators.database import VaultValidatorCrud
 from src.validators.event_processors import get_latest_vault_v2_validator_public_keys
@@ -20,10 +22,13 @@ EXITING_STATUSES = [
     ValidatorStatus.ACTIVE_SLASHED,
 ] + EXITED_STATUSES
 
+# Index assigned to validators that are not present in the beacon state yet
+# and were built solely from their pending deposits.
+UNKNOWN_VALIDATOR_INDEX = -1
+
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable-next=too-many-locals
 async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     """
     Retrieves the consensus balances of vault validators eligible for funding.
@@ -35,98 +40,156 @@ async def fetch_funding_validators_balances() -> dict[HexStr, Gwei]:
     if not vault_public_keys:
         return {}
 
-    # Fetch consensus validators and pending consolidations from one consistent snapshot
-    chain_head = await get_chain_latest_head()
-    slot = str(chain_head.slot)
-    consensus_validators = await fetch_consensus_validators(list(vault_public_keys), slot=slot)
-    pending_consolidations = await get_pending_consolidations(chain_head, consensus_validators)
-
-    # Filter compounding and remove exiting/withdrawn validators, as they are not
-    # eligible for funding.
-    validators_balances: dict[HexStr, Gwei] = {}
-    ineligible_public_keys: set[HexStr] = set()
-    index_to_validator: dict[int, ConsensusValidator] = {}
-    for validator in consensus_validators:
-        index_to_validator[validator.index] = validator
-        if validator.is_compounding and validator.status not in EXITING_STATUSES:
-            validators_balances[validator.public_key] = validator.balance
-        else:
-            ineligible_public_keys.add(validator.public_key)
-
-    # Exclude pending consolidation sources from funding and credit their balances
-    # to the targets; drop targets whose source balance is unknown.
-    for cons in pending_consolidations:
-        target = index_to_validator.get(cons.target_index)
-        source = index_to_validator.get(cons.source_index)
-        if source is None:
-            if target is not None:
-                validators_balances.pop(target.public_key, None)
-                ineligible_public_keys.add(target.public_key)
-        else:
-            validators_balances.pop(source.public_key, None)
-            ineligible_public_keys.add(source.public_key)
-            if target is not None and target.public_key in validators_balances:
-                validators_balances[target.public_key] = Gwei(
-                    validators_balances[target.public_key] + source.balance
-                )
-
-    # Keys not yet known to the consensus node are eligible too,
-    # their balances come solely from pending deposits.
-    eligible_public_keys = vault_public_keys - ineligible_public_keys
-
-    # Add balances from pending deposits that are not yet reflected in the consensus node.
-    pending_deposits_amounts = await fetch_compounding_pending_deposits_amounts(
-        public_keys=eligible_public_keys, slot=slot
+    validators = await build_consensus_validators(
+        public_keys=vault_public_keys,
+        with_pending_deposits=True,
+        with_consolidations=True,
+        compounding_deposits_only=True,
     )
-    for public_key, amount in pending_deposits_amounts.items():
-        validators_balances[public_key] = Gwei(
-            validators_balances.get(public_key, Gwei(0)) + amount
+
+    validators_balances: dict[HexStr, Gwei] = {}
+    for validator in validators:
+        # Non-compounding and exiting/withdrawn validators are not eligible for funding.
+        if not validator.is_compounding or validator.status in EXITING_STATUSES:
+            continue
+
+        # Consolidation sources are drained into their targets, so they are not funded.
+        if validator.is_consolidation_source:
+            continue
+
+        # Drop targets whose source balance is unknown instead of guessing
+        # their post-consolidation balance.
+        if validator.is_consolidation_target and validator.target_consolidation_balance is None:
+            continue
+
+        validators_balances[validator.public_key] = Gwei(
+            validator.balance
+            + (validator.pending_balance or 0)
+            + (validator.target_consolidation_balance or 0)
         )
 
     return validators_balances
 
 
-async def fetch_compounding_pending_deposits_amounts(
-    public_keys: set[HexStr], slot: str
-) -> dict[HexStr, Gwei]:
+async def build_consensus_validators(
+    public_keys: Collection[HexStr],
+    chain_head: ChainHead | None = None,
+    with_pending_deposits: bool = False,
+    with_consolidations: bool = False,
+    compounding_deposits_only: bool = False,
+) -> list[ConsensusValidator]:
     """
-    Sums pending-deposit-queue amounts (Gwei) per pubkey, restricted to ``public_keys``.
-    Only deposits with compounding (0x02) withdrawal credentials are counted:
-    non-0x02 deposits are still processed by the CL, but they never contribute
-    fundable compounding balance, so counting them would overstate top-up capacity.
+    Fetches the consensus validators for ``public_keys`` and optionally enriches them with
+    the pending deposits and pending consolidations data from the same chain snapshot.
+
+    ``with_pending_deposits`` fills in ``pending_balance`` and additionally returns validators
+    that are not present in the beacon state yet, but already have pending deposits. Such
+    validators get ``UNKNOWN_VALIDATOR_INDEX`` and their withdrawal credentials come from
+    the deposit itself.
+    ``compounding_deposits_only`` restricts pending deposits to the ones with compounding
+    (0x02) withdrawal credentials: non-0x02 deposits are still processed by the CL, but they
+    never contribute fundable compounding balance.
+
+    ``with_consolidations`` fills in ``is_consolidation_source``, ``is_consolidation_target``
+    and ``target_consolidation_balance``. The latter is the total balance the target will
+    receive from its pending consolidation sources; it stays ``None`` when at least one of
+    the sources is not among the fetched validators, i.e. its balance is unknown.
     """
     if not public_keys:
-        return {}
+        return []
 
-    pending_amounts: dict[HexStr, Gwei] = defaultdict(lambda: Gwei(0))
-    all_pending_deposits = await consensus_client.get_pending_deposits(slot)
-    for deposit in all_pending_deposits:
+    chain_head = chain_head or await get_chain_latest_head()
+    slot = str(chain_head.slot)
+    validators = await fetch_consensus_validators(list(public_keys), slot=slot)
+
+    if with_consolidations:
+        _apply_pending_consolidations(
+            validators=validators,
+            pending_consolidations=await get_pending_consolidations(chain_head, validators),
+        )
+
+    if with_pending_deposits:
+        validators += await apply_pending_deposits(
+            validators=validators,
+            public_keys=set(public_keys),
+            slot=slot,
+            compounding_deposits_only=compounding_deposits_only,
+        )
+
+    return validators
+
+
+def _apply_pending_consolidations(
+    validators: list[ConsensusValidator], pending_consolidations: list[PendingConsolidation]
+) -> None:
+    index_to_validator = {val.index: val for val in validators}
+
+    target_balances: dict[int, Gwei] = defaultdict(lambda: Gwei(0))
+    unknown_source_targets: set[int] = set()
+
+    for cons in pending_consolidations:
+        source = index_to_validator.get(cons.source_index)
+        if source is not None:
+            source.is_consolidation_source = True
+
+        target = index_to_validator.get(cons.target_index)
+        if target is None:
+            continue
+        target.is_consolidation_target = True
+
+        if source is None:
+            unknown_source_targets.add(cons.target_index)
+        else:
+            target_balances[cons.target_index] = Gwei(
+                target_balances[cons.target_index] + source.balance
+            )
+
+    for index, balance in target_balances.items():
+        if index not in unknown_source_targets:
+            index_to_validator[index].target_consolidation_balance = balance
+
+
+async def apply_pending_deposits(
+    validators: list[ConsensusValidator],
+    public_keys: set[HexStr],
+    slot: str,
+    compounding_deposits_only: bool = False,
+) -> list[ConsensusValidator]:
+    """
+    Fills in ``pending_balance`` of ``validators`` in place and returns the validators that
+    are not present in the beacon state yet, but already have pending deposits.
+    Can be called separately from `build_consensus_validators` to delay fetching the
+    pending deposit queue until it is really needed.
+    """
+    new_validators: list[ConsensusValidator] = []
+    public_key_to_validator = {val.public_key: val for val in validators}
+
+    for deposit in await consensus_client.get_pending_deposits(slot):
         public_key: HexStr = deposit['pubkey']
         if public_key not in public_keys:
             continue
-        if not deposit['withdrawal_credentials'].startswith('0x02'):
+
+        withdrawal_credentials: HexStr = deposit['withdrawal_credentials']
+        if compounding_deposits_only and not withdrawal_credentials.startswith('0x02'):
             continue
-        pending_amounts[public_key] = Gwei(pending_amounts[public_key] + int(deposit['amount']))
 
-    return dict(pending_amounts)
+        validator = public_key_to_validator.get(public_key)
+        if validator is None:
+            # Validator is not present in the beacon state yet
+            validator = ConsensusValidator(
+                index=UNKNOWN_VALIDATOR_INDEX,
+                public_key=public_key,
+                balance=Gwei(0),
+                withdrawal_credentials=withdrawal_credentials,
+                status=ValidatorStatus.PENDING_INITIALIZED,
+                activation_epoch=settings.network_config.FAR_FUTURE_EPOCH,
+            )
+            public_key_to_validator[public_key] = validator
+            new_validators.append(validator)
 
+        validator.pending_balance = Gwei((validator.pending_balance or 0) + int(deposit['amount']))
 
-async def fetch_pending_deposits_amounts(public_keys: set[HexStr], slot: str) -> dict[HexStr, Gwei]:
-    """
-    Sums pending-deposit-queue amounts (Gwei) per pubkey, restricted to ``public_keys``.
-    """
-    if not public_keys:
-        return {}
-
-    pending_amounts: dict[HexStr, Gwei] = defaultdict(lambda: Gwei(0))
-    all_pending_deposits = await consensus_client.get_pending_deposits(slot)
-    for deposit in all_pending_deposits:
-        public_key: HexStr = deposit['pubkey']
-        if public_key not in public_keys:
-            continue
-        pending_amounts[public_key] = Gwei(pending_amounts[public_key] + int(deposit['amount']))
-
-    return dict(pending_amounts)
+    return new_validators
 
 
 async def fetch_consensus_validators(

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from dataclasses import replace
 from itertools import batched
 from typing import Collection
 
@@ -103,50 +104,65 @@ async def build_consensus_validators(
     validators = await fetch_consensus_validators(list(public_keys), slot=slot)
 
     if with_consolidations:
-        _apply_pending_consolidations(
+        validators = _apply_pending_consolidations(
             validators=validators,
             pending_consolidations=await get_pending_consolidations(chain_head, validators),
         )
 
     if with_pending_deposits:
-        validators += await apply_pending_deposits(
+        validators, new_validators = await apply_pending_deposits(
             validators=validators,
             public_keys=set(public_keys),
             slot=slot,
             compounding_deposits_only=compounding_deposits_only,
         )
+        validators += new_validators
 
     return validators
 
 
 def _apply_pending_consolidations(
     validators: list[ConsensusValidator], pending_consolidations: list[PendingConsolidation]
-) -> None:
+) -> list[ConsensusValidator]:
+    """
+    Returns a copy of ``validators``, in the same order, with the consolidation fields
+    filled in.
+    """
     index_to_validator = {val.index: val for val in validators}
 
+    source_indexes: set[int] = set()
+    target_indexes: set[int] = set()
     target_balances: dict[int, Gwei] = defaultdict(lambda: Gwei(0))
     unknown_source_targets: set[int] = set()
 
     for cons in pending_consolidations:
         source = index_to_validator.get(cons.source_index)
         if source is not None:
-            source.is_consolidation_source = True
+            source_indexes.add(cons.source_index)
 
-        target = index_to_validator.get(cons.target_index)
-        if target is None:
+        if cons.target_index not in index_to_validator:
             continue
-        target.is_consolidation_target = True
+        target_indexes.add(cons.target_index)
 
         if source is None:
+            # The source balance is unknown, so the target balance can't be determined
             unknown_source_targets.add(cons.target_index)
         else:
             target_balances[cons.target_index] = Gwei(
                 target_balances[cons.target_index] + source.balance
             )
 
-    for index, balance in target_balances.items():
-        if index not in unknown_source_targets:
-            index_to_validator[index].target_consolidation_balance = balance
+    return [
+        replace(
+            val,
+            is_consolidation_source=val.index in source_indexes,
+            is_consolidation_target=val.index in target_indexes,
+            target_consolidation_balance=(
+                None if val.index in unknown_source_targets else target_balances.get(val.index)
+            ),
+        )
+        for val in validators
+    ]
 
 
 async def apply_pending_deposits(
@@ -154,15 +170,19 @@ async def apply_pending_deposits(
     public_keys: set[HexStr],
     slot: str,
     compounding_deposits_only: bool = False,
-) -> list[ConsensusValidator]:
+) -> tuple[list[ConsensusValidator], list[ConsensusValidator]]:
     """
-    Fills in ``pending_balance`` of ``validators`` in place and returns the validators that
-    are not present in the beacon state yet, but already have pending deposits.
+    Returns a tuple of:
+    1) a copy of ``validators``, in the same order, with ``pending_balance`` filled in
+    2) validators that are not present in the beacon state yet, but already have
+       pending deposits
+
     Can be called separately from `build_consensus_validators` to delay fetching the
     pending deposit queue until it is really needed.
     """
-    new_validators: list[ConsensusValidator] = []
-    public_key_to_validator = {val.public_key: val for val in validators}
+    known_public_keys = {val.public_key for val in validators}
+    pending_balances: dict[HexStr, Gwei] = defaultdict(lambda: Gwei(0))
+    new_credentials: dict[HexStr, HexStr] = {}
 
     for deposit in await consensus_client.get_pending_deposits(slot):
         public_key: HexStr = deposit['pubkey']
@@ -173,23 +193,27 @@ async def apply_pending_deposits(
         if compounding_deposits_only and not withdrawal_credentials.startswith('0x02'):
             continue
 
-        validator = public_key_to_validator.get(public_key)
-        if validator is None:
+        pending_balances[public_key] = Gwei(pending_balances[public_key] + int(deposit['amount']))
+        if public_key not in known_public_keys:
             # Validator is not present in the beacon state yet
-            validator = ConsensusValidator(
-                index=UNKNOWN_VALIDATOR_INDEX,
-                public_key=public_key,
-                balance=Gwei(0),
-                withdrawal_credentials=withdrawal_credentials,
-                status=ValidatorStatus.PENDING_INITIALIZED,
-                activation_epoch=settings.network_config.FAR_FUTURE_EPOCH,
-            )
-            public_key_to_validator[public_key] = validator
-            new_validators.append(validator)
+            new_credentials.setdefault(public_key, withdrawal_credentials)
 
-        validator.pending_balance = Gwei((validator.pending_balance or 0) + int(deposit['amount']))
-
-    return new_validators
+    enriched_validators = [
+        replace(val, pending_balance=pending_balances.get(val.public_key)) for val in validators
+    ]
+    new_validators = [
+        ConsensusValidator(
+            index=UNKNOWN_VALIDATOR_INDEX,
+            public_key=public_key,
+            balance=Gwei(0),
+            withdrawal_credentials=withdrawal_credentials,
+            status=ValidatorStatus.PENDING_INITIALIZED,
+            activation_epoch=settings.network_config.FAR_FUTURE_EPOCH,
+            pending_balance=pending_balances[public_key],
+        )
+        for public_key, withdrawal_credentials in new_credentials.items()
+    ]
+    return enriched_validators, new_validators
 
 
 async def fetch_consensus_validators(

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -211,7 +211,10 @@ async def apply_pending_deposits(
 
         pending_balances[public_key] = Gwei(pending_balances[public_key] + int(deposit['amount']))
         if public_key not in known_public_keys:
-            # Validator is not present in the beacon state yet
+            # Validator is not present in the beacon state yet.
+            # A validator's withdrawal credentials are set
+            # by the deposit that creates it, and later deposits in the queue
+            # for the same pubkey don't change them.
             new_credentials.setdefault(public_key, withdrawal_credentials)
 
     enriched_validators = [

--- a/src/validators/tests/factories.py
+++ b/src/validators/tests/factories.py
@@ -4,7 +4,7 @@ from sw_utils.tests import faker
 from web3.types import Gwei
 
 from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI, settings
-from src.validators.typings import ConsensusValidator
+from src.validators.typings import ConsensusValidator, ValidatorConsolidationData
 
 
 def create_consensus_validator(
@@ -16,14 +16,17 @@ def create_consensus_validator(
     is_compounding: bool = True,
     withdrawal_address: ChecksumAddress | None = None,
     pending_balance: Gwei | None = None,
-    target_consolidation_balance: Gwei | None = None,
-    is_consolidation_source: bool = False,
-    is_consolidation_target: bool = False,
+    consolidation_data: ValidatorConsolidationData | None = None,
+    # Set to False to build a validator whose consolidation data was not loaded
+    with_consolidation_data: bool = True,
 ) -> ConsensusValidator:
     # settings.vault is unset in tests that don't use the fake_settings fixture
     withdrawal_address = (
         withdrawal_address or getattr(settings, 'vault', None) or faker.eth_address()
     )
+    if consolidation_data is None and with_consolidation_data:
+        consolidation_data = ValidatorConsolidationData(is_source=False, is_target=False)
+
     return ConsensusValidator(
         public_key=public_key or faker.validator_public_key(),
         status=status,
@@ -36,9 +39,7 @@ def create_consensus_validator(
         ),
         activation_epoch=activation_epoch,
         pending_balance=pending_balance,
-        target_consolidation_balance=target_consolidation_balance,
-        is_consolidation_source=is_consolidation_source,
-        is_consolidation_target=is_consolidation_target,
+        consolidation_data=consolidation_data,
     )
 
 

--- a/src/validators/tests/factories.py
+++ b/src/validators/tests/factories.py
@@ -15,6 +15,10 @@ def create_consensus_validator(
     activation_epoch: int | None = None,
     is_compounding: bool = True,
     withdrawal_address: ChecksumAddress | None = None,
+    pending_balance: Gwei | None = None,
+    target_consolidation_balance: Gwei | None = None,
+    is_consolidation_source: bool = False,
+    is_consolidation_target: bool = False,
 ) -> ConsensusValidator:
     # settings.vault is unset in tests that don't use the fake_settings fixture
     withdrawal_address = (
@@ -31,6 +35,10 @@ def create_consensus_validator(
             else _build_non_compound_credentials(withdrawal_address)
         ),
         activation_epoch=activation_epoch,
+        pending_balance=pending_balance,
+        target_consolidation_balance=target_consolidation_balance,
+        is_consolidation_source=is_consolidation_source,
+        is_consolidation_target=is_consolidation_target,
     )
 
 

--- a/src/validators/tests/test_consensus.py
+++ b/src/validators/tests/test_consensus.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sw_utils import ValidatorStatus
 from sw_utils.tests import faker
 from web3.types import Gwei
@@ -9,102 +10,12 @@ from src.common.tests.factories import create_chain_head
 from src.common.tests.utils import ether_to_gwei
 from src.common.typings import PendingConsolidation
 from src.validators.consensus import (
+    UNKNOWN_VALIDATOR_INDEX,
+    build_consensus_validators,
     fetch_funding_validators_balances,
-    fetch_pending_deposits_amounts,
 )
 from src.validators.tests.factories import create_consensus_validator
 from src.validators.typings import ConsensusValidator, VaultValidator
-
-
-async def test_fetch_pending_deposits_amounts_empty_public_keys():
-    """No pubkeys requested means no beacon call and an empty result."""
-    mock_consensus = AsyncMock()
-
-    with patch('src.validators.consensus.consensus_client', mock_consensus):
-        result = await fetch_pending_deposits_amounts(public_keys=set(), slot='100')
-
-    assert result == {}
-    mock_consensus.get_pending_deposits.assert_not_called()
-
-
-async def test_fetch_pending_deposits_amounts_sums_multiple_deposits():
-    """Multiple pending deposits for the same pubkey are summed."""
-    pub_key = faker.validator_public_key()
-
-    mock_consensus = AsyncMock()
-    mock_consensus.get_pending_deposits.return_value = [
-        {
-            'pubkey': pub_key,
-            'amount': str(ether_to_gwei(1000)),
-            'withdrawal_credentials': '0x02' + '00' * 30,
-            'slot': '90',
-        },
-        {
-            'pubkey': pub_key,
-            'amount': str(ether_to_gwei(800)),
-            'withdrawal_credentials': '0x02' + '00' * 30,
-            'slot': '95',
-        },
-    ]
-
-    with patch('src.validators.consensus.consensus_client', mock_consensus):
-        result = await fetch_pending_deposits_amounts(public_keys={pub_key}, slot='100')
-
-    assert result == {pub_key: ether_to_gwei(1800)}
-    mock_consensus.get_pending_deposits.assert_called_once_with('100')
-
-
-async def test_fetch_pending_deposits_amounts_filters_by_requested_public_keys():
-    """Deposits for pubkeys outside the requested set are ignored."""
-    requested_pub_key = faker.validator_public_key()
-    other_pub_key = faker.validator_public_key()
-
-    mock_consensus = AsyncMock()
-    mock_consensus.get_pending_deposits.return_value = [
-        {
-            'pubkey': requested_pub_key,
-            'amount': str(ether_to_gwei(32)),
-            'withdrawal_credentials': '0x02' + '00' * 30,
-            'slot': '90',
-        },
-        {
-            'pubkey': other_pub_key,
-            'amount': str(ether_to_gwei(9999)),
-            'withdrawal_credentials': '0x02' + '00' * 30,
-            'slot': '91',
-        },
-    ]
-
-    with patch('src.validators.consensus.consensus_client', mock_consensus):
-        result = await fetch_pending_deposits_amounts(public_keys={requested_pub_key}, slot='100')
-
-    assert result == {requested_pub_key: ether_to_gwei(32)}
-
-
-async def test_fetch_pending_deposits_amounts_counts_regardless_of_credentials_prefix():
-    """Unlike funding balances, every pending deposit counts, not only 0x02-prefixed ones."""
-    pub_key = faker.validator_public_key()
-
-    mock_consensus = AsyncMock()
-    mock_consensus.get_pending_deposits.return_value = [
-        {
-            'pubkey': pub_key,
-            'amount': str(ether_to_gwei(10)),
-            'withdrawal_credentials': '0x01' + '00' * 30,
-            'slot': '90',
-        },
-        {
-            'pubkey': pub_key,
-            'amount': str(ether_to_gwei(20)),
-            'withdrawal_credentials': '0x02' + '00' * 30,
-            'slot': '91',
-        },
-    ]
-
-    with patch('src.validators.consensus.consensus_client', mock_consensus):
-        result = await fetch_pending_deposits_amounts(public_keys={pub_key}, slot='100')
-
-    assert result == {pub_key: ether_to_gwei(30)}
 
 
 async def test_fetch_funding_validators_balances_adds_pending_consolidation_source_balance(
@@ -248,13 +159,148 @@ async def test_fetch_funding_validators_balances_no_consolidations_baseline(
     assert result == {active.public_key: Gwei(ether_to_gwei(40) + pending_deposit_amount)}
 
 
+@pytest.mark.usefixtures('fake_settings')
+async def test_build_consensus_validators_without_flags_leaves_optional_fields_unset():
+    """Pending deposits and consolidations are not fetched unless explicitly requested."""
+    validator = create_consensus_validator(index=1)
+    mock_consensus = AsyncMock()
+
+    with patch_funding_dependencies(
+        consensus_validators=[validator], mock_consensus=mock_consensus
+    ):
+        result = await build_consensus_validators([validator.public_key])
+
+    assert result == [validator]
+    assert validator.pending_balance is None
+    assert validator.target_consolidation_balance is None
+    assert not validator.is_consolidation_source
+    assert not validator.is_consolidation_target
+    mock_consensus.get_pending_deposits.assert_not_called()
+
+
+@pytest.mark.usefixtures('fake_settings')
+async def test_build_consensus_validators_marks_consolidation_source_and_target():
+    """Consolidation flags are set and the source balance is credited to the target."""
+    source = create_consensus_validator(index=1, balance=ether_to_gwei(20))
+    target = create_consensus_validator(index=2, balance=ether_to_gwei(40))
+    consolidations = [PendingConsolidation(source_index=source.index, target_index=target.index)]
+
+    with patch_funding_dependencies(
+        consensus_validators=[source, target], pending_consolidations=consolidations
+    ):
+        await build_consensus_validators(
+            [source.public_key, target.public_key], with_consolidations=True
+        )
+
+    assert source.is_consolidation_source is True
+    assert source.is_consolidation_target is False
+    assert source.target_consolidation_balance is None
+
+    assert target.is_consolidation_target is True
+    assert target.is_consolidation_source is False
+    assert target.target_consolidation_balance == ether_to_gwei(20)
+
+
+@pytest.mark.usefixtures('fake_settings')
+async def test_build_consensus_validators_leaves_target_balance_unknown_for_missing_source():
+    """The target's consolidation balance can't be determined when a source is not fetched."""
+    target = create_consensus_validator(index=2, balance=ether_to_gwei(40))
+    known_source = create_consensus_validator(index=3, balance=ether_to_gwei(10))
+    consolidations = [
+        PendingConsolidation(source_index=999, target_index=target.index),
+        PendingConsolidation(source_index=known_source.index, target_index=target.index),
+    ]
+
+    with patch_funding_dependencies(
+        consensus_validators=[target, known_source], pending_consolidations=consolidations
+    ):
+        await build_consensus_validators(
+            [target.public_key, known_source.public_key], with_consolidations=True
+        )
+
+    assert target.is_consolidation_target is True
+    assert target.target_consolidation_balance is None
+
+
+async def test_build_consensus_validators_adds_pending_deposits(compounding_creds):
+    """Pending deposits fill in pending_balance and add validators absent from the beacon state."""
+    validator = create_consensus_validator(index=1, balance=ether_to_gwei(32))
+    absent_public_key = faker.validator_public_key()
+    pending_deposits = [
+        {
+            'pubkey': validator.public_key,
+            'amount': str(ether_to_gwei(1)),
+            'withdrawal_credentials': compounding_creds,
+        },
+        {
+            'pubkey': validator.public_key,
+            'amount': str(ether_to_gwei(2)),
+            'withdrawal_credentials': compounding_creds,
+        },
+        {
+            'pubkey': absent_public_key,
+            'amount': str(ether_to_gwei(32)),
+            'withdrawal_credentials': compounding_creds,
+        },
+    ]
+
+    with patch_funding_dependencies(
+        consensus_validators=[validator], pending_deposits=pending_deposits
+    ):
+        result = await build_consensus_validators(
+            [validator.public_key, absent_public_key], with_pending_deposits=True
+        )
+
+    assert validator.pending_balance == ether_to_gwei(3)
+
+    assert len(result) == 2
+    absent_validator = result[1]
+    assert absent_validator.public_key == absent_public_key
+    assert absent_validator.index == UNKNOWN_VALIDATOR_INDEX
+    assert absent_validator.balance == Gwei(0)
+    assert absent_validator.pending_balance == ether_to_gwei(32)
+    assert absent_validator.status == ValidatorStatus.PENDING_INITIALIZED
+    assert absent_validator.is_compounding is True
+
+
+async def test_build_consensus_validators_compounding_deposits_only(compounding_creds):
+    """Non-0x02 deposits are skipped when only compounding deposits are requested."""
+    validator = create_consensus_validator(index=1, balance=ether_to_gwei(32))
+    absent_public_key = faker.validator_public_key()
+    pending_deposits = [
+        {
+            'pubkey': validator.public_key,
+            'amount': str(ether_to_gwei(1)),
+            'withdrawal_credentials': '0x01' + compounding_creds[4:],
+        },
+        {
+            'pubkey': absent_public_key,
+            'amount': str(ether_to_gwei(32)),
+            'withdrawal_credentials': '0x01' + compounding_creds[4:],
+        },
+    ]
+
+    with patch_funding_dependencies(
+        consensus_validators=[validator], pending_deposits=pending_deposits
+    ):
+        result = await build_consensus_validators(
+            [validator.public_key, absent_public_key],
+            with_pending_deposits=True,
+            compounding_deposits_only=True,
+        )
+
+    assert result == [validator]
+    assert validator.pending_balance is None
+
+
 @contextmanager
 def patch_funding_dependencies(
     consensus_validators: list[ConsensusValidator],
     pending_consolidations: list[PendingConsolidation] | None = None,
     pending_deposits: list[dict] | None = None,
+    mock_consensus: AsyncMock | None = None,
 ):
-    mock_consensus = AsyncMock()
+    mock_consensus = mock_consensus or AsyncMock()
     mock_consensus.get_pending_deposits.return_value = pending_deposits or []
     with (
         patch(

--- a/src/validators/tests/test_consensus.py
+++ b/src/validators/tests/test_consensus.py
@@ -18,279 +18,403 @@ from src.validators.tests.factories import create_consensus_validator
 from src.validators.typings import ConsensusValidator, VaultValidator
 
 
-async def test_fetch_funding_validators_balances_adds_pending_consolidation_source_balance(
-    vault_validator_crud,
-):
-    """A pending consolidation's source balance is credited to the target, since that is
-    what the target will actually hold once the consolidation is processed."""
-    target_balance = ether_to_gwei(40)
-    source_balance = ether_to_gwei(20)
-    source = create_consensus_validator(
-        index=1, balance=source_balance, is_compounding=True, activation_epoch=1
-    )
-    target = create_consensus_validator(
-        index=2, balance=target_balance, is_compounding=True, activation_epoch=1
-    )
+@pytest.mark.usefixtures('fake_settings')
+class TestFetchFundingValidatorsBalances:
+    async def test_adds_pending_consolidation_source_balance(self, vault_validator_crud):
+        """A pending consolidation's source balance is credited to the target, since that is
+        what the target will actually hold once the consolidation is processed."""
+        target_balance = ether_to_gwei(40)
+        source_balance = ether_to_gwei(20)
+        source = create_consensus_validator(
+            index=1, balance=source_balance, is_compounding=True, activation_epoch=1
+        )
+        target = create_consensus_validator(
+            index=2, balance=target_balance, is_compounding=True, activation_epoch=1
+        )
 
-    vault_validator_crud.save_vault_validators(
-        [
-            VaultValidator(public_key=source.public_key, block_number=1),
-            VaultValidator(public_key=target.public_key, block_number=2),
+        vault_validator_crud.save_vault_validators(
+            [
+                VaultValidator(public_key=source.public_key, block_number=1),
+                VaultValidator(public_key=target.public_key, block_number=2),
+            ]
+        )
+
+        pending_consolidations = [
+            PendingConsolidation(source_index=source.index, target_index=target.index)
         ]
-    )
 
-    pending_consolidations = [
-        PendingConsolidation(source_index=source.index, target_index=target.index)
-    ]
+        with patch_funding_dependencies(
+            consensus_validators=[source, target],
+            pending_consolidations=pending_consolidations,
+        ):
+            result = await fetch_funding_validators_balances()
 
-    with patch_funding_dependencies(
-        consensus_validators=[source, target],
-        pending_consolidations=pending_consolidations,
-    ):
-        result = await fetch_funding_validators_balances()
+        assert result == {target.public_key: Gwei(target_balance + source_balance)}
 
-    assert result == {target.public_key: Gwei(target_balance + source_balance)}
+    async def test_excludes_consolidation_source(self, vault_validator_crud):
+        """A pending consolidation's source keeps compounding until it is processed, so it
+        would otherwise pass the eligibility filter; it must be excluded from the fundable set."""
+        source = create_consensus_validator(
+            index=1, balance=ether_to_gwei(20), is_compounding=True, activation_epoch=1
+        )
+        target = create_consensus_validator(
+            index=2, balance=ether_to_gwei(40), is_compounding=True, activation_epoch=1
+        )
 
+        vault_validator_crud.save_vault_validators(
+            [
+                VaultValidator(public_key=source.public_key, block_number=1),
+                VaultValidator(public_key=target.public_key, block_number=2),
+            ]
+        )
 
-async def test_fetch_funding_validators_balances_excludes_consolidation_source(
-    vault_validator_crud,
-):
-    """A pending consolidation's source keeps compounding until it is processed, so it
-    would otherwise pass the eligibility filter; it must be excluded from the fundable set."""
-    source = create_consensus_validator(
-        index=1, balance=ether_to_gwei(20), is_compounding=True, activation_epoch=1
-    )
-    target = create_consensus_validator(
-        index=2, balance=ether_to_gwei(40), is_compounding=True, activation_epoch=1
-    )
-
-    vault_validator_crud.save_vault_validators(
-        [
-            VaultValidator(public_key=source.public_key, block_number=1),
-            VaultValidator(public_key=target.public_key, block_number=2),
+        pending_consolidations = [
+            PendingConsolidation(source_index=source.index, target_index=target.index)
         ]
-    )
 
-    pending_consolidations = [
-        PendingConsolidation(source_index=source.index, target_index=target.index)
-    ]
+        with patch_funding_dependencies(
+            consensus_validators=[source, target],
+            pending_consolidations=pending_consolidations,
+        ):
+            result = await fetch_funding_validators_balances()
 
-    with patch_funding_dependencies(
-        consensus_validators=[source, target],
-        pending_consolidations=pending_consolidations,
-    ):
-        result = await fetch_funding_validators_balances()
+        assert source.public_key not in result
 
-    assert source.public_key not in result
+    async def test_excludes_target_when_source_balance_unknown(self, vault_validator_crud):
+        """If a pending consolidation's source isn't among the vault's fetched consensus
+        validators, its balance can't be determined; the target is dropped from the fundable
+        set instead of guessing its post-consolidation balance."""
+        target = create_consensus_validator(
+            index=2, balance=ether_to_gwei(40), is_compounding=True, activation_epoch=1
+        )
 
+        vault_validator_crud.save_vault_validators(
+            [VaultValidator(public_key=target.public_key, block_number=1)]
+        )
 
-async def test_fetch_funding_validators_balances_excludes_target_when_source_balance_unknown(
-    vault_validator_crud,
-):
-    """If a pending consolidation's source isn't among the vault's fetched consensus
-    validators, its balance can't be determined; the target is dropped from the fundable
-    set instead of guessing its post-consolidation balance."""
-    target = create_consensus_validator(
-        index=2, balance=ether_to_gwei(40), is_compounding=True, activation_epoch=1
-    )
+        # source_index has no matching validator in the fetched set
+        pending_consolidations = [PendingConsolidation(source_index=999, target_index=target.index)]
 
-    vault_validator_crud.save_vault_validators(
-        [VaultValidator(public_key=target.public_key, block_number=1)]
-    )
+        with patch_funding_dependencies(
+            consensus_validators=[target],
+            pending_consolidations=pending_consolidations,
+        ):
+            result = await fetch_funding_validators_balances()
 
-    # source_index has no matching validator in the fetched set
-    pending_consolidations = [PendingConsolidation(source_index=999, target_index=target.index)]
+        assert result == {}
 
-    with patch_funding_dependencies(
-        consensus_validators=[target],
-        pending_consolidations=pending_consolidations,
-    ):
-        result = await fetch_funding_validators_balances()
+    async def test_no_consolidations_baseline(self, vault_validator_crud, compounding_creds):
+        """Baseline behavior is unchanged when there are no pending consolidations: pending
+        deposits are added to balances, and exiting/non-compounding validators are excluded."""
+        active = create_consensus_validator(
+            index=1,
+            balance=ether_to_gwei(40),
+            is_compounding=True,
+            activation_epoch=1,
+            status=ValidatorStatus.ACTIVE_ONGOING,
+        )
+        exiting = create_consensus_validator(
+            index=2,
+            balance=ether_to_gwei(50),
+            is_compounding=True,
+            activation_epoch=1,
+            status=ValidatorStatus.ACTIVE_EXITING,
+        )
+        non_compounding = create_consensus_validator(
+            index=3, balance=ether_to_gwei(32), is_compounding=False, activation_epoch=1
+        )
 
-    assert result == {}
+        vault_validator_crud.save_vault_validators(
+            [
+                VaultValidator(public_key=active.public_key, block_number=1),
+                VaultValidator(public_key=exiting.public_key, block_number=2),
+                VaultValidator(public_key=non_compounding.public_key, block_number=3),
+            ]
+        )
 
-
-async def test_fetch_funding_validators_balances_no_consolidations_baseline(
-    vault_validator_crud, compounding_creds
-):
-    """Baseline behavior is unchanged when there are no pending consolidations: pending
-    deposits are added to balances, and exiting/non-compounding validators are excluded."""
-    active = create_consensus_validator(
-        index=1,
-        balance=ether_to_gwei(40),
-        is_compounding=True,
-        activation_epoch=1,
-        status=ValidatorStatus.ACTIVE_ONGOING,
-    )
-    exiting = create_consensus_validator(
-        index=2,
-        balance=ether_to_gwei(50),
-        is_compounding=True,
-        activation_epoch=1,
-        status=ValidatorStatus.ACTIVE_EXITING,
-    )
-    non_compounding = create_consensus_validator(
-        index=3, balance=ether_to_gwei(32), is_compounding=False, activation_epoch=1
-    )
-
-    vault_validator_crud.save_vault_validators(
-        [
-            VaultValidator(public_key=active.public_key, block_number=1),
-            VaultValidator(public_key=exiting.public_key, block_number=2),
-            VaultValidator(public_key=non_compounding.public_key, block_number=3),
+        pending_deposit_amount = ether_to_gwei(5)
+        pending_deposits = [
+            {
+                'pubkey': active.public_key,
+                'amount': str(pending_deposit_amount),
+                'withdrawal_credentials': compounding_creds,
+            },
         ]
-    )
 
-    pending_deposit_amount = ether_to_gwei(5)
-    pending_deposits = [
-        {
-            'pubkey': active.public_key,
-            'amount': str(pending_deposit_amount),
-            'withdrawal_credentials': compounding_creds,
-        },
-    ]
+        with patch_funding_dependencies(
+            consensus_validators=[active, exiting, non_compounding],
+            pending_deposits=pending_deposits,
+        ):
+            result = await fetch_funding_validators_balances()
 
-    with patch_funding_dependencies(
-        consensus_validators=[active, exiting, non_compounding],
-        pending_deposits=pending_deposits,
-    ):
-        result = await fetch_funding_validators_balances()
-
-    assert result == {active.public_key: Gwei(ether_to_gwei(40) + pending_deposit_amount)}
+        assert result == {active.public_key: Gwei(ether_to_gwei(40) + pending_deposit_amount)}
 
 
 @pytest.mark.usefixtures('fake_settings')
-async def test_build_consensus_validators_without_flags_leaves_optional_fields_unset():
-    """Pending deposits and consolidations are not fetched unless explicitly requested."""
-    validator = create_consensus_validator(index=1)
-    mock_consensus = AsyncMock()
+class TestBuildConsensusValidators:
+    async def test_without_flags_leaves_optional_fields_unset(self):
+        """The optional fields stay unset when the data behind them was not requested."""
+        validator = create_consensus_validator(index=1)
 
-    with patch_funding_dependencies(
-        consensus_validators=[validator], mock_consensus=mock_consensus
-    ):
-        result = await build_consensus_validators([validator.public_key])
+        with patch_funding_dependencies(consensus_validators=[validator]):
+            result = await build_consensus_validators([validator.public_key])
 
-    assert result == [validator]
-    assert validator.pending_balance is None
-    assert validator.target_consolidation_balance is None
-    assert not validator.is_consolidation_source
-    assert not validator.is_consolidation_target
-    mock_consensus.get_pending_deposits.assert_not_called()
+        assert len(result) == 1
+        assert result[0].pending_balance is None
+        assert result[0].target_consolidation_balance is None
+        assert result[0].is_consolidation_source is False
+        assert result[0].is_consolidation_target is False
 
+    async def test_without_flags_skips_extra_lookups(self):
+        """Pending deposits and consolidations are not fetched unless explicitly requested."""
+        validator = create_consensus_validator(index=1)
 
-@pytest.mark.usefixtures('fake_settings')
-async def test_build_consensus_validators_marks_consolidation_source_and_target():
-    """Consolidation flags are set and the source balance is credited to the target."""
-    source = create_consensus_validator(index=1, balance=ether_to_gwei(20))
-    target = create_consensus_validator(index=2, balance=ether_to_gwei(40))
-    consolidations = [PendingConsolidation(source_index=source.index, target_index=target.index)]
+        with patch_funding_dependencies(consensus_validators=[validator]) as mocks:
+            await build_consensus_validators([validator.public_key])
 
-    with patch_funding_dependencies(
-        consensus_validators=[source, target], pending_consolidations=consolidations
-    ):
-        await build_consensus_validators(
-            [source.public_key, target.public_key], with_consolidations=True
-        )
+        mocks['consolidations'].assert_not_called()
+        mocks['consensus'].get_pending_deposits.assert_not_called()
 
-    assert source.is_consolidation_source is True
-    assert source.is_consolidation_target is False
-    assert source.target_consolidation_balance is None
+    async def test_marks_consolidation_source_and_target(self):
+        """Consolidation flags are set and the source balance is credited to the target."""
+        source = create_consensus_validator(index=1, balance=ether_to_gwei(20))
+        target = create_consensus_validator(index=2, balance=ether_to_gwei(40))
+        consolidations = [
+            PendingConsolidation(source_index=source.index, target_index=target.index)
+        ]
 
-    assert target.is_consolidation_target is True
-    assert target.is_consolidation_source is False
-    assert target.target_consolidation_balance == ether_to_gwei(20)
+        with patch_funding_dependencies(
+            consensus_validators=[source, target], pending_consolidations=consolidations
+        ):
+            result = await build_consensus_validators(
+                [source.public_key, target.public_key], with_consolidations=True
+            )
 
+        # the original validators are left untouched
+        assert source.is_consolidation_source is False
+        assert target.is_consolidation_target is False
 
-@pytest.mark.usefixtures('fake_settings')
-async def test_build_consensus_validators_leaves_target_balance_unknown_for_missing_source():
-    """The target's consolidation balance can't be determined when a source is not fetched."""
-    target = create_consensus_validator(index=2, balance=ether_to_gwei(40))
-    known_source = create_consensus_validator(index=3, balance=ether_to_gwei(10))
-    consolidations = [
-        PendingConsolidation(source_index=999, target_index=target.index),
-        PendingConsolidation(source_index=known_source.index, target_index=target.index),
-    ]
+        result_source, result_target = result
+        assert result_source.public_key == source.public_key
+        assert result_source.is_consolidation_source is True
+        assert result_source.is_consolidation_target is False
+        assert result_source.target_consolidation_balance is None
 
-    with patch_funding_dependencies(
-        consensus_validators=[target, known_source], pending_consolidations=consolidations
-    ):
-        await build_consensus_validators(
-            [target.public_key, known_source.public_key], with_consolidations=True
-        )
+        assert result_target.public_key == target.public_key
+        assert result_target.is_consolidation_target is True
+        assert result_target.is_consolidation_source is False
+        assert result_target.target_consolidation_balance == ether_to_gwei(20)
 
-    assert target.is_consolidation_target is True
-    assert target.target_consolidation_balance is None
+    async def test_leaves_target_balance_unknown_for_missing_source(self):
+        """The target's consolidation balance can't be determined when a source is not fetched."""
+        target = create_consensus_validator(index=2, balance=ether_to_gwei(40))
+        known_source = create_consensus_validator(index=3, balance=ether_to_gwei(10))
+        consolidations = [
+            PendingConsolidation(source_index=999, target_index=target.index),
+            PendingConsolidation(source_index=known_source.index, target_index=target.index),
+        ]
 
+        with patch_funding_dependencies(
+            consensus_validators=[target, known_source], pending_consolidations=consolidations
+        ):
+            result = await build_consensus_validators(
+                [target.public_key, known_source.public_key], with_consolidations=True
+            )
 
-async def test_build_consensus_validators_adds_pending_deposits(compounding_creds):
-    """Pending deposits fill in pending_balance and add validators absent from the beacon state."""
-    validator = create_consensus_validator(index=1, balance=ether_to_gwei(32))
-    absent_public_key = faker.validator_public_key()
-    pending_deposits = [
-        {
-            'pubkey': validator.public_key,
-            'amount': str(ether_to_gwei(1)),
-            'withdrawal_credentials': compounding_creds,
-        },
-        {
-            'pubkey': validator.public_key,
-            'amount': str(ether_to_gwei(2)),
-            'withdrawal_credentials': compounding_creds,
-        },
-        {
-            'pubkey': absent_public_key,
-            'amount': str(ether_to_gwei(32)),
-            'withdrawal_credentials': compounding_creds,
-        },
-    ]
+        result_target = result[0]
+        assert result_target.public_key == target.public_key
+        assert result_target.is_consolidation_target is True
+        assert result_target.target_consolidation_balance is None
 
-    with patch_funding_dependencies(
-        consensus_validators=[validator], pending_deposits=pending_deposits
-    ):
-        result = await build_consensus_validators(
-            [validator.public_key, absent_public_key], with_pending_deposits=True
-        )
+    async def test_adds_pending_deposits(self, compounding_creds):
+        """Pending deposits fill in pending_balance and add validators absent from the beacon state."""
+        validator = create_consensus_validator(index=1, balance=ether_to_gwei(32))
+        absent_public_key = faker.validator_public_key()
+        pending_deposits = [
+            {
+                'pubkey': validator.public_key,
+                'amount': str(ether_to_gwei(1)),
+                'withdrawal_credentials': compounding_creds,
+            },
+            {
+                'pubkey': validator.public_key,
+                'amount': str(ether_to_gwei(2)),
+                'withdrawal_credentials': compounding_creds,
+            },
+            {
+                'pubkey': absent_public_key,
+                'amount': str(ether_to_gwei(32)),
+                'withdrawal_credentials': compounding_creds,
+            },
+        ]
 
-    assert validator.pending_balance == ether_to_gwei(3)
+        with patch_funding_dependencies(
+            consensus_validators=[validator], pending_deposits=pending_deposits
+        ):
+            result = await build_consensus_validators(
+                [validator.public_key, absent_public_key], with_pending_deposits=True
+            )
 
-    assert len(result) == 2
-    absent_validator = result[1]
-    assert absent_validator.public_key == absent_public_key
-    assert absent_validator.index == UNKNOWN_VALIDATOR_INDEX
-    assert absent_validator.balance == Gwei(0)
-    assert absent_validator.pending_balance == ether_to_gwei(32)
-    assert absent_validator.status == ValidatorStatus.PENDING_INITIALIZED
-    assert absent_validator.is_compounding is True
+        # the original validator is left untouched
+        assert validator.pending_balance is None
 
+        assert len(result) == 2
+        assert result[0].public_key == validator.public_key
+        assert result[0].pending_balance == ether_to_gwei(3)
 
-async def test_build_consensus_validators_compounding_deposits_only(compounding_creds):
-    """Non-0x02 deposits are skipped when only compounding deposits are requested."""
-    validator = create_consensus_validator(index=1, balance=ether_to_gwei(32))
-    absent_public_key = faker.validator_public_key()
-    pending_deposits = [
-        {
-            'pubkey': validator.public_key,
-            'amount': str(ether_to_gwei(1)),
-            'withdrawal_credentials': '0x01' + compounding_creds[4:],
-        },
-        {
-            'pubkey': absent_public_key,
-            'amount': str(ether_to_gwei(32)),
-            'withdrawal_credentials': '0x01' + compounding_creds[4:],
-        },
-    ]
+        absent_validator = result[1]
+        assert absent_validator.public_key == absent_public_key
+        assert absent_validator.index == UNKNOWN_VALIDATOR_INDEX
+        assert absent_validator.balance == Gwei(0)
+        assert absent_validator.pending_balance == ether_to_gwei(32)
+        assert absent_validator.status == ValidatorStatus.PENDING_INITIALIZED
+        assert absent_validator.is_compounding is True
 
-    with patch_funding_dependencies(
-        consensus_validators=[validator], pending_deposits=pending_deposits
-    ):
-        result = await build_consensus_validators(
-            [validator.public_key, absent_public_key],
-            with_pending_deposits=True,
-            compounding_deposits_only=True,
-        )
+    async def test_compounding_deposits_only(self, compounding_creds):
+        """Non-0x02 deposits are skipped when only compounding deposits are requested."""
+        validator = create_consensus_validator(index=1, balance=ether_to_gwei(32))
+        absent_public_key = faker.validator_public_key()
+        pending_deposits = [
+            {
+                'pubkey': validator.public_key,
+                'amount': str(ether_to_gwei(1)),
+                'withdrawal_credentials': '0x01' + compounding_creds[4:],
+            },
+            {
+                'pubkey': absent_public_key,
+                'amount': str(ether_to_gwei(32)),
+                'withdrawal_credentials': '0x01' + compounding_creds[4:],
+            },
+        ]
 
-    assert result == [validator]
-    assert validator.pending_balance is None
+        with patch_funding_dependencies(
+            consensus_validators=[validator], pending_deposits=pending_deposits
+        ):
+            result = await build_consensus_validators(
+                [validator.public_key, absent_public_key],
+                with_pending_deposits=True,
+                compounding_deposits_only=True,
+            )
+
+        assert len(result) == 1
+        assert result[0].public_key == validator.public_key
+        assert result[0].pending_balance is None
+
+    async def test_empty_public_keys(self):
+        """Nothing is fetched at all when no public keys are requested."""
+        with patch_funding_dependencies(consensus_validators=[]) as mocks:
+            result = await build_consensus_validators(
+                [], with_pending_deposits=True, with_consolidations=True
+            )
+
+        assert result == []
+        mocks['chain_head'].assert_not_called()
+        mocks['fetch_validators'].assert_not_called()
+        mocks['consolidations'].assert_not_called()
+        mocks['consensus'].get_pending_deposits.assert_not_called()
+
+    async def test_uses_given_chain_head(self):
+        """A caller-provided chain head is used as the snapshot for every lookup."""
+        validator = create_consensus_validator(index=1)
+        chain_head = create_chain_head(slot=777)
+
+        with patch_funding_dependencies(consensus_validators=[validator]) as mocks:
+            await build_consensus_validators(
+                [validator.public_key],
+                chain_head=chain_head,
+                with_pending_deposits=True,
+                with_consolidations=True,
+            )
+
+        mocks['chain_head'].assert_not_called()
+        assert mocks['fetch_validators'].call_args.kwargs['slot'] == '777'
+        assert mocks['consolidations'].call_args.args[0] == chain_head
+        mocks['consensus'].get_pending_deposits.assert_called_once_with('777')
+
+    async def test_ignores_deposits_for_other_public_keys(self, compounding_creds):
+        """Deposits for pubkeys outside the requested set are neither summed nor turned
+        into new validators."""
+        validator = create_consensus_validator(index=1)
+        pending_deposits = [
+            {
+                'pubkey': faker.validator_public_key(),
+                'amount': str(ether_to_gwei(32)),
+                'withdrawal_credentials': compounding_creds,
+            },
+        ]
+
+        with patch_funding_dependencies(
+            consensus_validators=[validator], pending_deposits=pending_deposits
+        ):
+            result = await build_consensus_validators(
+                [validator.public_key], with_pending_deposits=True
+            )
+
+        assert len(result) == 1
+        assert result[0].pending_balance is None
+
+    async def test_sums_absent_validator_deposits(self, compounding_creds):
+        """Several deposits for the same absent pubkey produce a single validator whose
+        credentials come from the first deposit."""
+        absent_public_key = faker.validator_public_key()
+        non_compounding_creds = '0x01' + compounding_creds[4:]
+        pending_deposits = [
+            {
+                'pubkey': absent_public_key,
+                'amount': str(ether_to_gwei(32)),
+                'withdrawal_credentials': non_compounding_creds,
+            },
+            {
+                'pubkey': absent_public_key,
+                'amount': str(ether_to_gwei(8)),
+                'withdrawal_credentials': compounding_creds,
+            },
+        ]
+
+        with patch_funding_dependencies(consensus_validators=[], pending_deposits=pending_deposits):
+            result = await build_consensus_validators(
+                [absent_public_key], with_pending_deposits=True
+            )
+
+        assert len(result) == 1
+        assert result[0].public_key == absent_public_key
+        assert result[0].pending_balance == ether_to_gwei(40)
+        assert result[0].withdrawal_credentials == non_compounding_creds
+        assert result[0].is_compounding is False
+
+    async def test_combines_consolidations_and_deposits(self, compounding_creds):
+        """Consolidation fields survive the pending deposits pass, and vice versa."""
+        source = create_consensus_validator(index=1, balance=ether_to_gwei(20))
+        target = create_consensus_validator(index=2, balance=ether_to_gwei(40))
+        consolidations = [
+            PendingConsolidation(source_index=source.index, target_index=target.index)
+        ]
+        pending_deposits = [
+            {
+                'pubkey': target.public_key,
+                'amount': str(ether_to_gwei(5)),
+                'withdrawal_credentials': compounding_creds,
+            },
+        ]
+
+        with patch_funding_dependencies(
+            consensus_validators=[source, target],
+            pending_consolidations=consolidations,
+            pending_deposits=pending_deposits,
+        ):
+            result = await build_consensus_validators(
+                [source.public_key, target.public_key],
+                with_pending_deposits=True,
+                with_consolidations=True,
+            )
+
+        result_source, result_target = result
+        assert result_source.is_consolidation_source is True
+        assert result_source.pending_balance is None
+
+        assert result_target.is_consolidation_target is True
+        assert result_target.target_consolidation_balance == ether_to_gwei(20)
+        assert result_target.pending_balance == ether_to_gwei(5)
 
 
 @contextmanager
@@ -298,9 +422,8 @@ def patch_funding_dependencies(
     consensus_validators: list[ConsensusValidator],
     pending_consolidations: list[PendingConsolidation] | None = None,
     pending_deposits: list[dict] | None = None,
-    mock_consensus: AsyncMock | None = None,
 ):
-    mock_consensus = mock_consensus or AsyncMock()
+    mock_consensus = AsyncMock()
     mock_consensus.get_pending_deposits.return_value = pending_deposits or []
     with (
         patch(
@@ -312,17 +435,22 @@ def patch_funding_dependencies(
             'src.validators.consensus.get_chain_latest_head',
             new_callable=AsyncMock,
             return_value=create_chain_head(slot=100),
-        ),
+        ) as mock_chain_head,
         patch(
             'src.validators.consensus.fetch_consensus_validators',
             new_callable=AsyncMock,
             return_value=consensus_validators,
-        ),
+        ) as mock_fetch_validators,
         patch(
             'src.validators.consensus.get_pending_consolidations',
             new_callable=AsyncMock,
             return_value=pending_consolidations or [],
-        ),
+        ) as mock_consolidations,
         patch('src.validators.consensus.consensus_client', mock_consensus),
     ):
-        yield
+        yield {
+            'chain_head': mock_chain_head,
+            'fetch_validators': mock_fetch_validators,
+            'consolidations': mock_consolidations,
+            'consensus': mock_consensus,
+        }

--- a/src/validators/tests/test_consensus.py
+++ b/src/validators/tests/test_consensus.py
@@ -15,7 +15,11 @@ from src.validators.consensus import (
     fetch_funding_validators_balances,
 )
 from src.validators.tests.factories import create_consensus_validator
-from src.validators.typings import ConsensusValidator, VaultValidator
+from src.validators.typings import (
+    ConsensusValidator,
+    ValidatorConsolidationData,
+    VaultValidator,
+)
 
 
 @pytest.mark.usefixtures('fake_settings')
@@ -154,16 +158,14 @@ class TestFetchFundingValidatorsBalances:
 class TestBuildConsensusValidators:
     async def test_without_flags_leaves_optional_fields_unset(self):
         """The optional fields stay unset when the data behind them was not requested."""
-        validator = create_consensus_validator(index=1)
+        validator = create_consensus_validator(index=1, with_consolidation_data=False)
 
         with patch_funding_dependencies(consensus_validators=[validator]):
             result = await build_consensus_validators([validator.public_key])
 
         assert len(result) == 1
         assert result[0].pending_balance is None
-        assert result[0].target_consolidation_balance is None
-        assert result[0].is_consolidation_source is False
-        assert result[0].is_consolidation_target is False
+        assert result[0].consolidation_data is None
 
     async def test_without_flags_skips_extra_lookups(self):
         """Pending deposits and consolidations are not fetched unless explicitly requested."""
@@ -191,19 +193,23 @@ class TestBuildConsensusValidators:
             )
 
         # the original validators are left untouched
-        assert source.is_consolidation_source is False
-        assert target.is_consolidation_target is False
+        assert source.consolidation_data == ValidatorConsolidationData(
+            is_source=False, is_target=False
+        )
+        assert target.consolidation_data == ValidatorConsolidationData(
+            is_source=False, is_target=False
+        )
 
         result_source, result_target = result
         assert result_source.public_key == source.public_key
-        assert result_source.is_consolidation_source is True
-        assert result_source.is_consolidation_target is False
-        assert result_source.target_consolidation_balance is None
+        assert result_source.consolidation_data == ValidatorConsolidationData(
+            is_source=True, is_target=False, target_balance=None
+        )
 
         assert result_target.public_key == target.public_key
-        assert result_target.is_consolidation_target is True
-        assert result_target.is_consolidation_source is False
-        assert result_target.target_consolidation_balance == ether_to_gwei(20)
+        assert result_target.consolidation_data == ValidatorConsolidationData(
+            is_source=False, is_target=True, target_balance=ether_to_gwei(20)
+        )
 
     async def test_leaves_target_balance_unknown_for_missing_source(self):
         """The target's consolidation balance can't be determined when a source is not fetched."""
@@ -223,8 +229,9 @@ class TestBuildConsensusValidators:
 
         result_target = result[0]
         assert result_target.public_key == target.public_key
-        assert result_target.is_consolidation_target is True
-        assert result_target.target_consolidation_balance is None
+        assert result_target.consolidation_data == ValidatorConsolidationData(
+            is_source=False, is_target=True, target_balance=None
+        )
 
     async def test_adds_pending_deposits(self, compounding_creds):
         """Pending deposits fill in pending_balance and add validators absent from the beacon state."""
@@ -409,11 +416,14 @@ class TestBuildConsensusValidators:
             )
 
         result_source, result_target = result
-        assert result_source.is_consolidation_source is True
+        assert result_source.consolidation_data == ValidatorConsolidationData(
+            is_source=True, is_target=False, target_balance=None
+        )
         assert result_source.pending_balance is None
 
-        assert result_target.is_consolidation_target is True
-        assert result_target.target_consolidation_balance == ether_to_gwei(20)
+        assert result_target.consolidation_data == ValidatorConsolidationData(
+            is_source=False, is_target=True, target_balance=ether_to_gwei(20)
+        )
         assert result_target.pending_balance == ether_to_gwei(5)
 
 

--- a/src/validators/typings.py
+++ b/src/validators/typings.py
@@ -49,6 +49,16 @@ class Validator:
 
 
 @dataclass
+class ValidatorConsolidationData:
+    is_source: bool
+    is_target: bool
+
+    # Total balance the target will receive from its pending consolidation sources.
+    # Stays `None` when at least one of the source balances is unknown.
+    target_balance: Gwei | None = None
+
+
+@dataclass
 # pylint: disable-next=too-many-instance-attributes
 class ConsensusValidator:
     index: int
@@ -59,11 +69,9 @@ class ConsensusValidator:
     activation_epoch: int
 
     # Optional fields populated by `build_consensus_validators` when the corresponding
-    # flag is passed. They stay unset when the data was not requested.
+    # flag is passed. They stay `None` when the data was not requested.
     pending_balance: Gwei | None = None
-    target_consolidation_balance: Gwei | None = None
-    is_consolidation_source: bool = False
-    is_consolidation_target: bool = False
+    consolidation_data: ValidatorConsolidationData | None = None
 
     @property
     def is_compounding(self) -> bool:

--- a/src/validators/typings.py
+++ b/src/validators/typings.py
@@ -49,6 +49,7 @@ class Validator:
 
 
 @dataclass
+# pylint: disable-next=too-many-instance-attributes
 class ConsensusValidator:
     index: int
     public_key: HexStr
@@ -56,6 +57,13 @@ class ConsensusValidator:
     withdrawal_credentials: HexStr
     status: ValidatorStatus
     activation_epoch: int
+
+    # Optional fields populated by `build_consensus_validators` when the corresponding
+    # flag is passed. They stay unset when the data was not requested.
+    pending_balance: Gwei | None = None
+    target_consolidation_balance: Gwei | None = None
+    is_consolidation_source: bool = False
+    is_consolidation_target: bool = False
 
     @property
     def is_compounding(self) -> bool:

--- a/src/withdrawals/assets.py
+++ b/src/withdrawals/assets.py
@@ -10,11 +10,7 @@ from web3.types import Gwei, Wei
 
 from src.common.contracts import validators_checker_contract
 from src.common.harvest import get_harvest_params
-from src.common.typings import (
-    ExitQueueMissingAssetsParams,
-    PendingConsolidation,
-    PendingPartialWithdrawal,
-)
+from src.common.typings import ExitQueueMissingAssetsParams, PendingPartialWithdrawal
 from src.config.settings import settings
 from src.validators.typings import ConsensusValidator
 
@@ -40,7 +36,6 @@ EXITING_STATUSES = [
 async def get_queued_assets(
     consensus_validators: list[ConsensusValidator],
     oracle_exiting_validators: list[ConsensusValidator],
-    consolidations: list[PendingConsolidation],
     pending_partial_withdrawals: list[PendingPartialWithdrawal],
     chain_head: ChainHead,
 ) -> Gwei:
@@ -62,11 +57,9 @@ async def get_queued_assets(
     )
 
     # fetch active validators exits
-    source_consolidations_indexes = {cons.source_index for cons in consolidations}
     validators_exits_amount = _calculate_validators_exits_amount(
         consensus_validators=consensus_validators,
         oracle_exiting_validators=oracle_exiting_validators,
-        source_consolidations_indexes=source_consolidations_indexes,
     )
 
     # Withdrawing assets are assets that are ready to cover the exit requests
@@ -97,7 +90,6 @@ async def get_queued_assets(
 def _calculate_validators_exits_amount(
     consensus_validators: list[ConsensusValidator],
     oracle_exiting_validators: list[ConsensusValidator],
-    source_consolidations_indexes: set[int],
 ) -> Wei:
     """
     Calculate the sum of exiting validators balances. Exiting validators are:
@@ -113,9 +105,10 @@ def _calculate_validators_exits_amount(
         oracle_exiting_indexes.add(val.index)
         total_exiting_amount += val.balance
 
-    excluded_indexes = source_consolidations_indexes.union(oracle_exiting_indexes)
     for val in consensus_validators:
-        if val.index not in excluded_indexes and val.status in EXITING_STATUSES:
+        if val.is_consolidation_source or val.index in oracle_exiting_indexes:
+            continue
+        if val.status in EXITING_STATUSES:
             total_exiting_amount += val.balance
 
     return Web3.to_wei(total_exiting_amount, 'gwei')

--- a/src/withdrawals/assets.py
+++ b/src/withdrawals/assets.py
@@ -9,6 +9,7 @@ from web3 import Web3
 from web3.types import Gwei, Wei
 
 from src.common.contracts import validators_checker_contract
+from src.common.exceptions import MissingConsolidationDataError
 from src.common.harvest import get_harvest_params
 from src.common.typings import ExitQueueMissingAssetsParams, PendingPartialWithdrawal
 from src.config.settings import settings
@@ -106,7 +107,9 @@ def _calculate_validators_exits_amount(
         total_exiting_amount += val.balance
 
     for val in consensus_validators:
-        if val.is_consolidation_source or val.index in oracle_exiting_indexes:
+        if val.consolidation_data is None:
+            raise MissingConsolidationDataError(val.public_key)
+        if val.consolidation_data.is_source or val.index in oracle_exiting_indexes:
             continue
         if val.status in EXITING_STATUSES:
             total_exiting_amount += val.balance

--- a/src/withdrawals/assets.py
+++ b/src/withdrawals/assets.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from sw_utils import (
     GNO_NETWORKS,
     ChainHead,
@@ -9,11 +11,10 @@ from web3 import Web3
 from web3.types import Gwei, Wei
 
 from src.common.contracts import validators_checker_contract
-from src.common.exceptions import MissingConsolidationDataError
 from src.common.harvest import get_harvest_params
 from src.common.typings import ExitQueueMissingAssetsParams, PendingPartialWithdrawal
 from src.config.settings import settings
-from src.validators.typings import ConsensusValidator
+from src.validators.typings import ConsensusValidator, ValidatorConsolidationData
 
 CAN_BE_EXITED_STATUSES = [
     ValidatorStatus.ACTIVE_ONGOING,
@@ -107,9 +108,8 @@ def _calculate_validators_exits_amount(
         total_exiting_amount += val.balance
 
     for val in consensus_validators:
-        if val.consolidation_data is None:
-            raise MissingConsolidationDataError(val.public_key)
-        if val.consolidation_data.is_source or val.index in oracle_exiting_indexes:
+        consolidation_data = cast(ValidatorConsolidationData, val.consolidation_data)
+        if consolidation_data.is_source or val.index in oracle_exiting_indexes:
             continue
         if val.status in EXITING_STATUSES:
             total_exiting_amount += val.balance

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -135,7 +135,7 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
         # The pending deposit queue is fetched only once it is clear that a withdrawal is
         # needed. Validators that are not in the beacon state yet can't be withdrawn from,
         # so the ones returned here are dropped.
-        await apply_pending_deposits(
+        consensus_validators, _ = await apply_pending_deposits(
             validators=consensus_validators,
             public_keys=vault_public_keys,
             slot=str(chain_head.slot),

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -17,7 +17,6 @@ from src.common.app_state import AppState
 from src.common.clients import execution_client
 from src.common.consensus import get_chain_latest_head
 from src.common.contracts import VaultContract
-from src.common.exceptions import MissingConsolidationDataError
 from src.common.metrics import metrics
 from src.common.protocol_config import get_protocol_config
 from src.common.typings import PendingPartialWithdrawal
@@ -37,7 +36,7 @@ from src.validators.database import VaultValidatorCrud
 from src.validators.exceptions import EmptyRelayerResponseException
 from src.validators.oracles import poll_active_exits
 from src.validators.relayer import RelayerClient
-from src.validators.typings import ConsensusValidator
+from src.validators.typings import ConsensusValidator, ValidatorConsolidationData
 from src.withdrawals.assets import CAN_BE_EXITED_STATUSES, get_queued_assets
 from src.withdrawals.execution import submit_withdraw_validators
 
@@ -226,9 +225,8 @@ async def _get_withdrawals(
 
     consolidation_source_indexes = set()
     for validator in consensus_validators:
-        if validator.consolidation_data is None:
-            raise MissingConsolidationDataError(validator.public_key)
-        if validator.consolidation_data.is_source:
+        consolidation_data = cast(ValidatorConsolidationData, validator.consolidation_data)
+        if consolidation_data.is_source:
             consolidation_source_indexes.add(validator.index)
 
     validator_partial_withdrawals: dict[int, Gwei] = defaultdict(lambda: Gwei(0))
@@ -346,8 +344,6 @@ def _filter_exitable_validators(
     """
     can_be_exited_validators = []
     for validator in consensus_validators:
-        if validator.consolidation_data is None:
-            raise MissingConsolidationDataError(validator.public_key)
         if validator.activation_epoch > max_activation_epoch:
             continue
         if validator.status != ValidatorStatus.ACTIVE_ONGOING:
@@ -356,7 +352,9 @@ def _filter_exitable_validators(
             continue
         if validator.index in partial_withdrawal_indexes:
             continue
-        if validator.consolidation_data.is_target or validator.consolidation_data.is_source:
+
+        consolidation_data = cast(ValidatorConsolidationData, validator.consolidation_data)
+        if consolidation_data.is_target or consolidation_data.is_source:
             continue
         can_be_exited_validators.append(validator)
     can_be_exited_validators.sort(key=lambda x: (x.balance + (x.pending_balance or 0), x.index))

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -16,7 +16,6 @@ from web3.types import BlockNumber, Gwei, Wei
 from src.common.app_state import AppState
 from src.common.clients import execution_client
 from src.common.consensus import get_chain_latest_head
-from src.common.consolidations import get_pending_consolidations
 from src.common.contracts import VaultContract
 from src.common.metrics import metrics
 from src.common.protocol_config import get_protocol_config
@@ -32,10 +31,7 @@ from src.config.settings import (
     WITHDRAWALS_INTERVAL,
     settings,
 )
-from src.validators.consensus import (
-    fetch_consensus_validators,
-    fetch_pending_deposits_amounts,
-)
+from src.validators.consensus import apply_pending_deposits, build_consensus_validators
 from src.validators.database import VaultValidatorCrud
 from src.validators.exceptions import EmptyRelayerResponseException
 from src.validators.oracles import poll_active_exits
@@ -103,15 +99,15 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
         if not await self._is_withdrawal_interval_passed(app_state, chain_head):
             return
 
-        vault_validators = VaultValidatorCrud().get_vault_validators()
-        consensus_validators = await fetch_consensus_validators(
-            [val.public_key for val in vault_validators],
-            slot=str(chain_head.slot),
+        vault_public_keys = {val.public_key for val in VaultValidatorCrud().get_vault_validators()}
+        consensus_validators = await build_consensus_validators(
+            public_keys=vault_public_keys,
+            chain_head=chain_head,
+            with_consolidations=True,
         )
         oracle_exiting_validators = await _fetch_oracle_exiting_validators(
             consensus_validators, protocol_config
         )
-        consolidations = await get_pending_consolidations(chain_head, consensus_validators)
 
         active_validators = [v for v in consensus_validators if v.status in CAN_BE_EXITED_STATUSES]
         pending_partial_withdrawals = await get_pending_partial_withdrawals(
@@ -122,7 +118,6 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
             consensus_validators=consensus_validators,
             oracle_exiting_validators=oracle_exiting_validators,
             pending_partial_withdrawals=pending_partial_withdrawals,
-            consolidations=consolidations,
             chain_head=chain_head,
         )
         metrics.queued_assets.labels(network=settings.network).set(int(queued_assets))
@@ -137,8 +132,12 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
             )
             return
 
-        pending_deposits = await fetch_pending_deposits_amounts(
-            public_keys={val.public_key for val in vault_validators},
+        # The pending deposit queue is fetched only once it is clear that a withdrawal is
+        # needed. Validators that are not in the beacon state yet can't be withdrawn from,
+        # so the ones returned here are dropped.
+        await apply_pending_deposits(
+            validators=consensus_validators,
+            public_keys=vault_public_keys,
             slot=str(chain_head.slot),
         )
         withdrawals = await _get_withdrawals(
@@ -148,9 +147,6 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
             pending_partial_withdrawals=pending_partial_withdrawals,
             validator_min_active_epochs=protocol_config.validator_min_active_epochs,
             oracle_exit_indexes={val.index for val in oracle_exiting_validators},
-            consolidation_target_indexes={c.target_index for c in consolidations},
-            consolidation_source_indexes={c.source_index for c in consolidations},
-            pending_deposits=pending_deposits,
         )
         if not withdrawals:
             logger.info(
@@ -223,9 +219,6 @@ async def _get_withdrawals(
     pending_partial_withdrawals: list[PendingPartialWithdrawal],
     validator_min_active_epochs: int,
     oracle_exit_indexes: set[int],
-    consolidation_target_indexes: set[int],
-    consolidation_source_indexes: set[int],
-    pending_deposits: dict[HexStr, Gwei],
 ) -> dict[HexStr, Gwei]:
     if queued_assets <= 0:
         return {}
@@ -245,7 +238,7 @@ async def _get_withdrawals(
         v
         for v in consensus_validators
         if v.is_partially_withdrawable(chain_head.epoch)
-        and v.index not in consolidation_source_indexes
+        and not v.is_consolidation_source
         and v.index not in oracle_exit_indexes
     ]
     partial_validator_indexes = {v.index for v in partial_validators}
@@ -274,9 +267,6 @@ async def _get_withdrawals(
         max_activation_epoch=max(max_activation_epoch, 0),
         oracle_exit_indexes=oracle_exit_indexes,
         partial_withdrawal_indexes=set(validator_partial_withdrawals.keys()),
-        consolidation_target_indexes=consolidation_target_indexes,
-        consolidation_source_indexes=consolidation_source_indexes,
-        pending_deposits=pending_deposits,
     )
 
     withdrawals: dict[HexStr, Gwei] = {}
@@ -334,15 +324,11 @@ def _get_partial_withdrawals(
     return withdrawals
 
 
-# pylint: disable-next=too-many-arguments
 def _filter_exitable_validators(
     consensus_validators: list[ConsensusValidator],
     max_activation_epoch: int,
     oracle_exit_indexes: set[int],
     partial_withdrawal_indexes: set[int],
-    consolidation_target_indexes: set[int],
-    consolidation_source_indexes: set[int],
-    pending_deposits: dict[HexStr, Gwei],
 ) -> list[ConsensusValidator]:
     """
     Return validators eligible for exit, ordered by balance to minimize assets exited.
@@ -360,14 +346,10 @@ def _filter_exitable_validators(
             continue
         if validator.index in partial_withdrawal_indexes:
             continue
-        if validator.index in consolidation_target_indexes:
-            continue
-        if validator.index in consolidation_source_indexes:
+        if validator.is_consolidation_target or validator.is_consolidation_source:
             continue
         can_be_exited_validators.append(validator)
-    can_be_exited_validators.sort(
-        key=lambda x: (x.balance + pending_deposits.get(x.public_key, 0), x.index)
-    )
+    can_be_exited_validators.sort(key=lambda x: (x.balance + (x.pending_balance or 0), x.index))
 
     return can_be_exited_validators
 

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -17,6 +17,7 @@ from src.common.app_state import AppState
 from src.common.clients import execution_client
 from src.common.consensus import get_chain_latest_head
 from src.common.contracts import VaultContract
+from src.common.exceptions import MissingConsolidationDataError
 from src.common.metrics import metrics
 from src.common.protocol_config import get_protocol_config
 from src.common.typings import PendingPartialWithdrawal
@@ -223,6 +224,13 @@ async def _get_withdrawals(
     if queued_assets <= 0:
         return {}
 
+    consolidation_source_indexes = set()
+    for validator in consensus_validators:
+        if validator.consolidation_data is None:
+            raise MissingConsolidationDataError(validator.public_key)
+        if validator.consolidation_data.is_source:
+            consolidation_source_indexes.add(validator.index)
+
     validator_partial_withdrawals: dict[int, Gwei] = defaultdict(lambda: Gwei(0))
     for withdrawal in pending_partial_withdrawals:
         validator_partial_withdrawals[
@@ -238,7 +246,7 @@ async def _get_withdrawals(
         v
         for v in consensus_validators
         if v.is_partially_withdrawable(chain_head.epoch)
-        and not v.is_consolidation_source
+        and v.index not in consolidation_source_indexes
         and v.index not in oracle_exit_indexes
     ]
     partial_validator_indexes = {v.index for v in partial_validators}
@@ -338,6 +346,8 @@ def _filter_exitable_validators(
     """
     can_be_exited_validators = []
     for validator in consensus_validators:
+        if validator.consolidation_data is None:
+            raise MissingConsolidationDataError(validator.public_key)
         if validator.activation_epoch > max_activation_epoch:
             continue
         if validator.status != ValidatorStatus.ACTIVE_ONGOING:
@@ -346,7 +356,7 @@ def _filter_exitable_validators(
             continue
         if validator.index in partial_withdrawal_indexes:
             continue
-        if validator.is_consolidation_target or validator.is_consolidation_source:
+        if validator.consolidation_data.is_target or validator.consolidation_data.is_source:
             continue
         can_be_exited_validators.append(validator)
     can_be_exited_validators.sort(key=lambda x: (x.balance + (x.pending_balance or 0), x.index))

--- a/src/withdrawals/tests/test_assets.py
+++ b/src/withdrawals/tests/test_assets.py
@@ -6,7 +6,6 @@ from sw_utils import ValidatorStatus
 from web3 import Web3
 from web3.types import Gwei, Wei
 
-from src.common.exceptions import MissingConsolidationDataError
 from src.common.tests.factories import create_chain_head
 from src.common.typings import PendingPartialWithdrawal
 from src.validators.tests.factories import create_consensus_validator
@@ -62,18 +61,6 @@ def test_calculate_validators_exits_amount():
     consensus_validators = []
     result = _calculate_validators_exits_amount(consensus_validators, oracle_exiting_validators)
     assert result == Web3.to_wei(0, 'gwei')
-
-    # raises_when_consolidation_data_was_not_loaded
-    consensus_validators = [
-        create_consensus_validator(
-            index=1,
-            balance=32,
-            status=ValidatorStatus.ACTIVE_EXITING,
-            with_consolidation_data=False,
-        ),
-    ]
-    with pytest.raises(MissingConsolidationDataError, match='Consolidation data is not loaded'):
-        _calculate_validators_exits_amount(consensus_validators, [])
 
 
 @pytest.mark.usefixtures('fake_settings')

--- a/src/withdrawals/tests/test_assets.py
+++ b/src/withdrawals/tests/test_assets.py
@@ -19,22 +19,21 @@ def test_calculate_validators_exits_amount():
         create_consensus_validator(index=2, balance=16),
     ]
     consensus_validators = []
-    source_consolidations_indexes = set()
-    result = _calculate_validators_exits_amount(
-        consensus_validators, oracle_exiting_validators, source_consolidations_indexes
-    )
+    result = _calculate_validators_exits_amount(consensus_validators, oracle_exiting_validators)
     assert result == Web3.to_wei(48, 'gwei')
 
-    # excludes_validators_in_source_consolidations_indexes
+    # excludes_consolidation_sources
     oracle_exiting_validators = []
     consensus_validators = [
-        create_consensus_validator(index=1, balance=32, status=ValidatorStatus.ACTIVE_EXITING),
+        create_consensus_validator(
+            index=1,
+            balance=32,
+            status=ValidatorStatus.ACTIVE_EXITING,
+            is_consolidation_source=True,
+        ),
         create_consensus_validator(index=2, balance=16, status=ValidatorStatus.ACTIVE_EXITING),
     ]
-    source_consolidations_indexes = {1}
-    result = _calculate_validators_exits_amount(
-        consensus_validators, oracle_exiting_validators, source_consolidations_indexes
-    )
+    result = _calculate_validators_exits_amount(consensus_validators, oracle_exiting_validators)
     assert result == Web3.to_wei(16, 'gwei')
 
     # excludes_validators_not_in_exiting_status
@@ -43,10 +42,7 @@ def test_calculate_validators_exits_amount():
         create_consensus_validator(index=1, balance=32, status=ValidatorStatus.ACTIVE_ONGOING),
         create_consensus_validator(index=2, balance=16, status=ValidatorStatus.EXITED_UNSLASHED),
     ]
-    source_consolidations_indexes = set()
-    result = _calculate_validators_exits_amount(
-        consensus_validators, oracle_exiting_validators, source_consolidations_indexes
-    )
+    result = _calculate_validators_exits_amount(consensus_validators, oracle_exiting_validators)
     assert result == Web3.to_wei(16, 'gwei')
 
     # calculates_combined_balance_for_oracle_and_manual_exits
@@ -56,19 +52,13 @@ def test_calculate_validators_exits_amount():
     consensus_validators = [
         create_consensus_validator(index=2, balance=16, status=ValidatorStatus.ACTIVE_EXITING),
     ]
-    source_consolidations_indexes = set()
-    result = _calculate_validators_exits_amount(
-        consensus_validators, oracle_exiting_validators, source_consolidations_indexes
-    )
+    result = _calculate_validators_exits_amount(consensus_validators, oracle_exiting_validators)
     assert result == Web3.to_wei(48, 'gwei')
 
     # returns_zero_when_no_validators_provided
     oracle_exiting_validators = []
     consensus_validators = []
-    source_consolidations_indexes = set()
-    result = _calculate_validators_exits_amount(
-        consensus_validators, oracle_exiting_validators, source_consolidations_indexes
-    )
+    result = _calculate_validators_exits_amount(consensus_validators, oracle_exiting_validators)
     assert result == Web3.to_wei(0, 'gwei')
 
 
@@ -85,7 +75,6 @@ class TestGetQueuedAssets:
             result = await get_queued_assets(
                 consensus_validators=[],
                 oracle_exiting_validators=[],
-                consolidations=[],
                 pending_partial_withdrawals=[],
                 chain_head=create_chain_head(),
             )
@@ -112,7 +101,6 @@ class TestGetQueuedAssets:
             await get_queued_assets(
                 consensus_validators=consensus_validators,
                 oracle_exiting_validators=oracle_exiting_validators,
-                consolidations=[],
                 pending_partial_withdrawals=pending_partial_withdrawals,
                 chain_head=create_chain_head(),
             )

--- a/src/withdrawals/tests/test_assets.py
+++ b/src/withdrawals/tests/test_assets.py
@@ -6,9 +6,11 @@ from sw_utils import ValidatorStatus
 from web3 import Web3
 from web3.types import Gwei, Wei
 
+from src.common.exceptions import MissingConsolidationDataError
 from src.common.tests.factories import create_chain_head
 from src.common.typings import PendingPartialWithdrawal
 from src.validators.tests.factories import create_consensus_validator
+from src.validators.typings import ValidatorConsolidationData
 from src.withdrawals.assets import _calculate_validators_exits_amount, get_queued_assets
 
 
@@ -29,7 +31,7 @@ def test_calculate_validators_exits_amount():
             index=1,
             balance=32,
             status=ValidatorStatus.ACTIVE_EXITING,
-            is_consolidation_source=True,
+            consolidation_data=ValidatorConsolidationData(is_source=True, is_target=False),
         ),
         create_consensus_validator(index=2, balance=16, status=ValidatorStatus.ACTIVE_EXITING),
     ]
@@ -60,6 +62,18 @@ def test_calculate_validators_exits_amount():
     consensus_validators = []
     result = _calculate_validators_exits_amount(consensus_validators, oracle_exiting_validators)
     assert result == Web3.to_wei(0, 'gwei')
+
+    # raises_when_consolidation_data_was_not_loaded
+    consensus_validators = [
+        create_consensus_validator(
+            index=1,
+            balance=32,
+            status=ValidatorStatus.ACTIVE_EXITING,
+            with_consolidation_data=False,
+        ),
+    ]
+    with pytest.raises(MissingConsolidationDataError, match='Consolidation data is not loaded'):
+        _calculate_validators_exits_amount(consensus_validators, [])
 
 
 @pytest.mark.usefixtures('fake_settings')

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -11,6 +11,7 @@ from src.common.typings import PendingPartialWithdrawal, Singleton
 from src.config.networks import HOODI
 from src.config.settings import WITHDRAWALS_INTERVAL, settings
 from src.validators.tests.factories import create_consensus_validator
+from src.validators.typings import ValidatorConsolidationData
 from src.withdrawals.tasks import (
     WithdrawalIntervalMixin,
     _fetch_oracle_exiting_validators,
@@ -615,7 +616,7 @@ async def test_get_withdrawals(data_dir):
             status=ValidatorStatus.ACTIVE_ONGOING,
             activation_epoch=90,
             index=1,
-            is_consolidation_target=True,
+            consolidation_data=ValidatorConsolidationData(is_source=False, is_target=True),
         ),
         create_consensus_validator(
             public_key='0x2',
@@ -844,7 +845,7 @@ async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
             balance=ether_to_gwei(40),
             status=ValidatorStatus.ACTIVE_ONGOING,
             activation_epoch=90,
-            is_consolidation_source=True,
+            consolidation_data=ValidatorConsolidationData(is_source=True, is_target=False),
         ),
         create_consensus_validator(
             public_key='0x2',
@@ -1083,7 +1084,7 @@ def test_filter_exitable_validators():
             activation_epoch=10,
             status=ValidatorStatus.ACTIVE_ONGOING,
             balance=32,
-            is_consolidation_target=True,
+            consolidation_data=ValidatorConsolidationData(is_source=False, is_target=True),
         ),
     ]
     result = _filter_exitable_validators(
@@ -1105,7 +1106,7 @@ def test_filter_exitable_validators():
             activation_epoch=10,
             status=ValidatorStatus.ACTIVE_ONGOING,
             balance=32,
-            is_consolidation_source=True,
+            consolidation_data=ValidatorConsolidationData(is_source=True, is_target=False),
         ),
     ]
     result = _filter_exitable_validators(

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -271,9 +271,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(2), '0x2': ether_to_gwei(18)}
     assert result == expected
@@ -302,9 +299,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
 
@@ -336,9 +330,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert result == {'0x1': ether_to_gwei(8), '0x2': ether_to_gwei(18)}
     settings.disable_full_withdrawals = False
@@ -367,9 +358,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0)}
     assert result == expected
@@ -398,9 +386,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(10)}
     assert result == expected
@@ -435,9 +420,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(18), '0x3': ether_to_gwei(28)}
     assert result == expected
@@ -471,9 +453,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=pending_partial_withdrawals,
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -507,9 +486,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=pending_partial_withdrawals,
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(49), '0x2': ether_to_gwei(11)}
     assert result == expected
@@ -538,9 +514,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0)}
     assert result == expected
@@ -569,9 +542,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(0), '0x2': ether_to_gwei(0)}
     assert result == expected
@@ -601,9 +571,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': 0}
     assert result == expected
@@ -634,9 +601,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes={1},
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -651,6 +615,7 @@ async def test_get_withdrawals(data_dir):
             status=ValidatorStatus.ACTIVE_ONGOING,
             activation_epoch=90,
             index=1,
+            is_consolidation_target=True,
         ),
         create_consensus_validator(
             public_key='0x2',
@@ -667,9 +632,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes={1},
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -700,9 +662,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -719,6 +678,7 @@ async def test_get_withdrawals(data_dir):
             status=ValidatorStatus.ACTIVE_ONGOING,
             activation_epoch=90,
             index=1,
+            pending_balance=ether_to_gwei(1800),
         ),
         create_consensus_validator(
             public_key='0x2',
@@ -735,9 +695,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={'0x1': ether_to_gwei(1800)},
     )
     # only the plain validator ('0x2') is exited; '0x1' with the huge pending
     # deposit sorts last and is left untouched
@@ -757,6 +714,7 @@ async def test_get_withdrawals(data_dir):
             status=ValidatorStatus.ACTIVE_ONGOING,
             activation_epoch=90,
             index=1,
+            pending_balance=ether_to_gwei(5),
         ),
         create_consensus_validator(
             public_key='0x2',
@@ -774,9 +732,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={'0x1': ether_to_gwei(5)},
     )
     # '0x1' sorts first (10 + 5 = 15 ETH effective, versus '0x2' at 50 ETH), but only
     # its real 10 ETH balance is subtracted from queued_assets, leaving 2 ETH still
@@ -803,9 +758,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {}
     assert result == expected
@@ -821,9 +773,6 @@ async def test_get_withdrawals(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert result == {}
 
@@ -866,9 +815,6 @@ async def test_get_withdrawals_non_compounding_exit_does_not_reduce_partial_capa
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     # v1 (40 ETH) is the cheapest to exit and is fully exited, leaving 27 ETH still
     # needed. partial_capacity (31 ETH from v2+v3) is untouched by v1's exit, so it
@@ -898,6 +844,7 @@ async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
             balance=ether_to_gwei(40),
             status=ValidatorStatus.ACTIVE_ONGOING,
             activation_epoch=90,
+            is_consolidation_source=True,
         ),
         create_consensus_validator(
             public_key='0x2',
@@ -914,9 +861,6 @@ async def test_get_withdrawals_excludes_consolidation_sources(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes={1},
-        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(0)}
     assert result == expected
@@ -953,9 +897,6 @@ async def test_get_withdrawals_excludes_oracle_exiting_validators_from_partials(
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes={1},
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x2': ether_to_gwei(5)}
     assert result == expected
@@ -983,9 +924,6 @@ async def test_get_withdrawals_boundary_activation_epoch_prefers_partial_over_fu
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     expected = {'0x1': ether_to_gwei(5)}
     assert result == expected
@@ -1077,9 +1015,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -1098,9 +1033,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -1119,9 +1051,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes={2},
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -1140,9 +1069,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes={2},
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -1153,7 +1079,11 @@ def test_filter_exitable_validators():
             index=1, activation_epoch=10, status=ValidatorStatus.ACTIVE_ONGOING, balance=32
         ),
         create_consensus_validator(
-            index=2, activation_epoch=10, status=ValidatorStatus.ACTIVE_ONGOING, balance=32
+            index=2,
+            activation_epoch=10,
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            balance=32,
+            is_consolidation_target=True,
         ),
     ]
     result = _filter_exitable_validators(
@@ -1161,9 +1091,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes={2},
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -1174,7 +1101,11 @@ def test_filter_exitable_validators():
             index=1, activation_epoch=10, status=ValidatorStatus.ACTIVE_ONGOING, balance=32
         ),
         create_consensus_validator(
-            index=2, activation_epoch=10, status=ValidatorStatus.ACTIVE_ONGOING, balance=32
+            index=2,
+            activation_epoch=10,
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            balance=32,
+            is_consolidation_source=True,
         ),
     ]
     result = _filter_exitable_validators(
@@ -1182,9 +1113,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes={2},
-        pending_deposits={},
     )
     assert len(result) == 1
     assert result[0].index == 1
@@ -1206,9 +1134,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert len(result) == 3
     assert result[0].index == 2
@@ -1223,6 +1148,7 @@ def test_filter_exitable_validators():
             activation_epoch=10,
             status=ValidatorStatus.ACTIVE_ONGOING,
             balance=ether_to_gwei(32),
+            pending_balance=ether_to_gwei(1800),
         ),
         create_consensus_validator(
             index=2,
@@ -1237,9 +1163,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes=set(),
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={'0x1': ether_to_gwei(1800)},
     )
     assert len(result) == 2
     assert result[0].index == 2
@@ -1259,9 +1182,6 @@ def test_filter_exitable_validators():
         max_activation_epoch=12,
         oracle_exit_indexes={1},
         partial_withdrawal_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={},
     )
     assert len(result) == 0
 
@@ -1506,9 +1426,6 @@ async def test_get_withdrawals_partial_topup_called_at_most_once(
             pending_partial_withdrawals=[],
             validator_min_active_epochs=10,
             oracle_exit_indexes=set(),
-            consolidation_target_indexes=set(),
-            consolidation_source_indexes=set(),
-            pending_deposits={},
         )
 
     assert len(calls) <= 1
@@ -1537,6 +1454,7 @@ async def test_get_withdrawals_pending_deposit_asymmetry(data_dir):
             status=ValidatorStatus.ACTIVE_ONGOING,
             activation_epoch=90,
             is_compounding=False,
+            pending_balance=ether_to_gwei(50),
         ),
         create_consensus_validator(
             public_key='0x2',
@@ -1554,9 +1472,6 @@ async def test_get_withdrawals_pending_deposit_asymmetry(data_dir):
         pending_partial_withdrawals=[],
         validator_min_active_epochs=10,
         oracle_exit_indexes=set(),
-        consolidation_target_indexes=set(),
-        consolidation_source_indexes=set(),
-        pending_deposits={'0x1': ether_to_gwei(50)},
     )
     # '0x1' (10+50 effective) exits first but only 10 ETH counts against queued_assets,
     # so '0x2' exits too


### PR DESCRIPTION
Introduces `build_consensus_validators` — a single builder that fetches the vault's consensus validators and enriches them with pending deposits and pending consolidations from one consistent chain snapshot. Callers now read that data off `ConsensusValidator` instead of threading parallel dicts and index sets around.

## `ConsensusValidator`

Four new optional fields, populated only when the corresponding flag is passed:

- `pending_balance` — total amount queued for the validator in the pending deposit queue
- `target_consolidation_balance` — balance incoming from the validator's pending consolidation sources
- `is_consolidation_source`, `is_consolidation_target`

## `build_consensus_validators`

```python
await build_consensus_validators(
    public_keys, chain_head=None,
    with_pending_deposits=False, with_consolidations=False, compounding_deposits_only=False,
)
```

- `with_pending_deposits` fills `pending_balance` and additionally returns validators that are not in the beacon state yet but already have pending deposits. Those get `UNKNOWN_VALIDATOR_INDEX` and take their withdrawal credentials from the deposit.
- `compounding_deposits_only` counts only 0x02 deposits, which is what the funding path needs.
- `with_consolidations` sets the consolidation flags. `target_consolidation_balance` stays `None` when any of a target's sources is outside the fetched set, i.e. its balance is unknown — previously this exclusion was order-dependent inside the loop, now it is not.

## Callers

`fetch_funding_validators_balances` is reduced to an eligibility filter plus a sum over the built validators. Behavior is unchanged.

The withdrawal task drops `get_pending_consolidations` / `fetch_pending_deposits_amounts` and their derived arguments:

- `get_queued_assets(consolidations=...)` and `_calculate_validators_exits_amount(source_consolidations_indexes=...)` → `is_consolidation_source`
- `_get_withdrawals` / `_filter_exitable_validators` lose `consolidation_target_indexes`, `consolidation_source_indexes` and `pending_deposits` → flags and `pending_balance`

The pending deposit queue is still fetched lazily, only once a withdrawal is known to be needed, via the now-public `apply_pending_deposits`. Fetching it as part of the initial build would pull the whole queue on every interval tick, including the common case where the task returns early.

## Non-mutating helpers

Neither enrichment step touches the validators it is given:

- `_apply_pending_consolidations` returns a copy of the list, in the original order, with the consolidation fields filled in
- `apply_pending_deposits` returns a tuple of (a copy of the list with `pending_balance` filled in, the validators that are missing from the beacon state but present in the pending deposit queue)

`fetch_pending_deposits_amounts` had no callers left and is removed.
