### PR TITLE
Move kept shares and vault split into Allocator

### DIFF
--- a/src/redemptions/api_client.py
+++ b/src/redemptions/api_client.py
@@ -6,6 +6,7 @@ from web3.types import Wei
 
 from src.config.networks import GNOSIS, MAINNET, ZERO_CHECKSUM_ADDRESS
 from src.config.settings import settings
+from src.redemptions.typings import ApiConfig
 
 RABBY_API_ENDPOINT = 'https://api.rabby.io/'
 DEBANK_API_ENDPOINT = 'https://pro-openapi.debank.com/'
@@ -29,17 +30,18 @@ STAKEWISE_DEBANK_PROTOCOL_IDS = ['stakewise', 'xdai_stakewise']
 
 class APIClient:
 
-    def __init__(
-        self, api_source: str = RABBY_API_SOURCE, api_access_key: str | None = None
-    ) -> None:
-        self.base_url = API_SOURCES[api_source]
-        self.api_access_key = api_access_key
-
-    async def get_protocols_locked_os_token(self, address: ChecksumAddress) -> Wei:
+    def __init__(self, api_config: ApiConfig) -> None:
         api_chain = API_SUPPORTED_CHAINS.get(settings.network)
         if api_chain is None:
             raise ValueError(f'Unsupported network for API Client: {settings.network}')
 
+        self.base_url = API_SOURCES[api_config.source]
+        self.source = api_config.source
+        self.access_key = api_config.access_key
+        self.sleep_timeout = api_config.sleep_timeout
+        self.api_chain = api_chain
+
+    async def get_protocols_locked_os_token(self, address: ChecksumAddress) -> Wei:
         url = urljoin(self.base_url, 'v1/user/complex_protocol_list')
         params = {
             'id': address,
@@ -48,7 +50,7 @@ class APIClient:
         protocol_data = await self._fetch_json(url, params=params)
         total_locked_os_token = Wei(0)
         for protocol in protocol_data:
-            if protocol['chain'] != api_chain:
+            if protocol['chain'] != self.api_chain:
                 continue
             # boosted OsEth handled via graph separately
             if protocol['id'] in STAKEWISE_DEBANK_PROTOCOL_IDS:
@@ -56,7 +58,7 @@ class APIClient:
             for portfolio_item in protocol.get('portfolio_item_list', []):
                 supply_token_list = portfolio_item.get('detail', {}).get('supply_token_list', [])
                 for supply_token in supply_token_list:
-                    if supply_token['chain'] != api_chain:
+                    if supply_token['chain'] != self.api_chain:
                         continue
                     if not Web3.is_address(supply_token['id']):
                         continue
@@ -69,8 +71,8 @@ class APIClient:
 
     async def _fetch_json(self, url: str, params: dict | None = None) -> dict | list:
         headers: dict[str, str] = {'user-agent': DEFAULT_USER_AGENT}
-        if self.api_access_key:
-            headers['AccessKey'] = self.api_access_key
+        if self.access_key:
+            headers['AccessKey'] = self.access_key
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 url=url,

--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -27,7 +27,7 @@ os_token_contract_address = NETWORKS[MAINNET].OS_TOKEN_CONTRACT_ADDRESS
 
 
 def test_create_os_token_positions_zero_allocators():
-    result = create_os_token_positions([], {}, 0)
+    result = create_os_token_positions([], Wei(0))
     assert result == []
 
 
@@ -44,10 +44,7 @@ def test_create_os_token_positions_single_vault():
             ],
         )
     ]
-    kept_tokens = {
-        address_1: Wei(0),
-    }
-    result = create_os_token_positions(allocators, kept_tokens, 0)
+    result = create_os_token_positions(allocators, Wei(0))
     assert result == [OsTokenPosition(owner=address_1, vault=vault_1, leaf_shares=Wei(150))]
 
 
@@ -63,12 +60,10 @@ def test_create_os_token_positions_kept_tokens():
                     address=Web3.to_checksum_address(vault_1), minted_shares=Wei(150), ltv=0.5
                 ),
             ],
+            wallet_shares=Wei(100),
         )
     ]
-    kept_tokens = {
-        address_1: Wei(100),
-    }
-    result = create_os_token_positions(allocators, kept_tokens, 0)
+    result = create_os_token_positions(allocators, Wei(0))
     assert result == [OsTokenPosition(owner=address_1, vault=vault_1, leaf_shares=Wei(50))]
 
 
@@ -93,13 +88,10 @@ def test_create_os_token_positions_multiple_allocators():
                     address=Web3.to_checksum_address(vault_1), minted_shares=Wei(75), ltv=0.5
                 ),
             ],
+            wallet_shares=Wei(75),
         ),
     ]
-    kept_tokens = {
-        address_1: Wei(0),
-        address_2: Wei(75),
-    }
-    result = create_os_token_positions(allocators, kept_tokens, 0)
+    result = create_os_token_positions(allocators, Wei(0))
     assert result == [OsTokenPosition(owner=address_1, vault=vault_1, leaf_shares=Wei(150))]
 
 
@@ -121,7 +113,7 @@ def test_create_os_token_positions_multiple_vaults_1():
             ],
         )
     ]
-    result = create_os_token_positions(allocators, {}, 0)
+    result = create_os_token_positions(allocators, Wei(0))
     assert result == [
         OsTokenPosition(owner=address_1, vault=vault_1, leaf_shares=Wei(150)),
         OsTokenPosition(owner=address_1, vault=vault_2, leaf_shares=Wei(150)),
@@ -143,12 +135,10 @@ def test_create_os_token_positions_multiple_vaults_2():
                     address=Web3.to_checksum_address(vault_2), minted_shares=Wei(666), ltv=0.5
                 ),
             ],
+            wallet_shares=Wei(100),
         )
     ]
-    kept_tokens = {
-        address_1: Wei(100),
-    }
-    result = create_os_token_positions(allocators, kept_tokens, 0)
+    result = create_os_token_positions(allocators, Wei(0))
     assert result == [
         OsTokenPosition(owner=address_1, vault=vault_2, leaf_shares=Wei(600)),
         OsTokenPosition(owner=address_1, vault=vault_1, leaf_shares=Wei(299)),
@@ -170,12 +160,10 @@ def test_create_os_token_positions_multiple_vaults_3():
                     address=Web3.to_checksum_address(vault_2), minted_shares=Wei(999), ltv=0.5
                 ),
             ],
+            wallet_shares=Wei(100),
         )
     ]
-    kept_tokens = {
-        address_1: Wei(100),
-    }
-    result = create_os_token_positions(allocators, kept_tokens, 0)
+    result = create_os_token_positions(allocators, Wei(0))
     assert result == [
         OsTokenPosition(owner=address_1, vault=vault_2, leaf_shares=Wei(900)),
         OsTokenPosition(owner=address_1, vault=vault_1, leaf_shares=Wei(0)),
@@ -197,12 +185,10 @@ def test_create_os_token_positions_min_redeemable_shares():
                     address=Web3.to_checksum_address(vault_2), minted_shares=Wei(666), ltv=0.5
                 ),
             ],
+            wallet_shares=Wei(100),
         )
     ]
-    kept_tokens = {
-        address_1: Wei(100),
-    }
-    result = create_os_token_positions(allocators, kept_tokens, 300)
+    result = create_os_token_positions(allocators, Wei(300))
     assert result == [
         OsTokenPosition(owner=address_1, vault=vault_2, leaf_shares=Wei(600)),
     ]
@@ -241,7 +227,7 @@ def test_create_os_token_positions_ordering_by_ltv_and_amount():
             ],
         ),
     ]
-    result = create_os_token_positions(allocators, {}, 0)
+    result = create_os_token_positions(allocators, Wei(0))
     # sorted by ltv desc, then amount desc
     assert result == [
         OsTokenPosition(owner=address_2, vault=vault_1, leaf_shares=Wei(500)),

--- a/src/redemptions/commands/tests/test_update_redeemable_positions.py
+++ b/src/redemptions/commands/tests/test_update_redeemable_positions.py
@@ -12,6 +12,7 @@ from src.config.networks import MAINNET, NETWORKS
 from src.config.settings import settings
 from src.redemptions.commands.update_redeemable_positions import (
     _distribute_boosted_shares,
+    _filter_min_redeemable_shares,
     calculate_boost_os_token_shares,
     create_os_token_positions,
     update_redeemable_positions,
@@ -296,6 +297,60 @@ async def test_calculate_boost_os_token_shares():
         (address_2, vault_1): 100,
         (address_2, vault_2): 3095,
     }
+
+
+def test_filter_min_redeemable_shares_drops_allocators_left_with_no_positions():
+    address_1 = faker.eth_address()
+    address_2 = faker.eth_address()
+    vault_1 = faker.eth_address()
+    vault_2 = faker.eth_address()
+
+    allocator_a = Allocator(
+        address=Web3.to_checksum_address(address_1),
+        vault_os_token_positions=[
+            VaultOsTokenPosition(
+                address=Web3.to_checksum_address(vault_1), minted_shares=Wei(500), ltv=0.5
+            ),
+            VaultOsTokenPosition(
+                address=Web3.to_checksum_address(vault_2), minted_shares=Wei(100), ltv=0.5
+            ),
+        ],
+    )
+    allocator_b = Allocator(
+        address=Web3.to_checksum_address(address_2),
+        vault_os_token_positions=[
+            VaultOsTokenPosition(
+                address=Web3.to_checksum_address(vault_1), minted_shares=Wei(50), ltv=0.5
+            ),
+        ],
+    )
+
+    result = _filter_min_redeemable_shares([allocator_a, allocator_b], Wei(200))
+    assert result == [allocator_a]
+    assert result[0].vault_os_token_positions == [
+        VaultOsTokenPosition(
+            address=Web3.to_checksum_address(vault_1), minted_shares=Wei(500), ltv=0.5
+        ),
+    ]
+
+
+def test_filter_min_redeemable_shares_zero_threshold_keeps_everything():
+    address_1 = faker.eth_address()
+    vault_1 = faker.eth_address()
+
+    allocators = [
+        Allocator(
+            address=Web3.to_checksum_address(address_1),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(
+                    address=Web3.to_checksum_address(vault_1), minted_shares=Wei(0), ltv=0.5
+                ),
+            ],
+        ),
+    ]
+
+    result = _filter_min_redeemable_shares(allocators, Wei(0))
+    assert result == allocators
 
 
 def test_distributes_boosted_shares():

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -231,7 +231,7 @@ async def process(
 
     # filter zero positions. Filter before kept shares calculation to reduce api calls
     min_redeemable_shares = Web3.to_wei(min_os_token_position_amount_gwei, 'gwei')
-    _filter_min_redeemable_shares(allocators, min_redeemable_shares)
+    allocators = _filter_min_redeemable_shares(allocators, min_redeemable_shares)
 
     if not allocators:
         logger.info('No allocators with redeemable shares above the threshold found, exiting...')
@@ -284,13 +284,21 @@ async def _apply_boost(
 def _filter_min_redeemable_shares(
     allocators: list[Allocator],
     min_redeemable_shares: Wei,
-) -> None:
+) -> list[Allocator]:
+    result = []
     for allocator in allocators:
-        allocator.vault_os_token_positions = [
+        vault_os_token_positions = [
             vault_position
             for vault_position in allocator.vault_os_token_positions
             if vault_position.redeemable_shares >= min_redeemable_shares
         ]
+        # drop allocators left with no vault positions so populate_kept_shares
+        # doesn't waste a rate-limited api call on a guaranteed-zero position
+        if not vault_os_token_positions:
+            continue
+        allocator.vault_os_token_positions = vault_os_token_positions
+        result.append(allocator)
+    return result
 
 
 def _build_api_client(api_config: ApiConfig) -> APIClient | None:

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -411,14 +411,18 @@ def create_os_token_positions(
     positions by ltv descending, then amount descending.
     """
     slices = [
-        (vault_position.ltv, vault_amount, allocator.address, vault_position.address)
+        vault_slice
         for allocator in allocators
-        for vault_position, vault_amount in allocator.iter_vault_slices(min_redeemable_shares)
+        for vault_slice in allocator.iter_vault_slices(min_redeemable_shares)
     ]
-    slices.sort(key=lambda s: (s[0], s[1]), reverse=True)
+    slices.sort(key=lambda s: (s.vault_position.ltv, s.amount), reverse=True)
     return [
-        OsTokenPosition(owner=owner, vault=vault, leaf_shares=vault_amount)
-        for _, vault_amount, owner, vault in slices
+        OsTokenPosition(
+            owner=s.allocator.address,
+            vault=s.vault_position.address,
+            leaf_shares=s.amount,
+        )
+        for s in slices
     ]
 
 

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -212,7 +212,6 @@ async def main(
         await close_clients()
 
 
-# pylint: disable-next=too-many-locals
 async def process(
     min_os_token_position_amount_gwei: Gwei,
     api_config: ApiConfig,
@@ -222,17 +221,57 @@ async def process(
     """
     finalized_block = await execution_client.eth.get_block('finalized')
     block_number = finalized_block['number']
+
+    allocators = await _fetch_allocators(block_number)
+
+    logger.info('Fetching boosted positions from the subgraph...')
+    leverage_positions = await graph_get_leverage_positions(block_number)
+    allocators = _exclude_boost_proxies(allocators, leverage_positions)
+    await _apply_boost(allocators, leverage_positions, block_number)
+
+    # filter zero positions. Filter before kept shares calculation to reduce api calls
+    min_redeemable_shares = Web3.to_wei(min_os_token_position_amount_gwei, 'gwei')
+    _filter_min_redeemable_shares(allocators, min_redeemable_shares)
+
+    if not allocators:
+        logger.info('No allocators with redeemable shares above the threshold found, exiting...')
+        return
+
+    logger.info('Fetching kept tokens for %s addresses', len(allocators))
+    api_client = _build_api_client(api_config)
+    await populate_kept_shares(allocators, block_number, api_client)
+    logger.info('Fetched kept tokens for %s addresses...', len(allocators))
+
+    os_token_positions = create_os_token_positions(allocators, min_redeemable_shares)
+    if not os_token_positions:
+        logger.info('No redeemable os token positions to upload, exiting...')
+        return
+
+    await _publish_positions(os_token_positions)
+
+
+async def _fetch_allocators(block_number: BlockNumber) -> list[Allocator]:
     logger.info('Fetching allocators from the subgraph...')
     allocators = await graph_get_redeemable_allocators(block_number)
     logger.info('Fetched %s allocators from the subgraph', len(allocators))
+    return allocators
 
-    # filter boost proxy positions
-    logger.info('Fetching boosted positions from the subgraph...')
-    leverage_positions = await graph_get_leverage_positions(block_number)
+
+def _exclude_boost_proxies(
+    allocators: list[Allocator],
+    leverage_positions: list[LeverageStrategyPosition],
+) -> list[Allocator]:
+    """Boost proxies hold minted osToken on behalf of a user; they are never allocators."""
     boost_proxies = {pos.proxy for pos in leverage_positions}
     logger.info('Found %s proxy positions to exclude', len(boost_proxies))
-    allocators = [a for a in allocators if a.address not in boost_proxies]
-    # reduce boosted positions
+    return [a for a in allocators if a.address not in boost_proxies]
+
+
+async def _apply_boost(
+    allocators: list[Allocator],
+    leverage_positions: list[LeverageStrategyPosition],
+    block_number: BlockNumber,
+) -> None:
     os_token_converter = await create_os_token_converter(block_number)
     boost_os_token_shares = await calculate_boost_os_token_shares(
         users={a.address for a in allocators},
@@ -241,8 +280,11 @@ async def process(
     )
     _distribute_boosted_shares(allocators, boost_os_token_shares)
 
-    # filter zero positions. Filter before kept shares calculation to reduce api calls
-    min_redeemable_shares = Web3.to_wei(min_os_token_position_amount_gwei, 'gwei')
+
+def _filter_min_redeemable_shares(
+    allocators: list[Allocator],
+    min_redeemable_shares: Wei,
+) -> None:
     for allocator in allocators:
         allocator.vault_os_token_positions = [
             vault_position
@@ -250,29 +292,15 @@ async def process(
             if vault_position.redeemable_shares >= min_redeemable_shares
         ]
 
-    if not allocators:
-        logger.info('No allocators with redeemable shares above the threshold found, exiting...')
-        return
 
-    logger.info('Fetching kept tokens for %s addresses', len(allocators))
-    address_to_redeemable_shares = {a.address: a.total_redeemable_shares for a in allocators}
-    kept_shares = await get_kept_shares(
-        address_to_redeemable_shares,
-        block_number,
-        api_config,
-    )
-    logger.info('Fetched kept tokens for %s addresses...', len(address_to_redeemable_shares))
-    # unmatched boosted shares are still held by the user, so keep them out of redeemable
-    # amounts by treating them as kept.
-    for allocator in allocators:
-        kept_shares[allocator.address] = Wei(
-            kept_shares[allocator.address] + allocator.residual_boosted_shares
-        )
+def _build_api_client(api_config: ApiConfig) -> APIClient | None:
+    # rabby doesnt support hoodi so skip api call
+    if settings.network not in API_SUPPORTED_CHAINS:
+        return None
+    return APIClient(api_config)
 
-    os_token_positions = create_os_token_positions(allocators, kept_shares, min_redeemable_shares)
-    if not os_token_positions:
-        logger.info('No redeemable os token positions to upload, exiting...')
-        return
+
+async def _publish_positions(os_token_positions: list[OsTokenPosition]) -> None:
     total_redeemable = sum(p.leaf_shares for p in os_token_positions)
     logger.info(
         'Created %(count)s redeemable os token positions. '
@@ -299,53 +327,47 @@ async def process(
     click.echo(f'Redeemable os token positions uploaded to IPFS: hash={ipfs_hash}')
 
 
-# pylint: disable-next=too-many-locals
-async def get_kept_shares(
-    address_to_redeemable_shares: dict[ChecksumAddress, Wei],
+async def populate_kept_shares(
+    allocators: list[Allocator],
     block_number: BlockNumber,
-    api_config: ApiConfig,
-) -> dict[ChecksumAddress, Wei]:
-    kept_shares = defaultdict(lambda: Wei(0))
+    api_client: APIClient | None,
+) -> None:
+    """Sets ``wallet_shares`` for every allocator, then ``locked_shares`` via the API — but only
+    for allocators whose wallet balance doesn't already cover their redeemable amount, and only
+    when the network is API-supported."""
     logger.info(
         'Fetching %s balances from the subgraph...', settings.network_config.OS_TOKEN_BALANCE_SYMBOL
     )
     os_token_holders = await graph_get_os_token_holders(block_number)
-    for address in address_to_redeemable_shares.keys():
-        kept_shares[address] = os_token_holders.get(address, Wei(0))
+    for allocator in allocators:
+        allocator.wallet_shares = os_token_holders.get(allocator.address, Wei(0))
 
-    # rabby doesnt support hoodi so skip api call
-    if settings.network not in API_SUPPORTED_CHAINS:
-        return kept_shares
+    if api_client is None:
+        return
 
     # do not fetch data from api if all os token are in the wallet
-    api_addresses = []
-    for address in address_to_redeemable_shares.keys():
-        if address_to_redeemable_shares[address] >= kept_shares[address]:
-            api_addresses.append(address)
-
-    if not api_addresses:
-        return kept_shares
+    api_allocators = [a for a in allocators if a.total_redeemable_shares >= a.wallet_shares]
+    if not api_allocators:
+        return
 
     logger.info(
         'Fetching locked %s from %s API for %s addresses...',
         settings.network_config.OS_TOKEN_BALANCE_SYMBOL,
-        api_config.source,
-        len(api_addresses),
+        api_client.source,
+        len(api_allocators),
     )
-    api_client = APIClient(api_source=api_config.source, api_access_key=api_config.access_key)
-    # fetch locked os token from the api
     with click.progressbar(
-        api_addresses,
+        api_allocators,
         label='Fetching os token amount locked in protocols from the api:\t\t',
         show_percent=False,
         show_pos=True,
     ) as progress_bar:
-        for index, address in enumerate(progress_bar):
+        for index, allocator in enumerate(progress_bar):
             if index:
-                await asyncio.sleep(api_config.sleep_timeout)  # to avoid rate limiting
-            locked_os_token = await api_client.get_protocols_locked_os_token(address=address)
-            kept_shares[address] = Wei(kept_shares[address] + locked_os_token)
-    return kept_shares
+                await asyncio.sleep(api_client.sleep_timeout)  # to avoid rate limiting
+            allocator.locked_shares = await api_client.get_protocols_locked_os_token(
+                address=allocator.address
+            )
 
 
 async def calculate_boost_os_token_shares(
@@ -356,9 +378,6 @@ async def calculate_boost_os_token_shares(
     boosted_positions: defaultdict[tuple[ChecksumAddress, ChecksumAddress], Wei] = defaultdict(
         lambda: Wei(0)
     )
-    if not leverage_positions:
-        return boosted_positions
-
     for position in leverage_positions:
         if position.user not in users:
             continue
@@ -377,45 +396,22 @@ async def calculate_boost_os_token_shares(
 
 def create_os_token_positions(
     allocators: list[Allocator],
-    kept_shares: dict[ChecksumAddress, Wei],
     min_redeemable_shares: Wei,
 ) -> list[OsTokenPosition]:
     """
-    Calculate vault proportions and create redeemable os token positions.
-    Sort by ltv descending, then amount descending.
+    Split each allocator's redeemable shares across its vaults and sort the resulting
+    positions by ltv descending, then amount descending.
     """
-    os_token_positions: list[OsTokenPosition] = []
-    position_ltv: dict[tuple[ChecksumAddress, ChecksumAddress], float] = {}
-    for allocator in allocators:
-        allocator_kept_shares = kept_shares.get(allocator.address, Wei(0))
-        redeemable_amount = max(0, allocator.total_redeemable_shares - allocator_kept_shares)
-        if redeemable_amount == 0:
-            continue
-
-        vault_ltv = {p.address: p.ltv for p in allocator.vault_os_token_positions}
-        allocated_amount = 0
-        vaults_proportions = allocator.vaults_proportions.items()
-        for index, (vault_address, proportion) in enumerate(vaults_proportions):
-            # dust handling
-            if index == len(vaults_proportions) - 1:
-                vault_amount = max(0, int(redeemable_amount - allocated_amount))
-            else:
-                vault_amount = int(redeemable_amount * proportion)
-            allocated_amount += vault_amount
-            if vault_amount < min_redeemable_shares:
-                continue
-            os_token_positions.append(
-                OsTokenPosition(
-                    owner=allocator.address,
-                    vault=vault_address,
-                    leaf_shares=Wei(vault_amount),
-                )
-            )
-            position_ltv[allocator.address, vault_address] = vault_ltv[vault_address]
-    os_token_positions.sort(
-        key=lambda p: (position_ltv[p.owner, p.vault], p.leaf_shares), reverse=True
-    )
-    return os_token_positions
+    slices = [
+        (vault_position.ltv, vault_amount, allocator.address, vault_position.address)
+        for allocator in allocators
+        for vault_position, vault_amount in allocator.iter_vault_slices(min_redeemable_shares)
+    ]
+    slices.sort(key=lambda s: (s[0], s[1]), reverse=True)
+    return [
+        OsTokenPosition(owner=owner, vault=vault, leaf_shares=vault_amount)
+        for _, vault_amount, owner, vault in slices
+    ]
 
 
 def _save_positions_to_file(positions_payload: list[dict]) -> Path:

--- a/src/redemptions/tests/test_api_client.py
+++ b/src/redemptions/tests/test_api_client.py
@@ -7,16 +7,19 @@ from web3.types import Wei
 
 from src.config.networks import MAINNET
 from src.config.settings import settings
-from src.redemptions.api_client import APIClient
+from src.redemptions.api_client import API_SLEEP_TIMEOUT, RABBY_API_SOURCE, APIClient
+from src.redemptions.typings import ApiConfig
+
+DEFAULT_API_CONFIG = ApiConfig(source=RABBY_API_SOURCE, sleep_timeout=API_SLEEP_TIMEOUT)
 
 
 class TestAPIClient:
     @pytest.mark.usefixtures('fake_settings')
     async def test_zero_when_no_protocol_data(self):
-        client = APIClient()
         with patch.object(settings, 'network', MAINNET), patch(
             'src.redemptions.api_client.APIClient._fetch_json', return_value=[]
         ):
+            client = APIClient(DEFAULT_API_CONFIG)
             result = await client.get_protocols_locked_os_token(
                 Web3.to_checksum_address('0x1234567890abcdef1234567890abcdef12345678')
             )
@@ -84,7 +87,7 @@ class TestAPIClient:
             'OS_TOKEN_CONTRACT_ADDRESS',
             '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38',
         ):
-            client = APIClient()
+            client = APIClient(DEFAULT_API_CONFIG)
             result = await client.get_protocols_locked_os_token(
                 Web3.to_checksum_address('0x1234567890abcdef1234567890abcdef12345678')
             )
@@ -101,7 +104,7 @@ class TestAPIClient:
             'OS_TOKEN_CONTRACT_ADDRESS',
             '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38',
         ):
-            client = APIClient()
+            client = APIClient(DEFAULT_API_CONFIG)
             result = await client.get_protocols_locked_os_token(
                 Web3.to_checksum_address('0x1234567890abcdef1234567890abcdef12345678')
             )
@@ -118,7 +121,7 @@ class TestAPIClient:
             'OS_TOKEN_CONTRACT_ADDRESS',
             '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38',
         ):
-            client = APIClient()
+            client = APIClient(DEFAULT_API_CONFIG)
             result = await client.get_protocols_locked_os_token(
                 Web3.to_checksum_address('0x1234567890abcdef1234567890abcdef12345678')
             )

--- a/src/redemptions/tests/test_typings.py
+++ b/src/redemptions/tests/test_typings.py
@@ -73,7 +73,7 @@ class TestAllocator:
 
         slices = list(allocator.iter_vault_slices(Wei(0)))
 
-        assert [(p.address, amount) for p, amount in slices] == [
+        assert [(s.vault_position.address, s.amount) for s in slices] == [
             (vault_1, Wei(299)),
             (vault_2, Wei(600)),
         ]
@@ -93,7 +93,7 @@ class TestAllocator:
 
         slices = list(allocator.iter_vault_slices(Wei(15)))
 
-        assert [(p.address, amount) for p, amount in slices] == [(vault_2, Wei(990))]
+        assert [(s.vault_position.address, s.amount) for s in slices] == [(vault_2, Wei(990))]
 
     def test_iter_vault_slices_yields_nothing_when_fully_kept(self) -> None:
         vault = Web3.to_checksum_address(faker.eth_address())

--- a/src/redemptions/tests/test_typings.py
+++ b/src/redemptions/tests/test_typings.py
@@ -1,7 +1,9 @@
 from sw_utils.tests import faker
+from web3 import Web3
+from web3.types import Wei
 
 from src.redemptions.tests.factories import make_position
-from src.redemptions.typings import OsTokenPosition
+from src.redemptions.typings import Allocator, OsTokenPosition, VaultOsTokenPosition
 
 
 class TestOsTokenPositionCodec:
@@ -31,3 +33,76 @@ class TestOsTokenPositionCodec:
 
         assert restored.owner == owner
         assert restored.vault == vault
+
+
+class TestAllocator:
+    def test_kept_shares_sums_wallet_locked_and_residual(self) -> None:
+        allocator = Allocator(
+            address=Web3.to_checksum_address(faker.eth_address()),
+            vault_os_token_positions=[],
+            residual_boosted_shares=Wei(10),
+            wallet_shares=Wei(20),
+            locked_shares=Wei(30),
+        )
+
+        assert allocator.kept_shares == Wei(60)
+
+    def test_redeemable_shares_floors_at_zero(self) -> None:
+        vault = Web3.to_checksum_address(faker.eth_address())
+        allocator = Allocator(
+            address=Web3.to_checksum_address(faker.eth_address()),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault, minted_shares=Wei(100), ltv=0.5),
+            ],
+            wallet_shares=Wei(150),
+        )
+
+        assert allocator.redeemable_shares == Wei(0)
+
+    def test_iter_vault_slices_splits_proportionally_with_dust_on_last_vault(self) -> None:
+        vault_1 = Web3.to_checksum_address(faker.eth_address())
+        vault_2 = Web3.to_checksum_address(faker.eth_address())
+        allocator = Allocator(
+            address=Web3.to_checksum_address(faker.eth_address()),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault_1, minted_shares=Wei(333), ltv=0.5),
+                VaultOsTokenPosition(address=vault_2, minted_shares=Wei(666), ltv=0.5),
+            ],
+            wallet_shares=Wei(100),
+        )
+
+        slices = list(allocator.iter_vault_slices(Wei(0)))
+
+        assert [(p.address, amount) for p, amount in slices] == [
+            (vault_1, Wei(299)),
+            (vault_2, Wei(600)),
+        ]
+
+    def test_iter_vault_slices_drops_slices_below_minimum_but_keeps_them_in_dust_calc(
+        self,
+    ) -> None:
+        vault_1 = Web3.to_checksum_address(faker.eth_address())
+        vault_2 = Web3.to_checksum_address(faker.eth_address())
+        allocator = Allocator(
+            address=Web3.to_checksum_address(faker.eth_address()),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault_1, minted_shares=Wei(10), ltv=0.5),
+                VaultOsTokenPosition(address=vault_2, minted_shares=Wei(990), ltv=0.5),
+            ],
+        )
+
+        slices = list(allocator.iter_vault_slices(Wei(15)))
+
+        assert [(p.address, amount) for p, amount in slices] == [(vault_2, Wei(990))]
+
+    def test_iter_vault_slices_yields_nothing_when_fully_kept(self) -> None:
+        vault = Web3.to_checksum_address(faker.eth_address())
+        allocator = Allocator(
+            address=Web3.to_checksum_address(faker.eth_address()),
+            vault_os_token_positions=[
+                VaultOsTokenPosition(address=vault, minted_shares=Wei(100), ltv=0.5),
+            ],
+            wallet_shares=Wei(100),
+        )
+
+        assert not list(allocator.iter_vault_slices(Wei(0)))

--- a/src/redemptions/typings.py
+++ b/src/redemptions/typings.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 from eth_typing import ChecksumAddress, HexStr
@@ -27,20 +28,48 @@ class Allocator:
     vault_os_token_positions: list[VaultOsTokenPosition]
     # boosted shares that couldn't be matched against a same-vault mint
     residual_boosted_shares: Wei = Wei(0)
+    # osToken balance held in the owner's wallet, from the subgraph
+    wallet_shares: Wei = Wei(0)
+    # osToken locked in third-party protocols (Rabby/DeBank), from the API
+    locked_shares: Wei = Wei(0)
 
     @property
     def total_redeemable_shares(self) -> Wei:
         return Wei(sum(s.redeemable_shares for s in self.vault_os_token_positions))
 
     @property
-    def vaults_proportions(self) -> dict[ChecksumAddress, float]:
-        total = self.total_redeemable_shares
-        if total == 0:
-            return {}
-        return {s.address: s.redeemable_shares / total for s in self.vault_os_token_positions}
+    def kept_shares(self) -> Wei:
+        return Wei(self.wallet_shares + self.locked_shares + self.residual_boosted_shares)
+
+    @property
+    def redeemable_shares(self) -> Wei:
+        return Wei(max(0, self.total_redeemable_shares - self.kept_shares))
 
     def get_vault_position(self, vault: ChecksumAddress) -> VaultOsTokenPosition | None:
         return next((vs for vs in self.vault_os_token_positions if vs.address == vault), None)
+
+    def iter_vault_slices(self, min_shares: Wei) -> Iterator[tuple[VaultOsTokenPosition, Wei]]:
+        """
+        Split ``redeemable_shares`` across vaults proportionally to each vault's (post-boost)
+        redeemable share of the total. The last vault absorbs the rounding dust. Slices below
+        ``min_shares`` are dropped, but still count towards the running allocated total so the
+        dust rule stays exact.
+        """
+        redeemable_amount = self.redeemable_shares
+        if redeemable_amount == 0:
+            return
+        total = self.total_redeemable_shares
+        allocated_amount = 0
+        positions = self.vault_os_token_positions
+        for index, position in enumerate(positions):
+            if index == len(positions) - 1:
+                vault_amount = max(0, int(redeemable_amount - allocated_amount))
+            else:
+                vault_amount = int(redeemable_amount * (position.redeemable_shares / total))
+            allocated_amount += vault_amount
+            if vault_amount < min_shares:
+                continue
+            yield position, Wei(vault_amount)
 
 
 @dataclass

--- a/src/redemptions/typings.py
+++ b/src/redemptions/typings.py
@@ -48,7 +48,7 @@ class Allocator:
     def get_vault_position(self, vault: ChecksumAddress) -> VaultOsTokenPosition | None:
         return next((vs for vs in self.vault_os_token_positions if vs.address == vault), None)
 
-    def iter_vault_slices(self, min_shares: Wei) -> Iterator[tuple[VaultOsTokenPosition, Wei]]:
+    def iter_vault_slices(self, min_shares: Wei) -> Iterator['VaultSlice']:
         """
         Split ``redeemable_shares`` across vaults proportionally to each vault's (post-boost)
         redeemable share of the total. The last vault absorbs the rounding dust. Slices below
@@ -69,7 +69,14 @@ class Allocator:
             allocated_amount += vault_amount
             if vault_amount < min_shares:
                 continue
-            yield position, Wei(vault_amount)
+            yield VaultSlice(allocator=self, vault_position=position, amount=Wei(vault_amount))
+
+
+@dataclass(frozen=True)
+class VaultSlice:
+    allocator: Allocator
+    vault_position: VaultOsTokenPosition
+    amount: Wei
 
 
 @dataclass


### PR DESCRIPTION
## Description

- `Allocator` owns all per-owner state: new `wallet_shares` / `locked_shares` fields, `kept_shares` and `redeemable_shares` properties, and `iter_vault_slices()` holding the proportional split and dust rule (logic unchanged).
- `process()` in `update-redeemable-positions` is split into named steps; the `kept_shares` dict and the `position_ltv` side dict are gone.
- `APIClient` takes `ApiConfig` and resolves the chain in the constructor; it is built once per run.
- Drop the dead empty-list guard in `calculate_boost_os_token_shares`.
- Allocators left without vault positions after the min-shares filter are dropped before the kept-shares lookup, so they no longer trigger a Rabby/DeBank call.