### PR TITLE
Remove ipfs.io from IPFS fetch endpoints

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -330,8 +330,7 @@ class Settings(metaclass=Singleton):
         self.ipfs_fetch_endpoints = decouple_config(
             'IPFS_FETCH_ENDPOINTS',
             cast=Csv(),
-            default='https://stakewise.myfilebase.com,'
-            'https://stakewise-ipfs.quicknode-ipfs.com',
+            default='https://stakewise.myfilebase.com,https://stakewise-ipfs.quicknode-ipfs.com',
             group='IPFS',
             description='Comma separated IPFS gateways used to fetch oracle data.',
         )

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -330,8 +330,7 @@ class Settings(metaclass=Singleton):
         self.ipfs_fetch_endpoints = decouple_config(
             'IPFS_FETCH_ENDPOINTS',
             cast=Csv(),
-            default='https://ipfs.io,'
-            'https://stakewise.myfilebase.com,'
+            default='https://stakewise.myfilebase.com,'
             'https://stakewise-ipfs.quicknode-ipfs.com',
             group='IPFS',
             description='Comma separated IPFS gateways used to fetch oracle data.',


### PR DESCRIPTION
Shipyard announced they are shutting down their public IPFS services, including the `ipfs.io` gateway: https://ipshipyard.com/blog/2026-the-end-of-ipfs-at-shipyard/

Removes `https://ipfs.io` from the default `IPFS_FETCH_ENDPOINTS`. The remaining defaults are:

- `https://stakewise.myfilebase.com`
- `https://stakewise-ipfs.quicknode-ipfs.com`
