### PR TITLE
Exclude exiting validators from pending partial withdrawals

### DIFF
--- a/src/withdrawals/assets.py
+++ b/src/withdrawals/assets.py
@@ -18,16 +18,6 @@ from src.common.typings import (
 from src.config.settings import settings
 from src.validators.typings import ConsensusValidator
 
-CAN_BE_EXITED_STATUSES = [
-    ValidatorStatus.ACTIVE_ONGOING,
-    ValidatorStatus.ACTIVE_EXITING,
-    ValidatorStatus.ACTIVE_SLASHED,
-    ValidatorStatus.EXITED_UNSLASHED,
-    ValidatorStatus.EXITED_SLASHED,
-    ValidatorStatus.WITHDRAWAL_POSSIBLE,
-]
-
-
 EXITING_STATUSES = [
     ValidatorStatus.ACTIVE_EXITING,
     ValidatorStatus.ACTIVE_SLASHED,

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -41,7 +41,11 @@ from src.validators.exceptions import EmptyRelayerResponseException
 from src.validators.oracles import poll_active_exits
 from src.validators.relayer import RelayerClient
 from src.validators.typings import ConsensusValidator
-from src.withdrawals.assets import CAN_BE_EXITED_STATUSES, get_queued_assets
+from src.withdrawals.assets import (
+    CAN_BE_EXITED_STATUSES,
+    EXITING_STATUSES,
+    get_queued_assets,
+)
 from src.withdrawals.execution import submit_withdraw_validators
 
 logger = logging.getLogger(__name__)
@@ -113,10 +117,12 @@ class ValidatorWithdrawalSubtask(WithdrawalIntervalMixin):
         )
         consolidations = await get_pending_consolidations(chain_head, consensus_validators)
 
-        active_validators = [v for v in consensus_validators if v.status in CAN_BE_EXITED_STATUSES]
+        non_exiting_validators = _filter_non_exiting_validators(
+            consensus_validators, oracle_exiting_validators
+        )
         pending_partial_withdrawals = await get_pending_partial_withdrawals(
             chain_head=chain_head,
-            consensus_validators=active_validators,
+            consensus_validators=non_exiting_validators,
         )
         queued_assets = await get_queued_assets(
             consensus_validators=consensus_validators,
@@ -370,6 +376,26 @@ def _filter_exitable_validators(
     )
 
     return can_be_exited_validators
+
+
+def _filter_non_exiting_validators(
+    consensus_validators: list[ConsensusValidator],
+    oracle_exiting_validators: list[ConsensusValidator],
+) -> list[ConsensusValidator]:
+    """
+    A CL pending partial withdrawal on a validator whose exit_epoch is set pays 0 and
+    is dequeued without withdrawing, while its full balance is already counted as
+    exiting elsewhere -- exclude such validators so their pending partials aren't
+    double-counted.
+    """
+    oracle_exiting_indexes = {val.index for val in oracle_exiting_validators}
+    return [
+        v
+        for v in consensus_validators
+        if v.status in CAN_BE_EXITED_STATUSES
+        and v.status not in EXITING_STATUSES
+        and v.index not in oracle_exiting_indexes
+    ]
 
 
 async def _fetch_oracle_exiting_validators(

--- a/src/withdrawals/tasks.py
+++ b/src/withdrawals/tasks.py
@@ -41,11 +41,7 @@ from src.validators.exceptions import EmptyRelayerResponseException
 from src.validators.oracles import poll_active_exits
 from src.validators.relayer import RelayerClient
 from src.validators.typings import ConsensusValidator
-from src.withdrawals.assets import (
-    CAN_BE_EXITED_STATUSES,
-    EXITING_STATUSES,
-    get_queued_assets,
-)
+from src.withdrawals.assets import get_queued_assets
 from src.withdrawals.execution import submit_withdraw_validators
 
 logger = logging.getLogger(__name__)
@@ -392,9 +388,7 @@ def _filter_non_exiting_validators(
     return [
         v
         for v in consensus_validators
-        if v.status in CAN_BE_EXITED_STATUSES
-        and v.status not in EXITING_STATUSES
-        and v.index not in oracle_exiting_indexes
+        if v.status == ValidatorStatus.ACTIVE_ONGOING and v.index not in oracle_exiting_indexes
     ]
 
 

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -962,6 +962,46 @@ async def test_get_withdrawals_excludes_oracle_exiting_validators_from_partials(
     assert result == expected
 
 
+async def test_get_withdrawals_excludes_oracle_exiting_from_partial_capacity(data_dir):
+    settings.set(vault=None, vault_dir=data_dir, network=HOODI)
+
+    # v1 is still ACTIVE_ONGOING on the CL but already oracle-exiting: new partial
+    # requests for it would pay 0 once its exit_epoch is set, so it must not inflate
+    # partial_capacity or receive a partial withdrawal. Excluding it drops combined
+    # capacity (8 + 18 ETH) below the 20 ETH request, routing v2 to a full exit instead.
+    chain_head = create_chain_head(epoch=500)
+    queued_assets = ether_to_gwei(20)
+    consensus_validators = [
+        create_consensus_validator(
+            public_key='0x1',
+            index=1,
+            balance=ether_to_gwei(40),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+        create_consensus_validator(
+            public_key='0x2',
+            index=2,
+            balance=ether_to_gwei(50),
+            status=ValidatorStatus.ACTIVE_ONGOING,
+            activation_epoch=90,
+        ),
+    ]
+    result = await _get_withdrawals(
+        chain_head=chain_head,
+        queued_assets=queued_assets,
+        consensus_validators=consensus_validators,
+        pending_partial_withdrawals=[],
+        validator_min_active_epochs=10,
+        oracle_exit_indexes={1},
+        consolidation_target_indexes=set(),
+        consolidation_source_indexes=set(),
+        pending_deposits={},
+    )
+    expected = {'0x2': ether_to_gwei(0)}
+    assert result == expected
+
+
 async def test_get_withdrawals_boundary_activation_epoch_prefers_partial_over_full_exit(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -965,10 +965,8 @@ async def test_get_withdrawals_excludes_oracle_exiting_validators_from_partials(
 async def test_get_withdrawals_excludes_oracle_exiting_from_partial_capacity(data_dir):
     settings.set(vault=None, vault_dir=data_dir, network=HOODI)
 
-    # v1 is still ACTIVE_ONGOING on the CL but already oracle-exiting: new partial
-    # requests for it would pay 0 once its exit_epoch is set, so it must not inflate
-    # partial_capacity or receive a partial withdrawal. Excluding it drops combined
-    # capacity (8 + 18 ETH) below the 20 ETH request, routing v2 to a full exit instead.
+    # v1 is still ACTIVE_ONGOING on the CL but already oracle-exiting, so it must not
+    # inflate partial_capacity or receive a partial withdrawal; only v2 gets exited.
     chain_head = create_chain_head(epoch=500)
     queued_assets = ether_to_gwei(20)
     consensus_validators = [

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -16,6 +16,7 @@ from src.withdrawals.tasks import (
     _fetch_oracle_exiting_validators,
     _filter_exitable_validators,
     _filter_full_withdrawals,
+    _filter_non_exiting_validators,
     _get_partial_withdrawals,
     _get_withdrawals,
     _is_pending_partial_withdrawals_queue_full,
@@ -1274,6 +1275,36 @@ def test_filter_full_withdrawals():
     }
     assert _filter_full_withdrawals(withdrawals) == ['0x1', '0x3']
     assert _filter_full_withdrawals({}) == []
+
+
+def test_filter_non_exiting_validators():
+    # an exiting validator's index is dropped even though it is in CAN_BE_EXITED_STATUSES
+    validators = [
+        create_consensus_validator(index=1, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+        create_consensus_validator(index=2, status=ValidatorStatus.ACTIVE_EXITING, balance=32),
+    ]
+    result = _filter_non_exiting_validators(validators, oracle_exiting_validators=[])
+    assert [v.index for v in result] == [1]
+
+    # a validator still ACTIVE_ONGOING on the CL but already in the oracle's exiting
+    # set is excluded too, so its pending partial isn't counted on top of the balance
+    # already summed via the oracle-exiting branch
+    validators = [
+        create_consensus_validator(index=1, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+        create_consensus_validator(index=2, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+    ]
+    oracle_exiting_validators = [
+        create_consensus_validator(index=2, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
+    ]
+    result = _filter_non_exiting_validators(validators, oracle_exiting_validators)
+    assert [v.index for v in result] == [1]
+
+    # a validator outside CAN_BE_EXITED_STATUSES (e.g. still pending) is also excluded
+    validators = [
+        create_consensus_validator(index=1, status=ValidatorStatus.PENDING_QUEUED, balance=32),
+    ]
+    result = _filter_non_exiting_validators(validators, oracle_exiting_validators=[])
+    assert result == []
 
 
 async def test_fetch_oracle_exiting_validators():

--- a/src/withdrawals/tests/test_tasks.py
+++ b/src/withdrawals/tests/test_tasks.py
@@ -1316,7 +1316,7 @@ def test_filter_full_withdrawals():
 
 
 def test_filter_non_exiting_validators():
-    # an exiting validator's index is dropped even though it is in CAN_BE_EXITED_STATUSES
+    # a validator that isn't ACTIVE_ONGOING (e.g. already exiting) is dropped
     validators = [
         create_consensus_validator(index=1, status=ValidatorStatus.ACTIVE_ONGOING, balance=32),
         create_consensus_validator(index=2, status=ValidatorStatus.ACTIVE_EXITING, balance=32),
@@ -1337,7 +1337,7 @@ def test_filter_non_exiting_validators():
     result = _filter_non_exiting_validators(validators, oracle_exiting_validators)
     assert [v.index for v in result] == [1]
 
-    # a validator outside CAN_BE_EXITED_STATUSES (e.g. still pending) is also excluded
+    # a validator that isn't ACTIVE_ONGOING (e.g. still pending) is also excluded
     validators = [
         create_consensus_validator(index=1, status=ValidatorStatus.PENDING_QUEUED, balance=32),
     ]


### PR DESCRIPTION
## Description

`withdrawing_assets` double-counted validators that are both exiting and holding a CL pending partial withdrawal. Per Electra semantics, a pending partial withdrawal on a validator whose `exit_epoch` is set pays **0** — it is dequeued without withdrawing anything — while `_calculate_validators_exits_amount` already counts that validator's full balance as arriving.

### Example

A vault validator holds 33 ETH; the operator plans a 1 ETH partial withdrawal to serve the exit queue:

1. The operator submits an EIP-7002 partial withdrawal request for 1 ETH. The CL accepts it and places a 1 ETH entry into `state.pending_partial_withdrawals`.
2. Before that entry reaches the head of the CL withdrawal sweep, the validator starts exiting — via slashing, a manual voluntary exit by the node runner, or the oracle picking it for a force exit (the oracle's exclusion only sees CL pending withdrawals, not the in-flight EL request queue, so this race needs no misbehavior at all). `initiate_validator_exit` sets its `exit_epoch`.
3. When the sweep reaches the entry, `is_eligible_for_partial_withdrawals` fails (`exit_epoch != FAR_FUTURE_EPOCH`), so per `get_pending_partial_withdrawals` the entry is dequeued with `processed_count += 1` but **no `Withdrawal` is produced** — the 1 ETH never moves. The validator's actual funds arrive later, all at once, via the full-withdrawal sweep.
4. The operator's old accounting counted both sides: the 1 ETH pending partial (fetched for all `CAN_BE_EXITED_STATUSES` validators, which includes exiting ones) **and** the same validator's full 33 ETH balance via `_calculate_validators_exits_amount` — 34 ETH of "withdrawing" against 33 ETH of reality.
5. `withdrawing_assets` is passed to `getExitQueueMissingAssets`, so the queue's missing assets came back 1 ETH short and the operator submitted 1 ETH less in new withdrawal requests than the exit/redemption queue actually needed.

The error persists until the phantom entry drains at its `withdrawable_epoch` (roughly a day), and it compounds: every exiting validator with a queued partial adds its own overstatement, so a batch of force exits during heavy redemption traffic can leave the queue meaningfully under-served exactly when coverage matters most.

Pending partial withdrawals are now summed only for validators that are not exiting — excluding both `EXITING_STATUSES` and the oracle's active-exit set. `_get_withdrawals` already excludes oracle-exiting validators from the partial-withdrawal capacity selection; this PR adds a regression test guarding that this exclusion also protects partial capacity accounting. Mirrors stakewise/v3-oracle#646.