### PR TITLE
Refresh osToken converter after harvest and haircut withdrawable cap

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import sys
 from dataclasses import replace
+from decimal import Decimal
 from pathlib import Path
 
 import click
@@ -54,6 +55,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_INTERVAL = 60  # 1 minute
 DEFAULT_MIN_QUEUED_ASSETS = Web3.to_wei(0.1, 'ether')
 DEFAULT_MIN_QUEUED_ASSETS_GWEI = Web3.from_wei(DEFAULT_MIN_QUEUED_ASSETS, 'gwei')
+
+# Haircut applied when a position is capped to a vault's withdrawable assets, so osToken
+# rate growth (avgRewardPerSecond) between simulation and tx inclusion can't push
+# receivedAssets above availableAssets and revert the redeem call.
+WITHDRAWABLE_ASSETS_HAIRCUT = Decimal('0.999')
 
 
 @click.option(
@@ -293,6 +299,9 @@ async def _redeem_os_token_positions(
 
         # Re-fetch the block number so the freshly-updated state is visible downstream.
         block_number = await execution_client.eth.block_number
+        # Recreate the converter after harvesting settles: convertToAssets grows every
+        # second, so a snapshot taken before waiting for receipts would already be stale.
+        os_token_converter = await create_os_token_converter(block_number)
 
     tree = PositionsMerkleTree(all_positions, nonce)
     await redeem_positions(
@@ -363,8 +372,9 @@ async def redeem_positions(
         assets_to_redeem = converter.to_assets(shares_to_redeem)
 
         if withdrawable < assets_to_redeem:
-            shares_to_redeem = converter.to_shares(withdrawable)
-            assets_to_redeem = withdrawable
+            shares_to_redeem, assets_to_redeem = _apply_withdrawable_haircut(
+                withdrawable, converter
+            )
 
         if shares_to_redeem <= 0:
             continue
@@ -382,25 +392,6 @@ async def redeem_positions(
 
         remaining_shares = Wei(remaining_shares - shares_to_redeem)
         vault_to_withdrawable[position.vault] = Wei(withdrawable - assets_to_redeem)
-
-
-async def _get_vault_withdrawable(
-    vault: ChecksumAddress,
-    vault_to_withdrawable: dict[ChecksumAddress, Wei],
-    unharvested_vaults: set[ChecksumAddress],
-    block_number: BlockNumber,
-) -> Wei | None:
-    """Cached withdrawable assets for a vault, populated on first use. Returns None (and
-    marks the vault unharvested) when its on-chain state requires an update first."""
-    if vault not in vault_to_withdrawable:
-        if await VaultContract(vault).is_state_update_required(block_number):
-            logger.info('Skipping unharvested vault %s', vault)
-            unharvested_vaults.add(vault)
-            return None
-        vault_to_withdrawable[vault] = await get_withdrawable_assets(
-            vault, block_number=block_number
-        )
-    return vault_to_withdrawable[vault]
 
 
 async def _get_live_shares(
@@ -423,6 +414,34 @@ async def _get_live_shares(
             'Skipping position index=%d: owner has no live osToken position', position.index
         )
     return live_shares
+
+
+async def _get_vault_withdrawable(
+    vault: ChecksumAddress,
+    vault_to_withdrawable: dict[ChecksumAddress, Wei],
+    unharvested_vaults: set[ChecksumAddress],
+    block_number: BlockNumber,
+) -> Wei | None:
+    """Cached withdrawable assets for a vault, populated on first use. Returns None (and
+    marks the vault unharvested) when its on-chain state requires an update first."""
+    if vault not in vault_to_withdrawable:
+        if await VaultContract(vault).is_state_update_required(block_number):
+            logger.info('Skipping unharvested vault %s', vault)
+            unharvested_vaults.add(vault)
+            return None
+        vault_to_withdrawable[vault] = await get_withdrawable_assets(
+            vault, block_number=block_number
+        )
+    return vault_to_withdrawable[vault]
+
+
+def _apply_withdrawable_haircut(withdrawable: Wei, converter: OsTokenConverter) -> tuple[Wei, Wei]:
+    """Haircut applied when a position is capped to the vault's withdrawable assets, so
+    osToken rate growth between simulation and tx inclusion can't push receivedAssets
+    above availableAssets and revert the redeem call. Returns (shares_to_redeem,
+    assets_to_redeem)."""
+    assets_to_redeem = Wei(int(withdrawable * WITHDRAWABLE_ASSETS_HAIRCUT))
+    return converter.to_shares(assets_to_redeem), assets_to_redeem
 
 
 async def _startup_check() -> None:

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -10,6 +10,7 @@ from web3 import Web3
 from web3.types import Gwei, Wei
 
 from src.redemptions.commands.process_redeemer import (
+    WITHDRAWABLE_ASSETS_HAIRCUT,
     _startup_check,
     process,
     redeem_positions,
@@ -66,7 +67,8 @@ class TestRedeemPositions:
             )
 
         assert mocks['submit_mock'].await_count == 1
-        assert _submitted_position(mocks).shares_to_redeem == Wei(100)
+        expected_shares = Wei(int(100 * WITHDRAWABLE_ASSETS_HAIRCUT))
+        assert _submitted_position(mocks).shares_to_redeem == expected_shares
 
     async def test_single_position_zero_withdrawable_skipped(self) -> None:
         position = make_position(processed_shares=500)
@@ -105,7 +107,10 @@ class TestRedeemPositions:
         first_position = _submitted_position(mocks, 0)
         second_position = _submitted_position(mocks, 1)
         assert first_position.owner == OWNER_1 and first_position.shares_to_redeem == Wei(500)
-        assert second_position.owner == OWNER_2 and second_position.shares_to_redeem == Wei(200)
+        # Remaining withdrawable after pos1 is 200; capped further by the haircut.
+        expected_second_shares = Wei(int(200 * WITHDRAWABLE_ASSETS_HAIRCUT))
+        assert second_position.owner == OWNER_2
+        assert second_position.shares_to_redeem == expected_second_shares
 
     async def test_budget_derived_ignoring_incoming_shares_to_redeem(self) -> None:
         """shares_to_redeem is assigned lazily from unprocessed_shares and the remaining
@@ -237,6 +242,25 @@ class TestRedeemPositions:
         assert submitted.owner == OWNER_2
         assert submitted.shares_to_redeem == Wei(1000)
 
+    async def test_capped_to_withdrawable_applies_haircut(self) -> None:
+        """When withdrawable < assets_to_redeem, a small margin is subtracted so that
+        osToken rate growth between simulation and tx inclusion can't push receivedAssets
+        over the vault's withdrawable assets."""
+        pos = make_position(leaf_shares=1200, processed_shares=0)
+
+        with _mock_redeem_positions(withdrawable=Wei(1000)) as mocks:
+            await redeem_positions(
+                tree=make_tree([pos]),
+                os_token_positions=[pos],
+                total_redemption_shares=Wei(1200),
+                converter=make_converter(100, 100),
+                block_number=BlockNumber(100),
+            )
+
+        submitted = _submitted_position(mocks)
+        assert submitted.shares_to_redeem == Wei(int(1000 * WITHDRAWABLE_ASSETS_HAIRCUT))
+        assert submitted.shares_to_redeem < Wei(1000)
+
 
 # --- Async function tests (with mocks) ---
 
@@ -329,6 +353,29 @@ class TestProcess:
         # The merkle tree is built from the fetched nonce; leaves use nonce - 1 internally
         assert redeem_call.kwargs['tree'].nonce == 5
         assert redeem_call.kwargs['total_redemption_shares'] == Wei(1000)
+
+    async def test_converter_recreated_after_vault_state_update(self) -> None:
+        """The osToken converter used for redemption must reflect state after
+        update_vaults_state settles, not the snapshot taken before waiting for receipts."""
+        positions = [make_position(leaf_shares=1000, processed_shares=500, shares_to_redeem=500)]
+        converter_before = make_converter(100, 100)
+        converter_after = make_converter(200, 100)
+
+        with (
+            _mock_process(positions=positions) as mocks,
+            patch(
+                f'{MODULE}.create_os_token_converter',
+                new=AsyncMock(side_effect=[converter_before, converter_after]),
+            ) as mock_create_converter,
+        ):
+            mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(1000))
+            mocks['mock_redeemer'].nonce = AsyncMock(return_value=5)
+
+            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+
+        assert mock_create_converter.await_count == 2
+        redeem_call = mocks['mock_redeem'].await_args
+        assert redeem_call.kwargs['converter'] is converter_after
 
     async def test_stale_vault_state_skips_redemption(self) -> None:
         """A failed vault state update leaves stale withdrawable assets and LTVs,


### PR DESCRIPTION
## Description

Fixes deterministic `InvalidReceivedAssets` reverts on cap-bound partial redemptions by (1) recreating the osToken converter after `update_vaults_state` settles and (2) applying a small haircut when a position is capped to the vault's withdrawable assets.

`OsTokenVaultController.convertToAssets` grows every second via `avgRewardPerSecond`. The converter used for the shares↔assets math was snapshotted **before** `update_vaults_state` waited for harvest receipts, so by the time a redemption transaction landed, the true rate had moved past the snapshot.

That mattered exactly in the partial-redemption path: when a position is capped to the vault's withdrawable assets, the operator computed `shares_to_redeem = to_shares(withdrawable)` with the stale rate, i.e. shares whose true value already equals (or exceeds) everything the vault can pay out. On-chain, `_redeemOsToken` recomputes `receivedAssets` with the **current** rate and reverts with `InvalidReceivedAssets` when it exceeds `availableAssets` (OsTokenUtils.sol) — and the margin for error is < 2 wei of flooring slack against ~1e10 wei of rate growth per 12 seconds of lag.

**Example.** Vault has 5 ETH withdrawable; the position is worth 8 ETH, so it is capped. Converter snapshot says 5 ETH = 4.75 osETH shares; the operator submits 4.75 shares. Twenty-four seconds later the transaction is included, 4.75 shares now convert to 5.00000002 ETH > 5 ETH available → revert. Every cycle replays the same math with the same lag, so the vault contributes **0** toward the queue until it is topped up past the full position value.

**Fix.**
- The converter is recreated after `update_vaults_state` (harvests change state and take receipt-wait time; a pre-harvest snapshot is guaranteed stale).
- When capping to withdrawable assets, `_apply_withdrawable_haircut` targets 99.9% of the withdrawable amount (`WITHDRAWABLE_ASSETS_HAIRCUT = 0.999`), leaving ~5 ETH × 0.001 = 0.005 ETH of headroom — several orders of magnitude more than the rate drifts between simulation and inclusion, while the residual remains redeemable in the next cycle.

Final PR of the redeem-loop stack — based on #821's branch, which builds on #820.