### PR TITLE
Cap redeem loop by owner's live osToken position

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -335,10 +335,21 @@ async def redeem_positions(
         if position.vault in unharvested_vaults:
             continue
 
-        live_shares = await _get_live_shares(position, shares_to_redeem, converter, block_number)
-        if live_shares <= 0:
+        ltv_exceeded, minted_shares = await is_position_ltv_exceeded(
+            position, converter, block_number
+        )
+        if ltv_exceeded:
+            logger.info('Skipping position index=%d: LTV > 1', position.index)
             continue
-        shares_to_redeem = live_shares
+
+        # Cap by the live minted position: the owner may have repaid or been
+        # liquidated after the positions file was published.
+        shares_to_redeem = Wei(min(shares_to_redeem, minted_shares))
+        if shares_to_redeem <= 0:
+            logger.info(
+                'Skipping position index=%d: owner has no live osToken position', position.index
+            )
+            continue
         assets_to_redeem = converter.to_assets(shares_to_redeem)
 
         if position.vault not in vault_to_withdrawable:
@@ -370,28 +381,6 @@ async def redeem_positions(
                 continue
 
         vault_to_withdrawable[position.vault] = Wei(withdrawable - assets_to_redeem)
-
-
-async def _get_live_shares(
-    position: OsTokenPosition,
-    unprocessed_shares: Wei,
-    converter: OsTokenConverter,
-    block_number: BlockNumber,
-) -> Wei:
-    """Owner's unprocessed shares capped by the live minted osToken position. Returns 0
-    when the position's LTV exceeds 1 or the owner has no live position left to redeem
-    (e.g. repaid or liquidated after the file was published)."""
-    ltv_exceeded, minted_shares = await is_position_ltv_exceeded(position, converter, block_number)
-    if ltv_exceeded:
-        logger.info('Skipping position index=%d: LTV > 1', position.index)
-        return Wei(0)
-
-    live_shares = Wei(min(unprocessed_shares, minted_shares))
-    if live_shares <= 0:
-        logger.info(
-            'Skipping position index=%d: owner has no live osToken position', position.index
-        )
-    return live_shares
 
 
 async def _startup_check() -> None:

--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -335,9 +335,11 @@ async def redeem_positions(
         if position.vault in unharvested_vaults:
             continue
 
-        if await is_position_ltv_exceeded(position, converter, block_number):
-            logger.info('Skipping position index=%d: LTV > 1', position.index)
+        live_shares = await _get_live_shares(position, shares_to_redeem, converter, block_number)
+        if live_shares <= 0:
             continue
+        shares_to_redeem = live_shares
+        assets_to_redeem = converter.to_assets(shares_to_redeem)
 
         if position.vault not in vault_to_withdrawable:
             if await VaultContract(position.vault).is_state_update_required(block_number):
@@ -368,6 +370,28 @@ async def redeem_positions(
                 continue
 
         vault_to_withdrawable[position.vault] = Wei(withdrawable - assets_to_redeem)
+
+
+async def _get_live_shares(
+    position: OsTokenPosition,
+    unprocessed_shares: Wei,
+    converter: OsTokenConverter,
+    block_number: BlockNumber,
+) -> Wei:
+    """Owner's unprocessed shares capped by the live minted osToken position. Returns 0
+    when the position's LTV exceeds 1 or the owner has no live position left to redeem
+    (e.g. repaid or liquidated after the file was published)."""
+    ltv_exceeded, minted_shares = await is_position_ltv_exceeded(position, converter, block_number)
+    if ltv_exceeded:
+        logger.info('Skipping position index=%d: LTV > 1', position.index)
+        return Wei(0)
+
+    live_shares = Wei(min(unprocessed_shares, minted_shares))
+    if live_shares <= 0:
+        logger.info(
+            'Skipping position index=%d: owner has no live osToken position', position.index
+        )
+    return live_shares
 
 
 async def _startup_check() -> None:

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -202,6 +202,36 @@ class TestRedeemPositions:
         # The first position fails but the round continues to the second
         assert mocks['submit_mock'].await_count == 2
 
+    async def test_zero_live_position_skipped_prefix_budget_not_reallocated(self) -> None:
+        """A position whose owner has fully repaid or been liquidated (minted_shares == 0)
+        is skipped without redeeming. Because shares_to_redeem is pre-assigned by a fixed
+        prefix pass, a later position's budget is unaffected by the skip."""
+        pos1 = make_position(
+            vault=VAULT_1,
+            owner=OWNER_1,
+            leaf_shares=1000,
+            processed_shares=0,
+            shares_to_redeem=1000,
+        )
+        pos2 = make_position(
+            vault=VAULT_2, owner=OWNER_2, leaf_shares=1000, processed_shares=0, shares_to_redeem=500
+        )
+
+        with _mock_redeem_positions(
+            withdrawable=Wei(10000), minted_shares=[Wei(0), Wei(1000)]
+        ) as mocks:
+            await redeem_positions(
+                tree=make_tree([pos1, pos2]),
+                os_token_positions=[pos1, pos2],
+                converter=make_converter(100, 100),
+                block_number=BlockNumber(100),
+            )
+
+        assert mocks['submit_mock'].await_count == 1
+        submitted = _submitted_position(mocks)
+        assert submitted.owner == OWNER_2
+        assert submitted.shares_to_redeem == Wei(500)
+
 
 # --- Async function tests (with mocks) ---
 
@@ -335,6 +365,7 @@ def _mock_redeem_positions(
     state_update_required: bool = False,
     submit_results: list[bool] | None = None,
     ltv_exceeded: bool = False,
+    minted_shares: Wei | list[Wei] | None = None,
 ) -> Iterator[dict[str, MagicMock]]:
     """Mock setup for redeem_positions tests.
 
@@ -346,6 +377,10 @@ def _mock_redeem_positions(
     abort the round. Simulation always succeeds; each live position is simulated first.
     ``ltv_exceeded`` simulates a position where the user's minted osToken loan exceeds
     their vault assets (LTV > 1), causing the position to be skipped.
+    ``minted_shares`` mocks the live vault.osTokenPositions(owner) value returned
+    alongside the LTV check; a constant applies to every call, a list is consumed in
+    call order (one entry per position). Defaults to an effectively unbounded value so
+    the unprocessed_shares cap is the only one exercised unless a test overrides it.
     """
     if isinstance(withdrawable, AsyncMock):
         get_withdrawable = withdrawable
@@ -364,13 +399,22 @@ def _mock_redeem_positions(
     vault_contract = MagicMock()
     vault_contract.is_state_update_required = AsyncMock(return_value=state_update_required)
 
+    if isinstance(minted_shares, list):
+        is_position_ltv_exceeded_mock = AsyncMock(
+            side_effect=[(ltv_exceeded, shares) for shares in minted_shares]
+        )
+    else:
+        is_position_ltv_exceeded_mock = AsyncMock(
+            return_value=(ltv_exceeded, minted_shares if minted_shares is not None else Wei(10**30))
+        )
+
     with (
         patch(f'{MODULE}.get_withdrawable_assets', new=get_withdrawable),
         patch(f'{MODULE}.is_meta_vault', new=AsyncMock(return_value=is_meta_vault)),
         patch(f'{MODULE}.VaultContract', return_value=vault_contract),
         patch(
             f'{MODULE}.is_position_ltv_exceeded',
-            new=AsyncMock(return_value=ltv_exceeded),
+            new=is_position_ltv_exceeded_mock,
         ),
         patch(f'{MODULE}.simulate_redeem_position', new=simulate_mock),
         patch(f'{MODULE}.tx_redeem_position', new=submit_mock),

--- a/src/redemptions/tasks.py
+++ b/src/redemptions/tasks.py
@@ -120,12 +120,15 @@ async def is_position_ltv_exceeded(
     position: OsTokenPosition,
     converter: OsTokenConverter,
     block_number: BlockNumber,
-) -> bool:
+) -> tuple[bool, Wei]:
+    """Returns whether the position's LTV exceeds 1, together with the owner's live
+    minted osToken shares (vault.osTokenPositions(owner)) so callers can cap
+    shares_to_redeem without an extra RPC call."""
     vault_contract = VaultContract(position.vault)
     minted_shares = await vault_contract.get_os_token_position(position.owner, block_number)
     loan_assets = converter.to_assets(minted_shares)
     user_assets = await vault_contract.get_user_assets(position.owner, block_number)
-    return loan_assets > user_assets
+    return loan_assets > user_assets, minted_shares
 
 
 async def assign_shares_to_redeem(


### PR DESCRIPTION
## Description

Caps each position in the `process-redeemer` loop by the owner's live osToken position and skips entries whose owner has nothing left to redeem.

The OsTokenRedeemer contract mins `sharesToRedeem` with `vault.osTokenPositions(owner)` and, when that is 0, still verifies the proof and emits `OsTokenPositionsRedeemed(0, 0)` **without reverting**. The operator only tracked `leaf_shares - leafToProcessedShares`, so a position whose owner repaid or was liquidated after the file was published:

1. passed `is_position_ltv_exceeded` (zero loan assets → LTV fine),
2. simulated successfully (the contract no-ops instead of reverting),
3. produced a real on-chain transaction every 60-second cycle.

Since the (0,0) redemption never advances `leafToProcessedShares`, the same dead position was retried **forever**.

**Example.** An owner is listed with a 100 osETH leaf and repays everything an hour after the file is set. Every cycle thereafter the operator sends a transaction that redeems nothing, burns gas, decrements `vault_to_withdrawable` for later positions in the same vault as if 100 osETH of assets had been consumed, and invalidates `ProcessedSharesCache` via the emitted event — forcing a full multicall refetch of processed shares each cycle.

**Fix.** `is_position_ltv_exceeded` now also returns the minted shares it already fetches (no extra RPC call), and the new `_get_live_shares` helper caps the position's shares by it, skipping the position when the owner has no live minted position left.

First of a three-PR stack refactoring the redeem loop — followed by #821 (lazy budget assignment) and #822 (converter refresh + haircut). The matching cap on the aggregation side is #813.