### PR TITLE
Unify transaction error handling and receipt checks

### DIFF
--- a/src/common/contracts.py
+++ b/src/common/contracts.py
@@ -24,7 +24,7 @@ from web3.contract.async_contract import (
 from web3.types import BlockNumber, ChecksumAddress, EventData, TxReceipt, Wei
 
 from src.common.clients import execution_client as default_execution_client
-from src.common.transaction import tx_manager
+from src.common.transaction import transact_checked
 from src.common.typings import (
     ExitQueueMissingAssetsParams,
     HarvestParams,
@@ -493,7 +493,7 @@ class RewardSplitterEncoder(BaseEncoder):
         )
 
 
-class MulticallContract(ContractWrapper):
+class MulticallContract(ContractWrapper, ErrorMixin):
     abi_path = 'abi/Multicall.json'
     settings_key = 'MULTICALL_CONTRACT_ADDRESS'
 
@@ -509,7 +509,7 @@ class MulticallContract(ContractWrapper):
         data: list[tuple[ChecksumAddress, HexStr]],
     ) -> TxReceipt | None:
         tx_function = self.contract.functions.aggregate(data)
-        return await tx_manager.transact(tx_function)
+        return await transact_checked(tx_function, contract=self, action='aggregate multicall')
 
 
 class ValidatorsCheckerContract(ContractWrapper):

--- a/src/common/tests/test_transaction.py
+++ b/src/common/tests/test_transaction.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 from hexbytes import HexBytes
 from web3 import Web3
-from web3.exceptions import TimeExhausted, Web3RPCError
+from web3.exceptions import ContractCustomError, TimeExhausted, Web3RPCError
 from web3.types import Wei
 
 from src.common.transaction import (
@@ -13,6 +13,7 @@ from src.common.transaction import (
     Fees,
     TransactionManager,
     _is_fee_too_low_error,
+    transact_checked,
 )
 
 GWEI = Web3.to_wei(1, 'gwei')
@@ -306,6 +307,43 @@ class TestTransactionManager:
         params = transact.call_args.args[0]
         assert params['maxFeePerGas'] == cap
         assert params['maxPriorityFeePerGas'] <= params['maxFeePerGas']
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestTransactChecked:
+    async def test_success_returns_receipt(self):
+        receipt = {'status': 1, 'transactionHash': HexBytes('0xab')}
+        tx_manager_mock = mock.Mock(transact=mock.AsyncMock(return_value=receipt))
+        with mock.patch('src.common.transaction.tx_manager', tx_manager_mock):
+            result = await transact_checked(mock.Mock(), contract=mock.Mock(), action='do stuff')
+
+        assert result is receipt
+
+    async def test_revert_returns_none(self):
+        contract = mock.Mock()
+        contract.decode_custom_error = mock.Mock(return_value='InvalidValidators()')
+        tx_manager_mock = mock.Mock(
+            transact=mock.AsyncMock(side_effect=ContractCustomError('reverted', data='0xdeadbeef'))
+        )
+        with mock.patch('src.common.transaction.tx_manager', tx_manager_mock):
+            result = await transact_checked(mock.Mock(), contract=contract, action='do stuff')
+
+        assert result is None
+        contract.decode_custom_error.assert_called_once_with('0xdeadbeef')
+
+    async def test_generic_exception_returns_none(self):
+        tx_manager_mock = mock.Mock(transact=mock.AsyncMock(side_effect=ValueError('boom')))
+        with mock.patch('src.common.transaction.tx_manager', tx_manager_mock):
+            result = await transact_checked(mock.Mock(), contract=mock.Mock(), action='do stuff')
+
+        assert result is None
+
+    async def test_none_receipt_returns_none(self):
+        tx_manager_mock = mock.Mock(transact=mock.AsyncMock(return_value=None))
+        with mock.patch('src.common.transaction.tx_manager', tx_manager_mock):
+            result = await transact_checked(mock.Mock(), contract=mock.Mock(), action='do stuff')
+
+        assert result is None
 
 
 @pytest.mark.parametrize(

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -302,8 +302,11 @@ async def transact_checked(
     estimate_gas: bool = False,
     revert_hint: str = '',
 ) -> TxReceipt | None:
-    """Submits `tx_function` via `tx_manager` and normalizes reverts/errors/unconfirmed
-    receipts into a logged `None`, so call sites don't hand-roll this each time."""
+    """Submits `tx_function` via `tx_manager`.
+
+    Returns the tx receipt on success. On revert, transaction error, or an
+    unconfirmed/failed receipt, logs the error and returns `None`.
+    """
     try:
         tx_receipt = await tx_manager.transact(
             tx_function, tx_params, high_priority=high_priority, estimate_gas=estimate_gas

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -1,15 +1,17 @@
 import asyncio
 import logging
 from math import ceil
+from typing import Protocol
 
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract.async_contract import AsyncContractFunction
-from web3.exceptions import TimeExhausted, Web3RPCError
+from web3.exceptions import ContractCustomError, TimeExhausted, Web3RPCError
 from web3.types import Nonce, TxParams, TxReceipt, Wei
 
 from src.common.clients import execution_client
 from src.common.execution import build_gas_manager
+from src.common.utils import format_error
 from src.common.wallet import wallet
 from src.config.settings import ATTEMPTS_WITH_DEFAULT_GAS, settings
 
@@ -284,3 +286,41 @@ def _is_fee_too_low_error(e: Web3RPCError) -> bool:
 
 
 tx_manager = TransactionManager()
+
+
+class _ErrorDecodable(Protocol):
+    # matches ErrorMixin.decode_custom_error (src/common/contracts.py); a structural
+    # Protocol here avoids importing contracts.py, which itself imports this module
+    def decode_custom_error(self, data: str) -> str | None: ...
+
+
+# pylint: disable-next=too-many-arguments
+async def transact_checked(
+    tx_function: AsyncContractFunction,
+    *,
+    contract: _ErrorDecodable,
+    action: str,
+    tx_params: TxParams | None = None,
+    high_priority: bool = False,
+    estimate_gas: bool = False,
+    revert_hint: str = '',
+) -> TxReceipt | None:
+    """Submits `tx_function` via `tx_manager` and normalizes reverts/errors/unconfirmed
+    receipts into a logged `None`, so call sites don't hand-roll this each time."""
+    try:
+        tx_receipt = await tx_manager.transact(
+            tx_function, tx_params, high_priority=high_priority, estimate_gas=estimate_gas
+        )
+    except ContractCustomError as e:
+        reason = contract.decode_custom_error(str(e.data)) or e.data
+        logger.error('Failed to %s: execution reverted with %s.%s', action, reason, revert_hint)
+        return None
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error('Failed to %s: %s', action, format_error(e))
+        if settings.verbose:
+            logger.exception(e)
+        return None
+    if tx_receipt is None:
+        logger.error('Failed to %s: transaction was not confirmed', action)
+        return None
+    return tx_receipt

--- a/src/common/transaction.py
+++ b/src/common/transaction.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from math import ceil
-from typing import Protocol
+from typing import TYPE_CHECKING
 
 from hexbytes import HexBytes
 from web3 import Web3
@@ -14,6 +14,9 @@ from src.common.execution import build_gas_manager
 from src.common.utils import format_error
 from src.common.wallet import wallet
 from src.config.settings import ATTEMPTS_WITH_DEFAULT_GAS, settings
+
+if TYPE_CHECKING:
+    from src.common.contracts import ErrorMixin
 
 logger = logging.getLogger(__name__)
 
@@ -288,17 +291,11 @@ def _is_fee_too_low_error(e: Web3RPCError) -> bool:
 tx_manager = TransactionManager()
 
 
-class _ErrorDecodable(Protocol):
-    # matches ErrorMixin.decode_custom_error (src/common/contracts.py); a structural
-    # Protocol here avoids importing contracts.py, which itself imports this module
-    def decode_custom_error(self, data: str) -> str | None: ...
-
-
 # pylint: disable-next=too-many-arguments
 async def transact_checked(
     tx_function: AsyncContractFunction,
     *,
-    contract: _ErrorDecodable,
+    contract: 'ErrorMixin',
     action: str,
     tx_params: TxParams | None = None,
     high_priority: bool = False,

--- a/src/exits/execution.py
+++ b/src/exits/execution.py
@@ -2,13 +2,10 @@ import logging
 
 from eth_typing import ChecksumAddress, HexStr
 from web3 import Web3
-from web3.exceptions import ContractCustomError
 
 from src.common.contracts import keeper_contract
-from src.common.transaction import tx_manager
+from src.common.transaction import transact_checked
 from src.common.typings import OraclesApproval
-from src.common.utils import format_error
-from src.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -19,27 +16,17 @@ async def submit_exit_signatures(
 ) -> HexStr | None:
     """Sends updateExitSignatures transaction to keeper contract"""
     logger.info('Submitting UpdateExitSignatures transaction')
-    try:
-        tx_function = keeper_contract.functions.updateExitSignatures(
-            vault_address,
-            approval.deadline,
-            approval.ipfs_hash,
-            approval.signatures,
-        )
-        tx_receipt = await tx_manager.transact(tx_function)
-
-    except ContractCustomError as e:
-        reason = keeper_contract.decode_custom_error(str(e.data)) or e.data
-        logger.error('Failed to update exit signatures: execution reverted with %s', reason)
-        return None
-    except Exception as e:
-        logger.error('Failed to update exit signatures: %s', format_error(e))
-
-        if settings.verbose:
-            logger.exception(e)
-        return None
-
+    tx_function = keeper_contract.functions.updateExitSignatures(
+        vault_address,
+        approval.deadline,
+        approval.ipfs_hash,
+        approval.signatures,
+    )
+    tx_receipt = await transact_checked(
+        tx_function,
+        contract=keeper_contract,
+        action='update exit signatures',
+    )
     if tx_receipt is None:
-        logger.error('UpdateExitSignatures transaction failed')
         return None
     return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/harvest/execution.py
+++ b/src/harvest/execution.py
@@ -27,6 +27,7 @@ async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr:
         action='harvest',
     )
     if tx_receipt is None:
+        # raise so BaseTask.run increments metrics.exception_count
         raise RuntimeError('Failed to confirm harvest tx')
 
     return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/harvest/execution.py
+++ b/src/harvest/execution.py
@@ -2,10 +2,9 @@ import logging
 
 from eth_typing import HexStr
 from web3 import Web3
-from web3.exceptions import ContractCustomError
 
 from src.common.contracts import VaultContract
-from src.common.transaction import tx_manager
+from src.common.transaction import transact_checked
 from src.common.typings import HarvestParams
 from src.config.settings import settings
 
@@ -14,23 +13,20 @@ logger = logging.getLogger(__name__)
 
 async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr | None:
     vault_contract = VaultContract(settings.vault)
-    try:
-        tx_function = vault_contract.functions.updateState(
-            (
-                harvest_params.rewards_root,
-                harvest_params.reward,
-                harvest_params.unlocked_mev_reward,
-                harvest_params.proof,
-            )
+    tx_function = vault_contract.functions.updateState(
+        (
+            harvest_params.rewards_root,
+            harvest_params.reward,
+            harvest_params.unlocked_mev_reward,
+            harvest_params.proof,
         )
-        tx_receipt = await tx_manager.transact(tx_function)
-    except ContractCustomError as e:
-        reason = vault_contract.decode_custom_error(str(e.data)) or e.data
-        logger.error('Failed to harvest: execution reverted with %s', reason)
-        return None
-
+    )
+    tx_receipt = await transact_checked(
+        tx_function,
+        contract=vault_contract,
+        action='harvest',
+    )
     if tx_receipt is None:
-        logger.error('Harvest transaction failed')
         return None
 
     return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/harvest/execution.py
+++ b/src/harvest/execution.py
@@ -11,7 +11,7 @@ from src.config.settings import settings
 logger = logging.getLogger(__name__)
 
 
-async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr | None:
+async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr:
     vault_contract = VaultContract(settings.vault)
     tx_function = vault_contract.functions.updateState(
         (
@@ -27,6 +27,6 @@ async def submit_harvest_transaction(harvest_params: HarvestParams) -> HexStr | 
         action='harvest',
     )
     if tx_receipt is None:
-        return None
+        raise RuntimeError('Failed to confirm harvest tx')
 
     return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/harvest/tasks.py
+++ b/src/harvest/tasks.py
@@ -28,8 +28,6 @@ class HarvestTask(BaseTask):
 
         logger.info('Starting vault %s harvest', settings.vault)
 
-        tx_hash = await submit_harvest_transaction(harvest_params=harvest_params)
+        await submit_harvest_transaction(harvest_params=harvest_params)
 
-        if not tx_hash:
-            return
         logger.info('Successfully harvested')

--- a/src/meta_vault/contracts.py
+++ b/src/meta_vault/contracts.py
@@ -1,16 +1,11 @@
-import logging
-
 from eth_typing import HexStr
 from web3 import AsyncWeb3
-from web3.exceptions import ContractCustomError
 from web3.types import ChecksumAddress, TxReceipt, Wei
 
 from src.common.contracts import BaseEncoder, ContractWrapper, ErrorMixin
-from src.common.transaction import tx_manager
+from src.common.transaction import transact_checked
 from src.common.typings import HarvestParams
 from src.meta_vault.typings import SubVaultExitRequest
-
-logger = logging.getLogger(__name__)
 
 
 class MetaVaultContract(ContractWrapper, ErrorMixin):
@@ -58,12 +53,7 @@ class SubVaultsRegistryContract(ContractWrapper, ErrorMixin):
 
     async def deposit_to_sub_vaults(self) -> TxReceipt | None:
         tx_function = self.contract.functions.depositToSubVaults()
-        try:
-            return await tx_manager.transact(tx_function)
-        except ContractCustomError as e:
-            reason = self.decode_custom_error(str(e.data)) or e.data
-            logger.error('Deposit to sub vaults execution reverted with %s', reason)
-            raise
+        return await transact_checked(tx_function, contract=self, action='deposit to sub vaults')
 
 
 class SubVaultsRegistryEncoder(BaseEncoder):

--- a/src/reward_splitter/tasks.py
+++ b/src/reward_splitter/tasks.py
@@ -143,7 +143,7 @@ async def claim_reward_splitters_for_vault(
         tx_receipt = await transact_checked(
             tx_function,
             contract=contract,
-            action='process fee splitter',
+            action=f'process fee splitter {address}',
         )
         if tx_receipt is None:
             raise RuntimeError('Failed to confirm fee splitter tx')

--- a/src/reward_splitter/tasks.py
+++ b/src/reward_splitter/tasks.py
@@ -2,7 +2,6 @@ import logging
 
 from sw_utils import InterruptHandler
 from web3 import Web3
-from web3.exceptions import ContractCustomError
 from web3.types import BlockNumber, ChecksumAddress, HexStr, Wei
 
 from src.common.app_state import AppState
@@ -11,7 +10,7 @@ from src.common.contracts import RewardSplitterContract, RewardSplitterEncoder
 from src.common.execution import check_gas_price
 from src.common.harvest import get_harvest_params
 from src.common.tasks import BaseTask
-from src.common.transaction import tx_manager
+from src.common.transaction import transact_checked
 from src.common.typings import ExitRequest, HarvestParams
 from src.common.wallet import wallet
 from src.config.settings import FEE_SPLITTER_INTERVAL, FEE_SPLITTER_MIN_ASSETS, settings
@@ -141,12 +140,11 @@ async def claim_reward_splitters_for_vault(
             execution_client=execution_client,
         )
         tx_function = contract.functions.multicall(address_calls)
-        try:
-            tx_receipt = await tx_manager.transact(tx_function)
-        except ContractCustomError as e:
-            reason = contract.decode_custom_error(str(e.data)) or e.data
-            logger.error('Fee splitter %s transaction execution reverted with %s', address, reason)
-            raise
+        tx_receipt = await transact_checked(
+            tx_function,
+            contract=contract,
+            action='process fee splitter',
+        )
         if tx_receipt is None:
             raise RuntimeError('Failed to confirm fee splitter tx')
 

--- a/src/reward_splitter/tests/test_tasks.py
+++ b/src/reward_splitter/tests/test_tasks.py
@@ -128,6 +128,10 @@ class TestClaimRewardSplittersForVault:
             )
 
         transact_checked_mock.assert_awaited_once()
+        assert (
+            transact_checked_mock.await_args.kwargs['action']
+            == f'process fee splitter {reward_splitter.address}'
+        )
 
 
 @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')

--- a/src/reward_splitter/tests/test_tasks.py
+++ b/src/reward_splitter/tests/test_tasks.py
@@ -84,8 +84,8 @@ class TestClaimRewardSplittersForVault:
         ), mock.patch(
             'src.reward_splitter.tasks.graph_get_claimable_exit_requests'
         ) as exit_requests_mock, mock.patch(
-            'src.reward_splitter.tasks.tx_manager'
-        ) as tx_manager_mock, mock.patch(
+            'src.reward_splitter.tasks.transact_checked'
+        ) as transact_checked_mock, mock.patch(
             'src.reward_splitter.tasks.wallet', new=mock.MagicMock()
         ):
             await claim_reward_splitters_for_vault(
@@ -95,7 +95,7 @@ class TestClaimRewardSplittersForVault:
             )
 
         exit_requests_mock.assert_not_called()
-        tx_manager_mock.transact.assert_not_called()
+        transact_checked_mock.assert_not_called()
 
     async def test_submits_claim_transaction(self):
         # After building the calls the claim tx must be submitted and its receipt awaited.
@@ -110,26 +110,24 @@ class TestClaimRewardSplittersForVault:
             'src.reward_splitter.tasks.graph_get_claimable_exit_requests',
             return_value={},
         ), mock.patch(
-            'src.reward_splitter.tasks.tx_manager'
-        ) as tx_manager_mock, mock.patch(
+            'src.reward_splitter.tasks.transact_checked'
+        ) as transact_checked_mock, mock.patch(
             'src.reward_splitter.tasks.RewardSplitterContract', new=mock.MagicMock()
         ), mock.patch(
             'src.reward_splitter.tasks.wallet', new=mock.MagicMock()
         ):
-            tx_manager_mock.transact = mock.AsyncMock(
-                return_value={
-                    'status': 1,
-                    'transactionHash': HexBytes(b'\x12' * 32),
-                    'blockNumber': Web3.to_int(123),
-                }
-            )
+            transact_checked_mock.return_value = {
+                'status': 1,
+                'transactionHash': HexBytes(b'\x12' * 32),
+                'blockNumber': Web3.to_int(123),
+            }
             await claim_reward_splitters_for_vault(
                 vault=ZERO_CHECKSUM_ADDRESS,
                 block_number=Web3.to_int(1),
                 harvest_params=None,
             )
 
-        tx_manager_mock.transact.assert_awaited_once()
+        transact_checked_mock.assert_awaited_once()
 
 
 @pytest.mark.usefixtures('fake_settings', 'setup_test_clients')

--- a/src/validators/execution.py
+++ b/src/validators/execution.py
@@ -8,9 +8,8 @@ from web3.exceptions import ContractCustomError
 from web3.types import Wei
 
 from src.common.contracts import VaultContract
-from src.common.transaction import tx_manager
+from src.common.transaction import transact_checked
 from src.common.typings import HarvestParams, OraclesApproval
-from src.common.utils import format_error
 from src.config.settings import settings
 from src.validators.signing.common import encode_tx_validator_list
 from src.validators.typings import Validator
@@ -57,27 +56,17 @@ async def tx_register_validators(
 
     # Simulate (estimate_gas) and send transaction with high-priority fees.
     logger.info('Submitting registration transaction')
-    try:
-        tx_receipt = await tx_manager.transact(
-            vault_contract.functions.multicall(calls),
-            high_priority=True,
-            estimate_gas=True,
-        )
-    except ContractCustomError as e:
-        logger.error(
-            'Failed to register validator(s): execution reverted with %s. '
-            'Most likely registry root has changed during validators registration. Retrying...',
-            vault_contract.decode_custom_error(str(e.data)) or e.data,
-        )
-        return None
-    except Exception as e:
-        logger.error('Failed to register validator(s): %s', format_error(e))
-        if settings.verbose:
-            logger.exception(e)
-        return None
-
+    tx_receipt = await transact_checked(
+        vault_contract.functions.multicall(calls),
+        contract=vault_contract,
+        action='register validator(s)',
+        high_priority=True,
+        estimate_gas=True,
+        revert_hint=(
+            ' Most likely registry root has changed during validators registration. Retrying...'
+        ),
+    )
     if tx_receipt is None:
-        logger.error('Registration transaction failed')
         return None
 
     return Web3.to_hex(tx_receipt['transactionHash'])
@@ -106,21 +95,13 @@ async def tx_fund_validators(
     calls.append(fund_validators_call)
 
     logger.info('Submitting fund validators transaction')
-    try:
-        tx_function = vault_contract.functions.multicall(calls)
-        tx_receipt = await tx_manager.transact(tx_function)
-    except ContractCustomError as e:
-        reason = vault_contract.decode_custom_error(str(e.data)) or e.data
-        logger.error('Failed to fund validator(s): execution reverted with %s', reason)
-        return None
-    except Exception as e:
-        logger.error('Failed to fund validator(s): %s', format_error(e))
-        if settings.verbose:
-            logger.exception(e)
-        return None
-
+    tx_function = vault_contract.functions.multicall(calls)
+    tx_receipt = await transact_checked(
+        tx_function,
+        contract=vault_contract,
+        action='fund validator(s)',
+    )
     if tx_receipt is None:
-        logger.error('Funding transaction failed')
         return None
 
     return Web3.to_hex(tx_receipt['transactionHash'])
@@ -159,25 +140,17 @@ async def tx_consolidate_validators(
     if oracle_signatures is None:
         oracle_signatures = b''
 
-    try:
-        tx_function = vault_contract.functions.consolidateValidators(
-            validators,
-            Web3.to_bytes(hexstr=validators_manager_signature),
-            oracle_signatures,
-        )
-        tx_receipt = await tx_manager.transact(tx_function, tx_params={'value': tx_fee})
-    except ContractCustomError as e:
-        reason = vault_contract.decode_custom_error(str(e.data)) or e.data
-        logger.info(
-            'Failed to submit consolidate validators transaction: execution reverted with %s',
-            reason,
-        )
-        return None
-    except Exception as e:
-        logger.info('Failed to submit consolidate validators transaction: %s', format_error(e))
-        return None
-
+    tx_function = vault_contract.functions.consolidateValidators(
+        validators,
+        Web3.to_bytes(hexstr=validators_manager_signature),
+        oracle_signatures,
+    )
+    tx_receipt = await transact_checked(
+        tx_function,
+        contract=vault_contract,
+        action='consolidate validator(s)',
+        tx_params={'value': tx_fee},
+    )
     if tx_receipt is None:
-        logger.info('Consolidate validators transaction failed')
         return None
     return Web3.to_hex(tx_receipt['transactionHash'])

--- a/src/withdrawals/execution.py
+++ b/src/withdrawals/execution.py
@@ -2,12 +2,10 @@ import logging
 
 from eth_typing import HexStr
 from web3 import Web3
-from web3.exceptions import ContractCustomError
 from web3.types import Gwei, Wei
 
 from src.common.contracts import VaultContract
-from src.common.transaction import tx_manager
-from src.common.utils import format_error
+from src.common.transaction import transact_checked
 from src.config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -21,22 +19,17 @@ async def submit_withdraw_validators(
     """Sends withdrawValidators transaction to vault contract"""
     logger.info('Submitting a withdrawal from validator(s) transaction')
     vault_contract = VaultContract(settings.vault)
-    try:
-        tx_function = vault_contract.functions.withdrawValidators(
-            _encode_withdrawals(withdrawals),
-            Web3.to_bytes(hexstr=validators_manager_signature),
-        )
-        tx_receipt = await tx_manager.transact(tx_function, tx_params={'value': tx_fee})
-    except ContractCustomError as e:
-        reason = vault_contract.decode_custom_error(str(e.data)) or e.data
-        logger.info('Failed to withdraw from validators: execution reverted with %s', reason)
-        return None
-    except Exception as e:
-        logger.info('Failed to withdraw from validators: %s', format_error(e))
-        return None
-
+    tx_function = vault_contract.functions.withdrawValidators(
+        _encode_withdrawals(withdrawals),
+        Web3.to_bytes(hexstr=validators_manager_signature),
+    )
+    tx_receipt = await transact_checked(
+        tx_function,
+        contract=vault_contract,
+        action='withdraw from validators',
+        tx_params={'value': tx_fee},
+    )
     if tx_receipt is None:
-        logger.info('Withdraw validators transaction failed')
         return None
     return Web3.to_hex(tx_receipt['transactionHash'])
 

--- a/src/withdrawals/tests/test_execution.py
+++ b/src/withdrawals/tests/test_execution.py
@@ -1,3 +1,4 @@
+import contextlib
 from unittest import mock
 
 import pytest
@@ -78,7 +79,7 @@ class TestSubmitWithdrawValidators:
             result = await submit_withdraw_validators(self.withdrawals, self.tx_fee, self.signature)
 
         assert result == Web3.to_hex(tx_hash)
-        assert transact.call_args.kwargs['tx_params'] == {'value': self.tx_fee}
+        assert transact.call_args.args[1] == {'value': self.tx_fee}
         vault_contract.functions.withdrawValidators.assert_called_once_with(
             _encode_withdrawals(self.withdrawals),
             Web3.to_bytes(hexstr=self.signature),
@@ -121,9 +122,9 @@ def _mock_vault_contract(decoded_error: str | None = None) -> mock.Mock:
     return vault_contract
 
 
+@contextlib.contextmanager
 def _patch(vault_contract: mock.Mock, transact: mock.AsyncMock):
-    return mock.patch.multiple(
-        'src.withdrawals.execution',
-        VaultContract=mock.Mock(return_value=vault_contract),
-        tx_manager=mock.Mock(transact=transact),
-    )
+    with mock.patch(
+        'src.withdrawals.execution.VaultContract', return_value=vault_contract
+    ), mock.patch('src.common.transaction.tx_manager', mock.Mock(transact=transact)):
+        yield


### PR DESCRIPTION
## Description

All `tx_manager.transact()` call sites hand-rolled the same wrapper: `try/except ContractCustomError` with `decode_custom_error`, a generic `except Exception` with `format_error`, and an `if tx_receipt is None` check — with inconsistent log levels, inconsistent verbose dumps, and two sites with partial or no handling.

This adds a shared `transact_checked()` helper in `src/common/transaction.py` that normalizes reverts, RPC errors, and unconfirmed receipts into a logged `None`, and converts all 9 call sites to use it:

- Failure logging is now uniform: `logger.error` plus a `settings.verbose` exception dump everywhere (consolidate/withdrawals previously logged failures at info level).
- `submit_harvest_transaction` gains generic-exception handling it previously lacked.
- `MulticallContract` now includes `ErrorMixin`, so `tx_aggregate` reverts are decoded and logged instead of propagating undecoded.
- The reward splitter raises `RuntimeError` on a revert instead of re-raising `ContractCustomError`; the loop aborts either way.
- The raising flows (reward splitter, meta vault deposit/state update) keep their raise-on-failure semantics; the hash-returning flows keep returning `HexStr | None`.