### PR TITLE
Revert "Speedup graph_get_allocators"

### DIFF
--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -388,43 +388,55 @@ class TestUpdateOsTokenPositions:
         runner: CliRunner,
     ):
         # hardcoded to check merkle root
-        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
-        address_2 = Web3.to_checksum_address('0x24c8DBBC3d1C35C4159787b1f7a62bea1A814242')
-        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
-        vault_2 = Web3.to_checksum_address('0xe8Ea1025b49D2B51C536cFBc0833F021ba4c6903')
+        address_1 = '0x2242b8ab71521f6abEE4B4D83195E70AcB08727a'
+        address_2 = '0x24c8DBBC3d1C35C4159787b1f7a62bea1A814242'
+        vault_1 = '0xEd735de172272C03CA6F60c1d90D83D9CFB46D22'
+        vault_2 = '0xe8Ea1025b49D2B51C536cFBc0833F021ba4c6903'
         allocators = [
-            Allocator(
-                address=address_1,
-                vault_os_token_positions=[
-                    VaultOsTokenPosition(
-                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
-                    ),
-                ],
-            ),
-            Allocator(
-                address=address_2,
-                vault_os_token_positions=[
-                    VaultOsTokenPosition(
-                        address=vault_2, minted_shares=Web3.to_wei(12, 'ether'), ltv=0.5
-                    ),
-                ],
-            ),
+            {
+                'vault': {
+                    'id': vault_1.lower(),
+                    'osTokenConfig': {'id': '2'},
+                },
+                'id': address_1.lower(),
+                'address': address_1,
+                'mintedOsTokenShares': Web3.to_wei(10, 'ether'),
+                'ltv': '0.5',
+            },
+            {
+                'vault': {
+                    'id': vault_2.lower(),
+                    'osTokenConfig': {'id': '2'},
+                },
+                'id': address_2.lower(),
+                'address': address_2,
+                'mintedOsTokenShares': Web3.to_wei(12, 'ether'),
+                'ltv': '0.5',
+            },
         ]
         leverage_positions = [
-            LeverageStrategyPosition(
-                user=address_1,
-                vault=vault_1,
-                proxy=Web3.to_checksum_address(faker.eth_address()),
-                os_token_shares=Web3.to_wei(1, 'ether'),
-                exiting_os_token_shares=Web3.to_wei(0.1, 'ether'),
-                assets=Web3.to_wei(0.1, 'ether'),
-                exiting_assets=Web3.to_wei(0.05, 'ether'),
-            ),
+            {
+                'user': address_1,
+                'vault': {
+                    'id': vault_1.lower(),
+                },
+                'proxy': faker.eth_address(),
+                'osTokenShares': Web3.to_wei(1, 'ether'),
+                'exitingOsTokenShares': Web3.to_wei(0.1, 'ether'),
+                'assets': Web3.to_wei(0.1, 'ether'),
+                'exitingAssets': Web3.to_wei(0.05, 'ether'),
+            },
         ]
-        os_token_holders = {
-            address_1: Web3.to_wei(4, 'ether'),
-            address_2: Web3.to_wei(13, 'ether'),
-        }
+        os_token_holders = [
+            {
+                'id': address_1.lower(),
+                'balance': Web3.to_wei(4, 'ether'),
+            },
+            {
+                'id': address_2.lower(),
+                'balance': Web3.to_wei(13, 'ether'),
+            },
+        ]
         mock_protocol_data = [
             {
                 'id': 'stakewise',
@@ -492,7 +504,10 @@ class TestUpdateOsTokenPositions:
             patch_os_token_contract_address(os_token_contract_address),
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
-            patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch(
+                'src.redemptions.graph.graph_client.fetch_pages',
+                side_effect=[allocators, leverage_positions, os_token_holders],
+            ),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -514,20 +529,22 @@ class TestUpdateOsTokenPositions:
         runner: CliRunner,
     ):
         # hardcoded to check merkle root
-        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
-        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
+        address_1 = '0x2242b8ab71521f6abEE4B4D83195E70AcB08727a'
+        vault_1 = '0xEd735de172272C03CA6F60c1d90D83D9CFB46D22'
         allocators = [
-            Allocator(
-                address=address_1,
-                vault_os_token_positions=[
-                    VaultOsTokenPosition(
-                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
-                    ),
-                ],
-            ),
+            {
+                'vault': {
+                    'id': vault_1.lower(),
+                    'osTokenConfig': {'id': '2'},
+                },
+                'id': address_1.lower(),
+                'address': address_1,
+                'mintedOsTokenShares': Web3.to_wei(10, 'ether'),
+                'ltv': '0.5',
+            },
         ]
-        leverage_positions: list[LeverageStrategyPosition] = []
-        os_token_holders: dict[ChecksumAddress, Wei] = {}
+        leverage_positions = []
+        os_token_holders = []
         mock_protocol_data = []
         os_token_converter = OsTokenConverter(110, 100)
         args = [
@@ -543,7 +560,10 @@ class TestUpdateOsTokenPositions:
             patch_os_token_contract_address(os_token_contract_address),
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
-            patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch(
+                'src.redemptions.graph.graph_client.fetch_pages',
+                side_effect=[allocators, leverage_positions, os_token_holders],
+            ),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -565,20 +585,22 @@ class TestUpdateOsTokenPositions:
         runner: CliRunner,
     ):
         # hardcoded to check merkle root
-        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
-        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
+        address_1 = '0x2242b8ab71521f6abEE4B4D83195E70AcB08727a'
+        vault_1 = '0xEd735de172272C03CA6F60c1d90D83D9CFB46D22'
         allocators = [
-            Allocator(
-                address=address_1,
-                vault_os_token_positions=[
-                    VaultOsTokenPosition(
-                        address=vault_1, minted_shares=Web3.to_wei(5, 'ether'), ltv=0.5
-                    ),
-                ],
-            ),
+            {
+                'vault': {
+                    'id': vault_1.lower(),
+                    'osTokenConfig': {'id': '2'},
+                },
+                'id': address_1.lower(),
+                'address': address_1,
+                'mintedOsTokenShares': Web3.to_wei(5, 'ether'),
+                'ltv': '0.5',
+            },
         ]
-        leverage_positions: list[LeverageStrategyPosition] = []
-        os_token_holders: dict[ChecksumAddress, Wei] = {}
+        leverage_positions = []
+        os_token_holders = []
         mock_protocol_data = []
         os_token_converter = OsTokenConverter(110, 100)
         args = [
@@ -596,7 +618,10 @@ class TestUpdateOsTokenPositions:
             patch_os_token_contract_address(os_token_contract_address),
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
-            patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch(
+                'src.redemptions.graph.graph_client.fetch_pages',
+                side_effect=[allocators, leverage_positions, os_token_holders],
+            ),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
@@ -612,20 +637,27 @@ class TestUpdateOsTokenPositions:
         runner: CliRunner,
     ):
         # hardcoded to check merkle root
-        address_1 = Web3.to_checksum_address('0x2242b8ab71521f6abEE4B4D83195E70AcB08727a')
-        vault_1 = Web3.to_checksum_address('0xEd735de172272C03CA6F60c1d90D83D9CFB46D22')
+        address_1 = '0x2242b8ab71521f6abEE4B4D83195E70AcB08727a'
+        vault_1 = '0xEd735de172272C03CA6F60c1d90D83D9CFB46D22'
         allocators = [
-            Allocator(
-                address=address_1,
-                vault_os_token_positions=[
-                    VaultOsTokenPosition(
-                        address=vault_1, minted_shares=Web3.to_wei(10, 'ether'), ltv=0.5
-                    ),
-                ],
-            ),
+            {
+                'vault': {
+                    'id': vault_1.lower(),
+                    'osTokenConfig': {'id': '2'},
+                },
+                'id': address_1.lower(),
+                'address': address_1,
+                'mintedOsTokenShares': Web3.to_wei(10, 'ether'),
+                'ltv': '0.5',
+            },
         ]
-        leverage_positions: list[LeverageStrategyPosition] = []
-        os_token_holders = {address_1: Web3.to_wei(7, 'ether')}
+        leverage_positions = []
+        os_token_holders = [
+            {
+                'id': address_1.lower(),
+                'balance': Web3.to_wei(7, 'ether'),
+            },
+        ]
         mock_protocol_data = []
         os_token_converter = OsTokenConverter(110, 100)
         args = [
@@ -643,28 +675,16 @@ class TestUpdateOsTokenPositions:
             patch_os_token_contract_address(os_token_contract_address),
             patch_os_token_converter(os_token_converter),
             patch_api_client(mock_protocol_data),
-            patch_graph_calls(allocators, leverage_positions, os_token_holders),
+            patch(
+                'src.redemptions.graph.graph_client.fetch_pages',
+                side_effect=[allocators, leverage_positions, os_token_holders],
+            ),
             patch_ipfs_client() as mock_upload_json,
             patch_startup_check(),
         ):
             result = runner.invoke(update_redeemable_positions, args, input='\n')
             assert result.exit_code == 0
             mock_upload_json.assert_not_called()
-
-
-@contextlib.contextmanager
-def patch_graph_calls(
-    allocators: list[Allocator],
-    leverage_positions: list[LeverageStrategyPosition],
-    os_token_holders: dict[ChecksumAddress, Wei],
-):
-    target = 'src.redemptions.commands.update_redeemable_positions'
-    with (
-        patch(f'{target}.graph_get_redeemable_allocators', return_value=allocators),
-        patch(f'{target}.graph_get_leverage_positions', return_value=leverage_positions),
-        patch(f'{target}.graph_get_os_token_holders', return_value=os_token_holders),
-    ):
-        yield
 
 
 @contextlib.contextmanager

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -37,9 +37,9 @@ from src.redemptions.api_client import (
 )
 from src.redemptions.contracts import os_token_redeemer_contract
 from src.redemptions.graph import (
+    graph_get_allocators,
     graph_get_leverage_positions,
     graph_get_os_token_holders,
-    graph_get_redeemable_allocators,
 )
 from src.redemptions.os_token_converter import create_os_token_converter
 from src.redemptions.typings import (
@@ -222,7 +222,7 @@ async def process(
     finalized_block = await execution_client.eth.get_block('finalized')
     block_number = finalized_block['number']
     logger.info('Fetching allocators from the subgraph...')
-    allocators = await graph_get_redeemable_allocators(block_number)
+    allocators = await graph_get_allocators(block_number, exclude_meta_vaults=True)
     logger.info('Fetched %s allocators from the subgraph', len(allocators))
 
     # filter boost proxy positions

--- a/src/redemptions/graph.py
+++ b/src/redemptions/graph.py
@@ -16,88 +16,56 @@ from src.redemptions.typings import (
 logger = logging.getLogger(__name__)
 
 
-async def graph_get_redeemable_allocators(block_number: BlockNumber) -> list[Allocator]:
-    """
-    Fetch allocators at the given block. First fetches vaults eligible for
-    redemption (excluding legacy and meta vaults), then fetches allocators
-    per vault.
-    """
-    vaults = await graph_get_redeemable_vaults(block_number)
-    return await graph_get_redeemable_allocators_from_vaults(vaults, block_number)
-
-
-async def graph_get_redeemable_vaults(block_number: BlockNumber) -> list[ChecksumAddress]:
-    """
-    Fetch vaults eligible for redemption at the given block, excluding legacy
-    vaults (osTokenConfig.id == '1') and meta vaults.
-    """
-    query = gql(
-        """
-        query vaultsQuery($block: Int, $first: Int, $lastID: String) {
-          vaults(
-            block: {number: $block},
-            where: {id_gt: $lastID, osTokenConfig_not: "1", isMetaVault: false},
-            orderBy: id,
-            first: $first
-          ) {
-            id
-          }
-        }
-        """
-    )
-    params = {'block': block_number}
-    response = await graph_client.fetch_pages(query, params=params, cursor_pagination=True)
-    return [Web3.to_checksum_address(item['id']) for item in response]
-
-
-async def graph_get_redeemable_allocators_from_vaults(
-    vaults: list[ChecksumAddress],
+async def graph_get_allocators(
     block_number: BlockNumber,
+    exclude_meta_vaults: bool = False,
 ) -> list[Allocator]:
     """
-    Fetch allocators at the given block for each vault in ``vaults`` and
-    return them as a list of Allocator objects. Filters records to include
-    only those with mintedOsTokenShares > 0.
+    Fetch allocators at the given block and return them as a list of Allocator objects.
+    Filter records to include only those with mintedOsTokenShares > 0.
+
+    When ``exclude_meta_vaults`` is True, allocators whose vault is a meta vault
+    are excluded at the subgraph level.
     """
+    vault_filter = ', vault_: { isMetaVault: false }' if exclude_meta_vaults else ''
     query = gql(
-        """
-        query getAllocators($block: Int, $first: Int, $lastID: String, $vault: String){
+        f"""
+        query getAllocators($block: Int, $first: Int, $lastID: String){{
           allocators(
-            block: {number: $block},
-            where: {
-                id_gt: $lastID,
-                vault: $vault,
-                mintedOsTokenShares_gt: 0
-            },
+           block: {{number: $block}},
+            where: {{
+                id_gt: $lastID{vault_filter}
+            }},
             orderBy: id
             first: $first
-          ){
+          ){{
+          vault {{
             id
-            address
-            mintedOsTokenShares
-            ltv
-          }
-        }
+            osTokenConfig {{
+              id
+            }}
+          }}
+          id
+          address
+          mintedOsTokenShares
+          ltv
+          }}
+        }}
         """
     )
+    params = {
+        'block': block_number,
+    }
+    response = await graph_client.fetch_pages(query, params=params, cursor_pagination=True)
     positions_by_allocator: defaultdict[str, list[VaultOsTokenPosition]] = defaultdict(list)
-    total = len(vaults)
-    for index, vault in enumerate(vaults, start=1):
-        params = {
-            'block': block_number,
-            'vault': vault.lower(),
-        }
-        logger.debug(
-            'graph_get_redeemable_allocators_from_vaults: querying vault %s (%d/%d)',
-            vault,
-            index,
-            total,
-        )
-        response = await graph_client.fetch_pages(query, params=params, cursor_pagination=True)
-        for item in response:
+    for item in response:
+        # filter legacy vaults. ID can be checksum address, skip cast to int
+        if item['vault']['osTokenConfig']['id'] == '1':
+            continue
+        if int(item['mintedOsTokenShares']) > 0:
             positions_by_allocator[item['address']].append(
                 VaultOsTokenPosition(
-                    address=vault,
+                    address=Web3.to_checksum_address(item['vault']['id']),
                     minted_shares=Wei(int(item['mintedOsTokenShares'])),
                     ltv=float(item['ltv']),
                 )

--- a/src/redemptions/tests/test_graph.py
+++ b/src/redemptions/tests/test_graph.py
@@ -1,108 +1,128 @@
+import random
 from unittest.mock import patch
 
 import pytest
-from eth_typing import BlockNumber
 from sw_utils.tests import faker
 from web3 import Web3
 from web3.types import Wei
 
-from src.redemptions.graph import (
-    graph_get_leverage_positions,
-    graph_get_os_token_holders,
-    graph_get_redeemable_allocators_from_vaults,
-)
-from src.redemptions.typings import (
-    Allocator,
-    LeverageStrategyPosition,
-    VaultOsTokenPosition,
-)
+from src.redemptions.graph import graph_get_allocators
+from src.redemptions.typings import Allocator, VaultOsTokenPosition
 
 
 @pytest.mark.usefixtures('fake_settings')
-async def test_graph_get_redeemable_allocators_from_vaults():
+async def test_graph_get_allocators():
     address_1 = faker.eth_address().lower()
     address_2 = faker.eth_address().lower()
-    vault_1 = Web3.to_checksum_address(faker.eth_address())
-    vault_2 = Web3.to_checksum_address(faker.eth_address())
+    vault_1 = faker.eth_address().lower()
+    vault_2 = faker.eth_address().lower()
 
-    vault_1_response = [
-        {'address': address_1, 'mintedOsTokenShares': '150', 'ltv': '0.5'},
-        {'address': address_2, 'mintedOsTokenShares': '1000', 'ltv': '0.7'},
-    ]
-    vault_2_response = [
-        {'address': address_1, 'mintedOsTokenShares': '2000', 'ltv': '0.8'},
-    ]
+    with patch('src.redemptions.graph.graph_client.fetch_pages', return_value=[]):
+        result = await graph_get_allocators(random.randint(1, 1000000))
+    assert result == []
 
-    with patch(
-        'src.redemptions.graph.graph_client.fetch_pages',
-        side_effect=[vault_1_response, vault_2_response],
-    ):
-        result = await graph_get_redeemable_allocators_from_vaults(
-            [vault_1, vault_2], BlockNumber(123)
-        )
-
-    by_address = {a.address: a for a in result}
-    assert by_address[Web3.to_checksum_address(address_1)] == Allocator(
-        address=Web3.to_checksum_address(address_1),
-        vault_os_token_positions=[
-            VaultOsTokenPosition(address=vault_1, minted_shares=Wei(150), ltv=0.5),
-            VaultOsTokenPosition(address=vault_2, minted_shares=Wei(2000), ltv=0.8),
-        ],
-    )
-    assert by_address[Web3.to_checksum_address(address_2)] == Allocator(
-        address=Web3.to_checksum_address(address_2),
-        vault_os_token_positions=[
-            VaultOsTokenPosition(address=vault_1, minted_shares=Wei(1000), ltv=0.7),
-        ],
-    )
-
-
-@pytest.mark.usefixtures('fake_settings')
-async def test_graph_get_leverage_positions():
-    user = faker.eth_address().lower()
-    vault = faker.eth_address().lower()
-    proxy = faker.eth_address().lower()
-
-    response = [
+    mock_response = [
         {
-            'user': user,
-            'vault': {'id': vault},
-            'proxy': proxy,
-            'osTokenShares': '1000',
-            'exitingOsTokenShares': '100',
-            'assets': '50',
-            'exitingAssets': '25',
+            'address': address_1,
+            'vault': {'id': vault_1, 'osTokenConfig': {'id': '2'}},
+            'mintedOsTokenShares': '0',
+            'ltv': '0',
+        },
+        {
+            'address': address_2,
+            'vault': {'id': vault_2, 'osTokenConfig': {'id': '2'}},
+            'mintedOsTokenShares': '1000',
+            'ltv': '0.7',
         },
     ]
-    with patch('src.redemptions.graph.graph_client.fetch_pages', return_value=response):
-        result = await graph_get_leverage_positions(BlockNumber(123))
-
+    with patch('src.redemptions.graph.graph_client.fetch_pages', return_value=mock_response):
+        result = await graph_get_allocators(random.randint(1, 1000000))
     assert result == [
-        LeverageStrategyPosition(
-            user=Web3.to_checksum_address(user),
-            vault=Web3.to_checksum_address(vault),
-            proxy=Web3.to_checksum_address(proxy),
-            os_token_shares=Wei(1000),
-            exiting_os_token_shares=Wei(100),
-            assets=Wei(50),
-            exiting_assets=Wei(25),
+        Allocator(
+            address=Web3.to_checksum_address(address_2),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(
+                    address=Web3.to_checksum_address(vault_2), minted_shares=Wei(1000), ltv=0.7
+                )
+            ],
+        )
+    ]
+
+    mock_response = [
+        {
+            'address': address_1,
+            'vault': {'id': vault_1, 'osTokenConfig': {'id': '2'}},
+            'mintedOsTokenShares': '150',
+            'ltv': '0.5',
+        },
+        {
+            'address': address_1,
+            'vault': {'id': vault_2, 'osTokenConfig': {'id': '2'}},
+            'mintedOsTokenShares': '1000',
+            'ltv': '0.7',
+        },
+    ]
+    with patch('src.redemptions.graph.graph_client.fetch_pages', return_value=mock_response):
+        result = await graph_get_allocators(random.randint(1, 1000000))
+    assert result == [
+        Allocator(
+            address=Web3.to_checksum_address(address_1),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(
+                    address=Web3.to_checksum_address(vault_1), minted_shares=Wei(150), ltv=0.5
+                ),
+                VaultOsTokenPosition(
+                    address=Web3.to_checksum_address(vault_2), minted_shares=Wei(1000), ltv=0.7
+                ),
+            ],
         )
     ]
 
 
 @pytest.mark.usefixtures('fake_settings')
-async def test_graph_get_os_token_holders():
+async def test_graph_get_allocators_filters_legacy_vaults():
+    """Allocator entries whose vault has osTokenConfig.id == '1' must be skipped."""
     address_1 = faker.eth_address().lower()
     address_2 = faker.eth_address().lower()
+    legacy_vault = faker.eth_address().lower()
+    vault = faker.eth_address().lower()
 
-    response = [
-        {'id': address_1, 'balance': '500'},
-        {'id': address_2, 'balance': '1000'},
+    mock_response = [
+        {
+            'address': address_1,
+            'vault': {'id': legacy_vault, 'osTokenConfig': {'id': '1'}},
+            'mintedOsTokenShares': '500',
+            'ltv': '0.6',
+        },
+        {
+            'address': address_2,
+            'vault': {'id': vault, 'osTokenConfig': {'id': '2'}},
+            'mintedOsTokenShares': '1000',
+            'ltv': '0.7',
+        },
     ]
-    with patch('src.redemptions.graph.graph_client.fetch_pages', return_value=response):
-        result = await graph_get_os_token_holders(BlockNumber(123))
+    with patch('src.redemptions.graph.graph_client.fetch_pages', return_value=mock_response):
+        result = await graph_get_allocators(random.randint(1, 1000000))
+    assert result == [
+        Allocator(
+            address=Web3.to_checksum_address(address_2),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(
+                    address=Web3.to_checksum_address(vault), minted_shares=Wei(1000), ltv=0.7
+                )
+            ],
+        )
+    ]
 
-    assert result == {
-        Web3.to_checksum_address(address_1): Wei(500),
-        Web3.to_checksum_address(address_2): Wei(1000),
-    }
+    # All entries belong to legacy vaults -> empty result.
+    mock_response = [
+        {
+            'address': address_1,
+            'vault': {'id': legacy_vault, 'osTokenConfig': {'id': '1'}},
+            'mintedOsTokenShares': '500',
+            'ltv': '0.6',
+        },
+    ]
+    with patch('src.redemptions.graph.graph_client.fetch_pages', return_value=mock_response):
+        result = await graph_get_allocators(random.randint(1, 1000000))
+    assert result == []


### PR DESCRIPTION
### Description

Reverts #732. The test file moved since the PR merged (`src/commands/tests/test_internal/` → `src/redemptions/commands/tests/`), so two conflict hunks in `test_update_redeemable_positions.py` were resolved manually: the pre-#732 test structure is restored while keeping the later balance-value changes from #811 (Arbitrum removal).