### PR TITLE
Process redeemer cleanups

### DIFF
--- a/src/redemptions/api_client.py
+++ b/src/redemptions/api_client.py
@@ -42,7 +42,7 @@ class APIClient:
         self.api_chain = api_chain
 
     @classmethod
-    def for_network(cls, api_config: ApiConfig) -> 'APIClient | None':
+    def build_client(cls, api_config: ApiConfig) -> 'APIClient | None':
         # rabby doesnt support hoodi so skip api call
         if settings.network not in API_SUPPORTED_CHAINS:
             return None

--- a/src/redemptions/api_client.py
+++ b/src/redemptions/api_client.py
@@ -41,6 +41,13 @@ class APIClient:
         self.sleep_timeout = api_config.sleep_timeout
         self.api_chain = api_chain
 
+    @classmethod
+    def for_network(cls, api_config: ApiConfig) -> 'APIClient | None':
+        # rabby doesnt support hoodi so skip api call
+        if settings.network not in API_SUPPORTED_CHAINS:
+            return None
+        return cls(api_config)
+
     async def get_protocols_locked_os_token(self, address: ChecksumAddress) -> Wei:
         url = urljoin(self.base_url, 'v1/user/complex_protocol_list')
         params = {

--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -324,7 +324,6 @@ async def redeem_positions(
     for position in os_token_positions:
         logger.info('Processing position index=%d', position.index)
         shares_to_redeem = position.shares_to_redeem
-        assets_to_redeem = converter.to_assets(shares_to_redeem)
 
         if await is_meta_vault(position.vault):
             logger.warning(

--- a/src/redemptions/commands/process_redeemer.py
+++ b/src/redemptions/commands/process_redeemer.py
@@ -184,9 +184,7 @@ async def main(
     try:
         with InterruptHandler() as interrupt_handler:
             while not interrupt_handler.exit:
-                block_number = await execution_client.eth.block_number
                 await process(
-                    block_number=block_number,
                     min_queued_assets=min_queued_assets,
                     dry_run=dry_run,
                 )
@@ -197,7 +195,6 @@ async def main(
 
 
 async def process(
-    block_number: BlockNumber,
     min_queued_assets: Gwei,
     dry_run: bool = False,
 ) -> None:
@@ -310,13 +307,16 @@ async def redeem_positions(
     block_number: BlockNumber,
     dry_run: bool = False,
 ) -> None:
-    """Redeem positions one by one. Each position's shares_to_redeem is already set by
-    assign_shares_to_redeem; this function further caps it by the vault's withdrawable assets.
+    """Redeem positions one by one, applying skips and caps on top of the shares_to_redeem
+    already assigned by assign_shares_to_redeem:
 
-    Meta-vault positions are skipped entirely. Vaults whose on-chain state is
-    stale (unharvested) are skipped, since their withdrawable assets would be
-    outdated. A position that fails to simulate or submit is skipped, so the
-    remaining positions are still processed.
+    - Meta-vault positions are skipped (unexpected; logged as a warning).
+    - Positions on a vault already marked unharvested this round are skipped.
+    - A live position with LTV > 1 is skipped.
+    - shares_to_redeem is capped by the owner's live minted shares.
+    - A vault requiring a state update is marked unharvested and its positions skipped.
+    - shares_to_redeem is capped by the vault's remaining withdrawable assets.
+    - A position that fails to simulate or submit is skipped; the rest continue.
     """
     vault_to_withdrawable: dict[ChecksumAddress, Wei] = {}
     unharvested_vaults: set[ChecksumAddress] = set()

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -4,7 +4,7 @@ from typing import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from eth_typing import BlockNumber, ChecksumAddress
+from eth_typing import BlockNumber
 from sw_utils.tests import faker
 from web3 import Web3
 from web3.types import Gwei, Wei
@@ -14,8 +14,8 @@ from src.redemptions.commands.process_redeemer import (
     process,
     redeem_positions,
 )
-from src.redemptions.merkle_tree import PositionsMerkleTree
 from src.redemptions.os_token_converter import OsTokenConverter
+from src.redemptions.tests.factories import make_position, make_tree
 from src.redemptions.typings import OsTokenPosition, VaultOsTokenPosition
 
 MODULE = 'src.redemptions.commands.process_redeemer'
@@ -80,8 +80,8 @@ class TestRedeemPositions:
 
     async def test_multiple_positions_share_vault_cache(self) -> None:
         """Withdrawable is fetched once per vault, decremented after each redemption."""
-        pos1 = make_position(owner=OWNER_1, processed_shares=500)
-        pos2 = make_position(owner=OWNER_2, processed_shares=0)
+        pos1 = make_position(vault=VAULT_1, owner=OWNER_1, processed_shares=500)
+        pos2 = make_position(vault=VAULT_1, owner=OWNER_2, processed_shares=0)
 
         get_withdrawable = AsyncMock(return_value=Wei(700))
         with _mock_redeem_positions(withdrawable=get_withdrawable) as mocks:
@@ -499,41 +499,3 @@ def _mock_process(
 
 def make_converter(total_assets: int = 110, total_shares: int = 100) -> OsTokenConverter:
     return OsTokenConverter(Wei(total_assets), Wei(total_shares))
-
-
-def make_tree(
-    positions: list[OsTokenPosition] | None = None, nonce: int = 5
-) -> PositionsMerkleTree:
-    """Build a positions merkle tree. Defaults to a single position so callers that
-    only need a valid tree (e.g. when tx_redeem_position is mocked) can omit it."""
-    return PositionsMerkleTree(positions or [make_position()], leaf_nonce=nonce)
-
-
-def make_position(
-    vault: ChecksumAddress = VAULT_1,
-    owner: ChecksumAddress = OWNER_1,
-    leaf_shares: int = 1000,
-    processed_shares: int = 500,
-    shares_to_redeem: int | None = None,
-) -> OsTokenPosition:
-    """Build a test position.
-
-    ``processed_shares`` defaults to half of ``leaf_shares`` so redemption-loop
-    tests don't silently no-op when a caller forgets to set it.
-
-    ``shares_to_redeem`` defaults to ``leaf_shares - processed_shares``
-    (i.e. unprocessed shares), mirroring what ``assign_shares_to_redeem`` would set
-    before handing positions to ``redeem_positions``.  Pass an explicit value
-    when testing the partial-fill or zero-withdrawable edge cases.
-    """
-    effective_shares_to_redeem = (
-        shares_to_redeem if shares_to_redeem is not None else leaf_shares - processed_shares
-    )
-    return OsTokenPosition(
-        vault=vault,
-        owner=owner,
-        leaf_shares=Wei(leaf_shares),
-        index=0,
-        processed_shares=Wei(processed_shares),
-        shares_to_redeem=Wei(effective_shares_to_redeem),
-    )

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -266,13 +266,13 @@ class TestProcess:
     async def test_no_queued_shares(self) -> None:
         with _mock_process() as mocks:
             mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(0))
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(1))
+            await process(min_queued_assets=Gwei(1))
 
     async def test_below_threshold(self) -> None:
         with _mock_process() as mocks:
             # 500 wei queued shares, threshold is 1000 Gwei
             mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(500))
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(1000))
+            await process(min_queued_assets=Gwei(1000))
             mocks['mock_redeem'].assert_not_called()
 
     async def test_gas_price_check_fails(self) -> None:
@@ -281,7 +281,7 @@ class TestProcess:
             _mock_process() as mocks,
             patch(f'{MODULE}.check_gas_price', new=AsyncMock(return_value=False)),
         ):
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+            await process(min_queued_assets=Gwei(0))
         mocks['mock_redeemer'].queued_shares.assert_not_called()
         mocks['mock_redeem'].assert_not_called()
 
@@ -290,7 +290,7 @@ class TestProcess:
         with _mock_process() as mocks:
             mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(1000))
             mocks['mock_redeemer'].nonce = AsyncMock(return_value=0)
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+            await process(min_queued_assets=Gwei(0))
         mocks['mock_redeem'].assert_not_called()
 
     async def test_no_positions_from_ipfs(self) -> None:
@@ -298,7 +298,7 @@ class TestProcess:
         with _mock_process(positions=[]) as mocks:
             mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(1000))
             mocks['mock_redeemer'].nonce = AsyncMock(return_value=5)
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+            await process(min_queued_assets=Gwei(0))
         mocks['mock_redeem'].assert_not_called()
 
     async def test_no_eligible_positions(self) -> None:
@@ -310,7 +310,7 @@ class TestProcess:
         ):
             mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(1000))
             mocks['mock_redeemer'].nonce = AsyncMock(return_value=5)
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+            await process(min_queued_assets=Gwei(0))
         mocks['mock_redeem'].assert_not_called()
 
     async def test_successful_redemption(self) -> None:
@@ -320,7 +320,7 @@ class TestProcess:
             mocks['mock_redeemer'].queued_shares = AsyncMock(return_value=Wei(1000))
             mocks['mock_redeemer'].nonce = AsyncMock(return_value=5)
 
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+            await process(min_queued_assets=Gwei(0))
 
         mocks['mock_redeem'].assert_awaited_once()
         redeem_call = mocks['mock_redeem'].await_args
@@ -337,7 +337,7 @@ class TestProcess:
             mocks['mock_redeemer'].nonce = AsyncMock(return_value=5)
             mocks['mock_update_state'].return_value = False
 
-            await process(block_number=BlockNumber(100), min_queued_assets=Gwei(0))
+            await process(min_queued_assets=Gwei(0))
 
         mocks['mock_update_state'].assert_awaited_once()
         mocks['mock_redeem'].assert_not_awaited()

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -30,7 +30,6 @@ from src.config.settings import settings
 from src.redemptions.api_client import (
     API_SLEEP_TIMEOUT,
     API_SOURCES,
-    API_SUPPORTED_CHAINS,
     DEBANK_API_SOURCE,
     RABBY_API_SOURCE,
     APIClient,
@@ -238,7 +237,7 @@ async def process(
         return
 
     logger.info('Fetching kept tokens for %s addresses', len(allocators))
-    api_client = _build_api_client(api_config)
+    api_client = APIClient.for_network(api_config)
     await populate_kept_shares(allocators, block_number, api_client)
     logger.info('Fetched kept tokens for %s addresses...', len(allocators))
 
@@ -299,13 +298,6 @@ def _filter_min_redeemable_shares(
         allocator.vault_os_token_positions = vault_os_token_positions
         result.append(allocator)
     return result
-
-
-def _build_api_client(api_config: ApiConfig) -> APIClient | None:
-    # rabby doesnt support hoodi so skip api call
-    if settings.network not in API_SUPPORTED_CHAINS:
-        return None
-    return APIClient(api_config)
 
 
 async def _publish_positions(os_token_positions: list[OsTokenPosition]) -> None:

--- a/src/redemptions/commands/update_redeemable_positions.py
+++ b/src/redemptions/commands/update_redeemable_positions.py
@@ -237,7 +237,7 @@ async def process(
         return
 
     logger.info('Fetching kept tokens for %s addresses', len(allocators))
-    api_client = APIClient.for_network(api_config)
+    api_client = APIClient.build_client(api_config)
     await populate_kept_shares(allocators, block_number, api_client)
     logger.info('Fetched kept tokens for %s addresses...', len(allocators))
 

--- a/src/redemptions/contracts.py
+++ b/src/redemptions/contracts.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from web3 import Web3
 from web3.types import BlockNumber, ChecksumAddress, EventData, Wei
 
@@ -58,7 +60,7 @@ class OsTokenRedeemerContract(ContractWrapper, ErrorMixin):
         )
 
     async def multicall_leaf_to_processed_shares(
-        self, positions: list[OsTokenPosition], nonce: int, block_number: BlockNumber
+        self, positions: Sequence[OsTokenPosition], nonce: int, block_number: BlockNumber
     ) -> list[Wei]:
         calls = [
             self.encode_abi('leafToProcessedShares', [p.leaf_hash(nonce - 1)]) for p in positions

--- a/src/redemptions/fetch_positions.py
+++ b/src/redemptions/fetch_positions.py
@@ -1,6 +1,8 @@
 import asyncio
 import functools
 from collections.abc import AsyncIterator, Callable
+from dataclasses import replace
+from itertools import batched
 from typing import Any, cast
 
 import aioitertools
@@ -124,15 +126,7 @@ async def fetch_positions_with_processed_shares(
     async for position, processed_shares in aioitertools.zip(
         positions, cached_iter_processed_shares(positions, nonce, block_number)
     ):
-        enriched.append(
-            OsTokenPosition(
-                owner=position.owner,
-                vault=position.vault,
-                leaf_shares=position.leaf_shares,
-                index=position.index,
-                processed_shares=processed_shares,
-            )
-        )
+        enriched.append(replace(position, processed_shares=processed_shares))
     return enriched
 
 
@@ -169,8 +163,7 @@ async def iter_processed_shares(
 ) -> AsyncIterator[Wei]:
     """Fetch processed shares via batched multicalls, yielding one value per position.
     The generator flattens batch results so callers see a flat stream aligned with positions."""
-    for i in range(0, len(positions), OS_TOKEN_REDEEMER_CHUNK_SIZE):
-        batch = positions[i : i + OS_TOKEN_REDEEMER_CHUNK_SIZE]
+    for batch in batched(positions, OS_TOKEN_REDEEMER_CHUNK_SIZE):
         rpc_results = await os_token_redeemer_contract.multicall_leaf_to_processed_shares(
             batch, nonce, block_number
         )
@@ -189,8 +182,7 @@ async def iter_live_shares(
     # Calldata encoding depends only on the ABI, so one VaultContract instance can encode
     # calls for every vault.
     encoder = VaultContract(positions[0].vault)
-    for i in range(0, len(positions), OS_TOKEN_REDEEMER_CHUNK_SIZE):
-        batch = positions[i : i + OS_TOKEN_REDEEMER_CHUNK_SIZE]
+    for batch in batched(positions, OS_TOKEN_REDEEMER_CHUNK_SIZE):
         calls = [
             (position.vault, encoder.encode_abi('osTokenPositions', [position.owner]))
             for position in batch

--- a/src/redemptions/tasks.py
+++ b/src/redemptions/tasks.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 
 from eth_typing import BlockNumber, ChecksumAddress
 from sw_utils import OsTokenConverter
-from sw_utils.typings import ChainHead, ProtocolConfig
+from sw_utils.typings import ChainHead
 from web3.types import Wei
 
 from src.common.contracts import VaultContract
@@ -39,23 +39,6 @@ async def get_redemption_assets(chain_head: ChainHead) -> Wei:
     await update_positions_cache(finalized_block_number)
     await update_processed_shares_cache(finalized_block_number)
 
-    protocol_config = await get_protocol_config()
-    vault_to_redemption_assets = await get_vault_to_redemption_assets_direct(
-        chain_head=chain_head, nonce=nonce, protocol_config=protocol_config
-    )
-    return vault_to_redemption_assets[settings.vault]
-
-
-async def get_vault_to_redemption_assets_direct(
-    chain_head: ChainHead, nonce: int, protocol_config: ProtocolConfig
-) -> defaultdict[ChecksumAddress, Wei]:
-    """
-    Get redemption assets per vault, based only on assets directly assigned
-    to each vault in the IPFS redeemable positions file. Meta vault assets are
-    not yet distributed across their sub-vault tree.
-
-    For Gno networks return value is in GNO-Wei.
-    """
     queued_shares = await os_token_redeemer_contract.queued_shares(
         block_number=chain_head.block_number
     )
@@ -65,6 +48,7 @@ async def get_vault_to_redemption_assets_direct(
     # OsToken in-protocol rate may increase while vault assets are exiting.
     # Ensure sufficient assets are allocated for redemption by applying
     # a conservative APR adjustment.
+    protocol_config = await get_protocol_config()
     total_redemption_assets = Wei(
         int(total_redemption_assets * protocol_config.os_token_redeem_multiplier)
     )
@@ -75,7 +59,7 @@ async def get_vault_to_redemption_assets_direct(
         os_token_converter=os_token_converter,
         block_number=chain_head.block_number,
     )
-    return vault_to_redemption_assets
+    return vault_to_redemption_assets.get(settings.vault, Wei(0))
 
 
 async def aggregate_redemption_assets_by_vaults(
@@ -83,7 +67,7 @@ async def aggregate_redemption_assets_by_vaults(
     nonce: int,
     os_token_converter: OsTokenConverter,
     block_number: BlockNumber,
-) -> defaultdict[ChecksumAddress, Wei]:
+) -> dict[ChecksumAddress, Wei]:
     """
     Iterate through redeemable positions until the total redemption assets are exhausted.
     Aggregate shares_to_redeem by vault and convert to assets.
@@ -107,16 +91,15 @@ async def aggregate_redemption_assets_by_vaults(
     # Aggregate shares_to_redeem by vault
     vault_to_shares_to_redeem: defaultdict[ChecksumAddress, Wei] = defaultdict(lambda: Wei(0))
     for position in positions:
-        vault_to_shares_to_redeem[position.vault] += position.shares_to_redeem  # type: ignore
+        vault_to_shares_to_redeem[position.vault] = Wei(
+            vault_to_shares_to_redeem[position.vault] + position.shares_to_redeem
+        )
 
     # Convert shares to assets per vault
-    return defaultdict(
-        lambda: Wei(0),
-        {
-            vault: os_token_converter.to_assets(shares)
-            for vault, shares in vault_to_shares_to_redeem.items()
-        },
-    )
+    return {
+        vault: os_token_converter.to_assets(shares)
+        for vault, shares in vault_to_shares_to_redeem.items()
+    }
 
 
 async def get_vault_os_token_position(

--- a/src/redemptions/tests/factories.py
+++ b/src/redemptions/tests/factories.py
@@ -2,6 +2,7 @@ from eth_typing import ChecksumAddress, HexStr
 from sw_utils.tests import faker
 from web3.types import Wei
 
+from src.redemptions.merkle_tree import PositionsMerkleTree
 from src.redemptions.typings import OsTokenPosition, RedeemablePositions
 
 
@@ -22,13 +23,35 @@ def make_position(
     owner: ChecksumAddress | None = None,
     leaf_shares: int = 1000,
     processed_shares: int = 500,
-    shares_to_redeem: int = 0,
+    shares_to_redeem: int | None = None,
+    index: int = 0,
 ) -> OsTokenPosition:
+    """Build a test position.
+
+    ``processed_shares`` defaults to half of ``leaf_shares`` so redemption-loop
+    tests don't silently no-op when a caller forgets to set it.
+
+    ``shares_to_redeem`` defaults to ``leaf_shares - processed_shares``
+    (i.e. unprocessed shares), mirroring what ``assign_shares_to_redeem`` would set
+    before handing positions to ``redeem_positions``.  Pass an explicit value
+    when testing the partial-fill or zero-withdrawable edge cases.
+    """
+    effective_shares_to_redeem = (
+        shares_to_redeem if shares_to_redeem is not None else leaf_shares - processed_shares
+    )
     return OsTokenPosition(
         vault=vault if vault is not None else faker.eth_address(),
         owner=owner if owner is not None else faker.eth_address(),
         leaf_shares=Wei(leaf_shares),
-        index=0,
+        index=index,
         processed_shares=Wei(processed_shares),
-        shares_to_redeem=Wei(shares_to_redeem),
+        shares_to_redeem=Wei(effective_shares_to_redeem),
     )
+
+
+def make_tree(
+    positions: list[OsTokenPosition] | None = None, nonce: int = 5
+) -> PositionsMerkleTree:
+    """Build a positions merkle tree. Defaults to a single position so callers that
+    only need a valid tree (e.g. when tx_redeem_position is mocked) can omit it."""
+    return PositionsMerkleTree(positions or [make_position()], leaf_nonce=nonce)

--- a/src/redemptions/tests/test_api_client.py
+++ b/src/redemptions/tests/test_api_client.py
@@ -5,7 +5,7 @@ import pytest
 from web3 import Web3
 from web3.types import Wei
 
-from src.config.networks import MAINNET
+from src.config.networks import HOODI, MAINNET
 from src.config.settings import settings
 from src.redemptions.api_client import API_SLEEP_TIMEOUT, RABBY_API_SOURCE, APIClient
 from src.redemptions.typings import ApiConfig
@@ -24,6 +24,18 @@ class TestAPIClient:
                 Web3.to_checksum_address('0x1234567890abcdef1234567890abcdef12345678')
             )
         assert result == Wei(0)
+
+    @pytest.mark.usefixtures('fake_settings')
+    async def test_for_network_returns_none_on_unsupported_network(self):
+        with patch.object(settings, 'network', HOODI):
+            client = APIClient.for_network(DEFAULT_API_CONFIG)
+        assert client is None
+
+    @pytest.mark.usefixtures('fake_settings')
+    async def test_for_network_returns_instance_on_supported_network(self):
+        with patch.object(settings, 'network', MAINNET):
+            client = APIClient.for_network(DEFAULT_API_CONFIG)
+        assert isinstance(client, APIClient)
 
     @pytest.mark.usefixtures('fake_settings')
     async def test_excludes_stakewise_protocol_from_total(self):

--- a/src/redemptions/tests/test_api_client.py
+++ b/src/redemptions/tests/test_api_client.py
@@ -26,15 +26,15 @@ class TestAPIClient:
         assert result == Wei(0)
 
     @pytest.mark.usefixtures('fake_settings')
-    async def test_for_network_returns_none_on_unsupported_network(self):
+    async def test_build_client_returns_none_on_unsupported_network(self):
         with patch.object(settings, 'network', HOODI):
-            client = APIClient.for_network(DEFAULT_API_CONFIG)
+            client = APIClient.build_client(DEFAULT_API_CONFIG)
         assert client is None
 
     @pytest.mark.usefixtures('fake_settings')
-    async def test_for_network_returns_instance_on_supported_network(self):
+    async def test_build_client_returns_instance_on_supported_network(self):
         with patch.object(settings, 'network', MAINNET):
-            client = APIClient.for_network(DEFAULT_API_CONFIG)
+            client = APIClient.build_client(DEFAULT_API_CONFIG)
         assert isinstance(client, APIClient)
 
     @pytest.mark.usefixtures('fake_settings')

--- a/src/redemptions/tests/test_execution.py
+++ b/src/redemptions/tests/test_execution.py
@@ -3,11 +3,10 @@ from typing import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from eth_typing import BlockNumber, ChecksumAddress
+from eth_typing import BlockNumber
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.exceptions import ContractCustomError
-from web3.types import Wei
 
 from src.redemptions.execution import (
     simulate_redeem_position,
@@ -15,8 +14,7 @@ from src.redemptions.execution import (
     tx_redeem_position,
     update_vaults_state,
 )
-from src.redemptions.merkle_tree import PositionsMerkleTree
-from src.redemptions.typings import OsTokenPosition
+from src.redemptions.tests.factories import make_position, make_tree
 
 MODULE = 'src.redemptions.execution'
 
@@ -305,29 +303,3 @@ def _mock_simulate_redeem_position(
             'redeemer': mock_redeemer,
             'call': call_mock,
         }
-
-
-def make_tree(
-    positions: list[OsTokenPosition] | None = None, nonce: int = 5
-) -> PositionsMerkleTree:
-    return PositionsMerkleTree(positions or [make_position()], leaf_nonce=nonce)
-
-
-def make_position(
-    vault: ChecksumAddress = VAULT_1,
-    owner: ChecksumAddress = OWNER_1,
-    leaf_shares: int = 1000,
-    processed_shares: int = 500,
-    shares_to_redeem: int | None = None,
-) -> OsTokenPosition:
-    effective_shares_to_redeem = (
-        shares_to_redeem if shares_to_redeem is not None else leaf_shares - processed_shares
-    )
-    return OsTokenPosition(
-        vault=vault,
-        owner=owner,
-        leaf_shares=Wei(leaf_shares),
-        index=0,
-        processed_shares=Wei(processed_shares),
-        shares_to_redeem=Wei(effective_shares_to_redeem),
-    )

--- a/src/redemptions/tests/test_tasks.py
+++ b/src/redemptions/tests/test_tasks.py
@@ -184,7 +184,7 @@ class TestAggregateRedemptionAssetsByVaults:
                 block_number=BlockNumber(0),
             )
             assert len(redemption_assets_by_vaults) <= 1  # length can be 0 if no assets to redeem
-            assert redemption_assets_by_vaults[vault_1] == expected_redeemed_assets
+            assert redemption_assets_by_vaults.get(vault_1, Wei(0)) == expected_redeemed_assets
 
     @pytest.mark.parametrize(
         'total_redemption_assets, leaf_shares, processed_shares, expected_redeemed_assets',
@@ -257,10 +257,18 @@ class TestAggregateRedemptionAssetsByVaults:
             assert len(redemption_assets_by_vaults) <= 2
             # allow 1 wei difference due to rounding
             assert (
-                abs(redemption_assets_by_vaults[vault_1] - expected_redeemed_assets['vault_1']) <= 1
+                abs(
+                    redemption_assets_by_vaults.get(vault_1, Wei(0))
+                    - expected_redeemed_assets['vault_1']
+                )
+                <= 1
             )
             assert (
-                abs(redemption_assets_by_vaults[vault_2] - expected_redeemed_assets['vault_2']) <= 1
+                abs(
+                    redemption_assets_by_vaults.get(vault_2, Wei(0))
+                    - expected_redeemed_assets['vault_2']
+                )
+                <= 1
             )
 
     async def test_2_vaults_many_users(self):


### PR DESCRIPTION
## Description

- `redeem_positions` computed `assets_to_redeem` at the top of the loop but unconditionally recomputed it before the first use, after the live-position lookup. Removed the dead assignment.
- Moved the network gating for the Rabby/DeBank client into `APIClient.for_network`, replacing the `_build_api_client` helper in `update_redeemable_positions`.
- `fetch_positions`: chunk positions with `itertools.batched` instead of two hand-written slice loops; build enriched positions with `dataclasses.replace` instead of copying fields by hand.
- `get_redemption_assets`: inlined the single-use `get_vault_to_redemption_assets_direct` and made the missing-vault default explicit. `aggregate_redemption_assets_by_vaults` returns a plain dict and accumulates without `type: ignore`.
- `process_redeemer`: dropped the unused `block_number` parameter of `process()`; `redeem_positions` docstring now lists every skip/cap path.
- Tests: one shared `make_position` / `make_tree` in `redemptions/tests/factories.py` instead of three diverging copies.