### PR TITLE
Unify merkle leaf encoding and IPFS positions codec

### DIFF
--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -291,7 +291,9 @@ async def _redeem_os_token_positions(
         # Re-fetch the block number so the freshly-updated state is visible downstream.
         block_number = await execution_client.eth.block_number
 
-    tree = PositionsMerkleTree(all_positions, nonce)
+    # Leaves use `nonce - 1`: setting the positions root increments the
+    # on-chain nonce, leaving it one ahead of the nonce baked into the leaves.
+    tree = PositionsMerkleTree(all_positions, leaf_nonce=nonce - 1)
     await redeem_positions(
         tree=tree,
         os_token_positions=os_token_positions,

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -324,8 +324,8 @@ class TestProcess:
 
         mocks['mock_redeem'].assert_awaited_once()
         redeem_call = mocks['mock_redeem'].await_args
-        # The merkle tree is built from the fetched nonce; leaves use nonce - 1 internally
-        assert redeem_call.kwargs['tree'].nonce == 5
+        # The merkle tree is built from the fetched nonce; leaves use nonce - 1
+        assert redeem_call.kwargs['tree'].leaf_nonce == 4
 
     async def test_stale_vault_state_skips_redemption(self) -> None:
         """A failed vault state update leaves stale withdrawable assets and LTVs,
@@ -506,7 +506,7 @@ def make_tree(
 ) -> PositionsMerkleTree:
     """Build a positions merkle tree. Defaults to a single position so callers that
     only need a valid tree (e.g. when tx_redeem_position is mocked) can omit it."""
-    return PositionsMerkleTree(positions or [make_position()], nonce)
+    return PositionsMerkleTree(positions or [make_position()], leaf_nonce=nonce)
 
 
 def make_position(

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import click
 from eth_typing import BlockNumber, ChecksumAddress
-from multiproof import StandardMerkleTree
 from sw_utils import OsTokenConverter
 from web3 import Web3
 from web3.types import Gwei, Wei
@@ -42,6 +41,7 @@ from src.redemptions.graph import (
     graph_get_os_token_holders,
     graph_get_redeemable_allocators,
 )
+from src.redemptions.merkle_tree import PositionsMerkleTree
 from src.redemptions.os_token_converter import create_os_token_converter
 from src.redemptions.typings import (
     Allocator,
@@ -291,16 +291,7 @@ async def process(
 
     # calculate merkle root
     nonce = await os_token_redeemer_contract.nonce()
-    leaves = [r.merkle_leaf(nonce) for r in os_token_positions]
-    tree = StandardMerkleTree.of(
-        leaves,
-        [
-            'uint256',
-            'address',
-            'uint256',
-            'address',
-        ],
-    )
+    tree = PositionsMerkleTree(os_token_positions, leaf_nonce=nonce)
     click.echo(f'Generated Merkle Tree root: {tree.root}')
 
     ipfs_upload_client = build_ipfs_upload_clients()

--- a/src/redemptions/fetch_positions.py
+++ b/src/redemptions/fetch_positions.py
@@ -228,14 +228,6 @@ async def fetch_positions_from_ipfs(
     data = cast(list[dict], await ipfs_fetch_client.fetch_json(redeemable_positions.ipfs_hash))
 
     # data structure example:
-    # [{"owner:" 0x01, "leaf_shares": 100000, "vault": 0x02}, ...]
+    # [{"owner": 0x01, "leaf_shares": 100000, "vault": 0x02}, ...]
 
-    return [
-        OsTokenPosition(
-            owner=Web3.to_checksum_address(item['owner']),
-            vault=Web3.to_checksum_address(item['vault']),
-            leaf_shares=Wei(int(item['leaf_shares'])),
-            index=index,
-        )
-        for index, item in enumerate(data)
-    ]
+    return [OsTokenPosition.from_dict(item, index=index) for index, item in enumerate(data)]

--- a/src/redemptions/merkle_tree.py
+++ b/src/redemptions/merkle_tree.py
@@ -1,26 +1,26 @@
-from eth_typing import ChecksumAddress
+from eth_typing import ChecksumAddress, HexStr
 from multiproof import StandardMerkleTree
 from multiproof.standard import MultiProof
 from web3.types import Wei
 
-from src.redemptions.typings import OsTokenPosition
-
-LEAF_TYPES = ['uint256', 'address', 'uint256', 'address']
+from src.redemptions.typings import LEAF_TYPES, OsTokenPosition
 
 
 class PositionsMerkleTree:
-    def __init__(self, all_positions: list[OsTokenPosition], nonce: int):
-        self.nonce = nonce
-        # Leaves use `nonce - 1`: setting the positions root increments the
-        # on-chain nonce, leaving it one ahead of the nonce baked into the leaves.
+    def __init__(self, all_positions: list[OsTokenPosition], leaf_nonce: int):
+        self.leaf_nonce = leaf_nonce
         self._tree = StandardMerkleTree.of(
-            [p.merkle_leaf(nonce - 1) for p in all_positions],
+            [p.merkle_leaf(leaf_nonce) for p in all_positions],
             LEAF_TYPES,
         )
+
+    @property
+    def root(self) -> HexStr:
+        return self._tree.root
 
     def get_multi_proof(
         self, positions_to_redeem: list[OsTokenPosition]
     ) -> MultiProof[tuple[int, ChecksumAddress, Wei, ChecksumAddress]]:
         """Build a merkle multiproof proving the given positions to redeem."""
-        redeem_leaves = [p.merkle_leaf(self.nonce - 1) for p in positions_to_redeem]
+        redeem_leaves = [p.merkle_leaf(self.leaf_nonce) for p in positions_to_redeem]
         return self._tree.get_multi_proof(redeem_leaves)

--- a/src/redemptions/tests/test_execution.py
+++ b/src/redemptions/tests/test_execution.py
@@ -310,7 +310,7 @@ def _mock_simulate_redeem_position(
 def make_tree(
     positions: list[OsTokenPosition] | None = None, nonce: int = 5
 ) -> PositionsMerkleTree:
-    return PositionsMerkleTree(positions or [make_position()], nonce)
+    return PositionsMerkleTree(positions or [make_position()], leaf_nonce=nonce)
 
 
 def make_position(

--- a/src/redemptions/tests/test_merkle_tree.py
+++ b/src/redemptions/tests/test_merkle_tree.py
@@ -5,14 +5,14 @@ from src.redemptions.tests.factories import make_position
 class TestPositionsMerkleTree:
     def test_single_position(self) -> None:
         position = make_position(leaf_shares=1000)
-        result = PositionsMerkleTree([position], nonce=5).get_multi_proof([position])
+        result = PositionsMerkleTree([position], leaf_nonce=4).get_multi_proof([position])
         assert len(result.leaves) == 1
 
     def test_partial_redeem(self) -> None:
         pos1 = make_position(leaf_shares=1000)
         pos2 = make_position(leaf_shares=2000)
 
-        result = PositionsMerkleTree([pos1, pos2], nonce=5).get_multi_proof([pos1])
+        result = PositionsMerkleTree([pos1, pos2], leaf_nonce=4).get_multi_proof([pos1])
         assert len(result.leaves) == 1
         assert len(result.proof) > 0
 
@@ -20,5 +20,5 @@ class TestPositionsMerkleTree:
         pos1 = make_position(leaf_shares=1000)
         pos2 = make_position(leaf_shares=2000)
 
-        result = PositionsMerkleTree([pos1, pos2], nonce=5).get_multi_proof([pos1, pos2])
+        result = PositionsMerkleTree([pos1, pos2], leaf_nonce=4).get_multi_proof([pos1, pos2])
         assert len(result.leaves) == 2

--- a/src/redemptions/tests/test_typings.py
+++ b/src/redemptions/tests/test_typings.py
@@ -1,0 +1,33 @@
+from sw_utils.tests import faker
+
+from src.redemptions.tests.factories import make_position
+from src.redemptions.typings import OsTokenPosition
+
+
+class TestOsTokenPositionCodec:
+    def test_round_trip(self) -> None:
+        position = make_position()
+
+        restored = OsTokenPosition.from_dict(position.as_dict(), index=position.index)
+
+        assert restored.owner == position.owner
+        assert restored.vault == position.vault
+        assert restored.leaf_shares == position.leaf_shares
+
+    def test_from_dict_propagates_index(self) -> None:
+        position = make_position()
+
+        restored = OsTokenPosition.from_dict(position.as_dict(), index=5)
+
+        assert restored.index == 5
+
+    def test_from_dict_checksums_lowercase_addresses(self) -> None:
+        owner = faker.eth_address()
+        vault = faker.eth_address()
+
+        restored = OsTokenPosition.from_dict(
+            {'owner': owner.lower(), 'vault': vault.lower(), 'leaf_shares': '1000'}
+        )
+
+        assert restored.owner == owner
+        assert restored.vault == vault

--- a/src/redemptions/typings.py
+++ b/src/redemptions/typings.py
@@ -5,6 +5,8 @@ from multiproof.standard import standard_leaf_hash
 from web3 import Web3
 from web3.types import Wei
 
+LEAF_TYPES = ['uint256', 'address', 'uint256', 'address']
+
 
 @dataclass
 class VaultOsTokenPosition:
@@ -99,7 +101,7 @@ class OsTokenPosition:
         """Get the Merkle leaf hash"""
         return standard_leaf_hash(
             values=(nonce, self.vault, self.leaf_shares, self.owner),
-            types=['uint256', 'address', 'uint256', 'address'],
+            types=LEAF_TYPES,
         )
 
 

--- a/src/redemptions/typings.py
+++ b/src/redemptions/typings.py
@@ -88,11 +88,21 @@ class OsTokenPosition:
         return Wei(max(0, self.leaf_shares - self.processed_shares))
 
     def as_dict(self) -> dict:
+        """``as_dict``/``from_dict`` define the IPFS positions file schema (kept in one place)."""
         return {
             'owner': self.owner,
             'vault': self.vault,
             'leaf_shares': str(self.leaf_shares),
         }
+
+    @classmethod
+    def from_dict(cls, data: dict, index: int = 0) -> 'OsTokenPosition':
+        return cls(
+            owner=Web3.to_checksum_address(data['owner']),
+            vault=Web3.to_checksum_address(data['vault']),
+            leaf_shares=Wei(int(data['leaf_shares'])),
+            index=index,
+        )
 
     def merkle_leaf(self, nonce: int) -> tuple[int, ChecksumAddress, Wei, ChecksumAddress]:
         return nonce, self.vault, self.leaf_shares, self.owner


### PR DESCRIPTION
## Description

- Move `LEAF_TYPES` to `typings.py` as the single definition of the merkle leaf encoding; `OsTokenPosition.leaf_hash` uses it.
- `PositionsMerkleTree` now takes an explicit `leaf_nonce` (no implicit `nonce - 1`) and exposes a `root` property.
- `process-redeemer` passes `leaf_nonce=nonce - 1` at the call site; `update-redeemable-positions` reuses `PositionsMerkleTree` instead of building a `StandardMerkleTree` inline.
- Add `OsTokenPosition.from_dict` as the counterpart of `as_dict`, so the IPFS positions file schema is defined in one place; `fetch_positions_from_ipfs` uses it instead of inline parsing.