### PR TITLE
Return VaultOsTokenPosition from get_vault_os_token_position

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -45,7 +45,7 @@ from src.redemptions.os_token_converter import (
     OsTokenConverter,
     create_os_token_converter,
 )
-from src.redemptions.tasks import assign_shares_to_redeem, is_position_ltv_exceeded
+from src.redemptions.tasks import assign_shares_to_redeem, get_vault_os_token_position
 from src.redemptions.typings import OsTokenPosition
 from src.validators.execution import get_withdrawable_assets
 
@@ -335,16 +335,16 @@ async def redeem_positions(
         if position.vault in unharvested_vaults:
             continue
 
-        ltv_exceeded, minted_shares = await is_position_ltv_exceeded(
+        vault_os_token_position = await get_vault_os_token_position(
             position, converter, block_number
         )
-        if ltv_exceeded:
+        if vault_os_token_position.ltv > 1:
             logger.info('Skipping position index=%d: LTV > 1', position.index)
             continue
 
         # Cap by the live minted position: the owner may have repaid or been
         # liquidated after the positions file was published.
-        shares_to_redeem = Wei(min(shares_to_redeem, minted_shares))
+        shares_to_redeem = Wei(min(shares_to_redeem, vault_os_token_position.minted_shares))
         if shares_to_redeem <= 0:
             logger.info(
                 'Skipping position index=%d: owner has no live osToken position', position.index

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -16,7 +16,7 @@ from src.redemptions.commands.process_redeemer import (
 )
 from src.redemptions.merkle_tree import PositionsMerkleTree
 from src.redemptions.os_token_converter import OsTokenConverter
-from src.redemptions.typings import OsTokenPosition
+from src.redemptions.typings import OsTokenPosition, VaultOsTokenPosition
 
 MODULE = 'src.redemptions.commands.process_redeemer'
 
@@ -377,8 +377,8 @@ def _mock_redeem_positions(
     abort the round. Simulation always succeeds; each live position is simulated first.
     ``ltv_exceeded`` simulates a position where the user's minted osToken loan exceeds
     their vault assets (LTV > 1), causing the position to be skipped.
-    ``minted_shares`` mocks the live vault.osTokenPositions(owner) value returned
-    alongside the LTV check; a constant applies to every call, a list is consumed in
+    ``minted_shares`` mocks the live vault.osTokenPositions(owner) value of the
+    returned VaultOsTokenPosition; a constant applies to every call, a list is consumed in
     call order (one entry per position). Defaults to an effectively unbounded value so
     the unprocessed_shares cap is the only one exercised unless a test overrides it.
     """
@@ -399,13 +399,22 @@ def _mock_redeem_positions(
     vault_contract = MagicMock()
     vault_contract.is_state_update_required = AsyncMock(return_value=state_update_required)
 
+    ltv = 2.0 if ltv_exceeded else 0.5
+    vault_address = faker.eth_address()
     if isinstance(minted_shares, list):
-        is_position_ltv_exceeded_mock = AsyncMock(
-            side_effect=[(ltv_exceeded, shares) for shares in minted_shares]
+        get_vault_os_token_position_mock = AsyncMock(
+            side_effect=[
+                VaultOsTokenPosition(address=vault_address, minted_shares=shares, ltv=ltv)
+                for shares in minted_shares
+            ]
         )
     else:
-        is_position_ltv_exceeded_mock = AsyncMock(
-            return_value=(ltv_exceeded, minted_shares if minted_shares is not None else Wei(10**30))
+        get_vault_os_token_position_mock = AsyncMock(
+            return_value=VaultOsTokenPosition(
+                address=vault_address,
+                minted_shares=minted_shares if minted_shares is not None else Wei(10**30),
+                ltv=ltv,
+            )
         )
 
     with (
@@ -413,8 +422,8 @@ def _mock_redeem_positions(
         patch(f'{MODULE}.is_meta_vault', new=AsyncMock(return_value=is_meta_vault)),
         patch(f'{MODULE}.VaultContract', return_value=vault_contract),
         patch(
-            f'{MODULE}.is_position_ltv_exceeded',
-            new=is_position_ltv_exceeded_mock,
+            f'{MODULE}.get_vault_os_token_position',
+            new=get_vault_os_token_position_mock,
         ),
         patch(f'{MODULE}.simulate_redeem_position', new=simulate_mock),
         patch(f'{MODULE}.tx_redeem_position', new=submit_mock),

--- a/src/redemptions/tasks.py
+++ b/src/redemptions/tasks.py
@@ -19,7 +19,7 @@ from src.redemptions.fetch_positions import (
     update_processed_shares_cache,
 )
 from src.redemptions.os_token_converter import create_os_token_converter
-from src.redemptions.typings import OsTokenPosition
+from src.redemptions.typings import OsTokenPosition, VaultOsTokenPosition
 
 logger = logging.getLogger(__name__)
 
@@ -119,19 +119,27 @@ async def aggregate_redemption_assets_by_vaults(
     )
 
 
-async def is_position_ltv_exceeded(
+async def get_vault_os_token_position(
     position: OsTokenPosition,
     converter: OsTokenConverter,
     block_number: BlockNumber,
-) -> tuple[bool, Wei]:
-    """Returns whether the position's LTV exceeds 1, together with the owner's live
-    minted osToken shares (vault.osTokenPositions(owner)) so callers can cap
-    shares_to_redeem without an extra RPC call."""
+) -> VaultOsTokenPosition:
+    """Fetch the owner's live osToken debt position in the position's vault.
+    Mirrors the OsTokenPosition of the VaultOsToken contract."""
     vault_contract = VaultContract(position.vault)
     minted_shares = await vault_contract.get_os_token_position(position.owner, block_number)
     loan_assets = converter.to_assets(minted_shares)
     user_assets = await vault_contract.get_user_assets(position.owner, block_number)
-    return loan_assets > user_assets, minted_shares
+    if user_assets > 0:
+        ltv = loan_assets / user_assets
+    else:
+        ltv = float('inf') if loan_assets > 0 else 0.0
+
+    return VaultOsTokenPosition(
+        address=position.vault,
+        minted_shares=minted_shares,
+        ltv=ltv,
+    )
 
 
 async def assign_shares_to_redeem(


### PR DESCRIPTION
Replaces `is_position_ltv_exceeded` with `get_vault_os_token_position`, which returns a `VaultOsTokenPosition` describing the owner's live osToken debt position in the vault instead of an opaque `(bool, Wei)` tuple.

- Reuses the existing `VaultOsTokenPosition` dataclass (`address`, `minted_shares`, `ltv`).
- `ltv = loan_assets / user_assets`; `inf` when the owner has no vault assets but non-zero debt, `0.0` when both are zero. This preserves the previous `loan_assets > user_assets` semantics.
- `redeem_positions` now checks `vault_os_token_position.ltv > 1` and caps `shares_to_redeem` by `vault_os_token_position.minted_shares`.

No behavior change — the on-chain calls and skip/cap rules are identical.
