### PR TITLE
Restore graph page size default to 500

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -496,7 +496,7 @@ class Settings(metaclass=Singleton):
         )
         self.graph_page_size = decouple_config(
             'GRAPH_PAGE_SIZE',
-            default=100,
+            default=500,
             cast=int,
             group='Subgraph',
             description='Number of records requested from the subgraph per page.',


### PR DESCRIPTION
## Problem

`graph_get_redeemable_allocators_from_vaults` started raising subgraph timeouts on v5-release.

`src/redemptions/graph.py` itself has not changed since #732. What changed is the page size the graph client paginates with:

| commit | `GRAPH_PAGE_SIZE` default |
|---|---|
| v5-release before the merge | **500** |
| master (`757b875`) | 100 |
| `3c6615d` "Merge branch 'master' into v5-release" | **100** |

#630 deliberately raised the default to 500 on v5-release for the redeemable-positions flow. Master never got that bump, and when #776 rewrote the whole settings block on master, the merge took master's version wholesale — silently reverting the 500 with no conflict.

## Why the smaller page size breaks it

The mainnet subgraph does not just get slower with a smaller `first` — it stops responding. Measured directly against the endpoint with the exact allocators query, cache-busted via a unique `id_gt` per request:

```
first=500  http=200  t=0.57s
first=250  http=200  t=0.53s
first=200  http=200  t=0.69s
first=150  no response  (>18s)
first=100  no response  (>20s)
first=50   no response  (>15s)
```

Repeatable on both prod and stage, with a sharp cliff between 150 and 200. It is not the filters: at `first: 100`, dropping `mintedOsTokenShares_gt`, `id_gt`, `vault` and `orderBy` one at a time still hangs on every variant.

With `GRAPH_REQUEST_TIMEOUT=10` and `GRAPH_RETRY_TIMEOUT=60`, a hanging page means the operator retries for a minute and then fails.

## Change

Restore `GRAPH_PAGE_SIZE` default to 500.

The server-side cause is not fixable from here and is worth raising separately with graph-node ops — 100 is the default in other deployments, so any other `allocators` pagination would hit the same wall. Note also that in a separate probe `allocators(first: 200)` without the vault filter hung as well, so 200 is not a safe threshold; 500 is the value that was working before.
