### PR TITLE
Scope remote-db keypairs by vault

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,9 +78,11 @@ CONSENSUS_ENDPOINTS=http://localhost:3500
 # FEE_SPLITTER_INTERVAL=86400
 # FEE_SPLITTER_MIN_ASSETS=1000000000000000
 
-# Disable new validator registrations and funding for registered validators.
-# Default is False
-# DISABLE_VALIDATOR_REGISTRATIONS=false
+# Disable registration of new validators. Default is False
+# DISABLE_VALIDATORS_REGISTRATION=false
+
+# Disable funding of existing 0x02 (compounding) validators. Default is False
+# DISABLE_VALIDATORS_FUNDING=false
 
 # Disable submitting validator withdrawals through the vault contract.
 # Default is False

--- a/src/remote_db/database.py
+++ b/src/remote_db/database.py
@@ -21,24 +21,27 @@ class KeyPairsCrud:
         return f'{settings.network}_keypairs'
 
     def get_keypairs_count(self) -> int:
-        """Returns the number of keypairs in the database."""
+        """Returns the number of keypairs in the database for the current vault."""
         with self.db_connection.cursor() as cur:
             cur.execute(
-                f'SELECT COUNT(*) FROM {self.table}',
+                f'SELECT COUNT(*) FROM {self.table} WHERE vault = %s',
+                (settings.vault,),
             )
             row = cur.fetchone()
             return row[0]
 
     def get_first_keypair(self) -> RemoteDatabaseKeyPair | None:
-        """Returns the first keypair in the database."""
+        """Returns the first keypair in the database for the current vault."""
         with self.db_connection.cursor() as cur:
             cur.execute(
                 f'''
                     SELECT public_key, private_key, nonce
                     FROM {self.table}
+                    WHERE vault = %s
                     ORDER BY public_key
                     LIMIT 1
                 ''',
+                (settings.vault,),
             )
             row = cur.fetchone()
             if row is None:
@@ -50,15 +53,16 @@ class KeyPairsCrud:
             )
 
     def get_keypairs(self) -> list[RemoteDatabaseKeyPair]:
-        """Returns keypairs from the database."""
-        params: dict = {}
+        """Returns keypairs from the database for the current vault."""
+        params: dict = {'vault': settings.vault}
 
         query = f'''
                 SELECT public_key, private_key, nonce
                 FROM {self.table}
+                WHERE vault = %(vault)s
         '''
 
-        query += 'ORDER BY public_key'
+        query += ' ORDER BY public_key'
 
         with self.db_connection.cursor() as cur:
             cur.execute(query, params)
@@ -74,9 +78,9 @@ class KeyPairsCrud:
         ]
 
     def remove_keypairs(self, in_public_keys: set[HexStr] | None = None) -> None:
-        """Removes keypairs from the database."""
-        where_list = []
-        params: dict = {}
+        """Removes keypairs from the database for the current vault."""
+        where_list = ['vault = %(vault)s']
+        params: dict = {'vault': settings.vault}
 
         if in_public_keys is not None:
             where_list.append('public_key IN %(in_public_keys)s')
@@ -85,18 +89,18 @@ class KeyPairsCrud:
         query = f'''
                 DELETE FROM {self.table}
         '''
-        if where_list:
-            query += f'WHERE {' AND '.join(where_list)}\n'
+        query += f'WHERE {' AND '.join(where_list)}\n'
 
         with self.db_connection.cursor() as cur:
             cur.execute(query, params)
 
     def upload_keypairs(self, keypairs: list[RemoteDatabaseKeyPair]) -> None:
-        """Uploads keypairs to the database."""
+        """Uploads keypairs to the database for the current vault."""
         with self.db_connection.cursor() as cur:
             cur.executemany(
                 f'''
                     INSERT INTO {self.table} (
+                        vault,
                         public_key,
                         private_key,
                         nonce
@@ -106,6 +110,7 @@ class KeyPairsCrud:
                 ''',
                 [
                     (
+                        settings.vault,
                         keypair.public_key,
                         keypair.private_key,
                         keypair.nonce,
@@ -120,12 +125,17 @@ class KeyPairsCrud:
             cur.execute(
                 f'''
                     CREATE TABLE IF NOT EXISTS {self.table} (
-                        public_key VARCHAR(98) UNIQUE NOT NULL,
-                        private_key VARCHAR(66) UNIQUE NOT NULL,
-                        nonce VARCHAR(34) UNIQUE NOT NULL
+                        vault VARCHAR(42) NOT NULL,
+                        public_key VARCHAR(98) NOT NULL,
+                        private_key VARCHAR(66) NOT NULL,
+                        nonce VARCHAR(34) NOT NULL,
+                        UNIQUE (vault, public_key)
                     )
                 '''
             )
+            # Upgrades a pre-existing V4-schema table (created without the
+            # vault column) so it can be scoped per vault; a no-op otherwise.
+            cur.execute(f'ALTER TABLE {self.table} ADD COLUMN IF NOT EXISTS vault VARCHAR(42)')
 
 
 def check_db_connection(db_url: str) -> None:

--- a/src/remote_db/tasks.py
+++ b/src/remote_db/tasks.py
@@ -99,6 +99,11 @@ def setup_web3signer(db_url: str, b64_encrypt_key: str, output_dir: Path) -> Non
     if not output_dir.exists():
         output_dir.mkdir(parents=True, exist_ok=True)
 
+    # Remove key files from a previous, larger export before writing the current set -
+    # otherwise Web3Signer would keep loading keys the operator believes were removed.
+    for filepath in output_dir.glob('key_*.yaml'):
+        filepath.unlink()
+
     sorted_private_keys = sorted(list(private_keys))
     for index, private_key in enumerate(sorted_private_keys):
         filename = f'key_{index}.yaml'

--- a/src/remote_db/tests/test_commands.py
+++ b/src/remote_db/tests/test_commands.py
@@ -199,6 +199,60 @@ class TestRemoteDbSetupWeb3Signer:
             output = 'Successfully retrieved web3signer private keys from the database.\n'
             assert output.strip() in result.output.strip()
 
+    def test_setup_web3signer_removes_stale_keys_on_shrink(
+        self,
+        data_dir: Path,
+        vault_address: HexAddress,
+        runner: CliRunner,
+        execution_endpoints: str,
+    ):
+        db_url = 'postgresql://user:password@localhost:5432/dbname'
+        encryption_key = '43ueY4nqsiajWHTnkdqrc3OWj2W+t0bbdBISJFjZ3Ck='
+
+        args = [
+            '--db-url',
+            db_url,
+            '--vault',
+            vault_address,
+            '--data-dir',
+            str(data_dir),
+            'setup-web3signer',
+            '--output-dir',
+            './web3signer',
+            '--encrypt-key',
+            encryption_key,
+        ]
+        keypairs = _get_remote_db_keypairs(base64.b64decode(encryption_key), total_validators=3)
+
+        with (
+            runner.isolated_filesystem(),
+            mock.patch.object(KeyPairsCrud, 'get_first_keypair', return_value=keypairs[0]),
+            mock.patch.object(KeyPairsCrud, 'get_keypairs', return_value=keypairs),
+        ):
+            result = runner.invoke(remote_db_group, args)
+            assert result.exit_code == 0
+
+            web3signer_dir = Path('./web3signer')
+            assert (web3signer_dir / 'key_0.yaml').exists()
+            assert (web3signer_dir / 'key_1.yaml').exists()
+            assert (web3signer_dir / 'key_2.yaml').exists()
+
+            other_filepath = web3signer_dir / 'other.txt'
+            other_filepath.write_text('unrelated file')
+
+            with (
+                mock.patch.object(KeyPairsCrud, 'get_first_keypair', return_value=keypairs[0]),
+                mock.patch.object(KeyPairsCrud, 'get_keypairs', return_value=keypairs[:1]),
+            ):
+                result = runner.invoke(remote_db_group, args)
+                assert result.exit_code == 0
+
+            assert (web3signer_dir / 'key_0.yaml').exists()
+            assert not (web3signer_dir / 'key_1.yaml').exists()
+            assert not (web3signer_dir / 'key_2.yaml').exists()
+            assert sorted(web3signer_dir.glob('key_*.yaml')) == [web3signer_dir / 'key_0.yaml']
+            assert other_filepath.exists()
+
 
 @pytest.mark.usefixtures(
     '_patch_check_db_connection',

--- a/src/remote_db/tests/test_database.py
+++ b/src/remote_db/tests/test_database.py
@@ -1,0 +1,157 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+from eth_typing import HexAddress
+
+from src.config.networks import HOODI
+from src.config.settings import settings
+from src.remote_db.database import KeyPairsCrud
+from src.remote_db.typings import RemoteDatabaseKeyPair
+
+
+class _FakeCursor:
+    def __init__(self, fetchone_result: Any = None, fetchall_result: Any = None) -> None:
+        self.fetchone_result = fetchone_result
+        self.fetchall_result = fetchall_result
+        self.executed_sql: str | None = None
+        self.executed_params: Any = None
+        self.executemany_sql: str | None = None
+        self.executemany_params: list[tuple] | None = None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed_sql = sql
+        self.executed_params = params
+
+    def executemany(self, sql: str, params_seq: list[tuple]) -> None:
+        self.executemany_sql = sql
+        self.executemany_params = params_seq
+
+    def fetchone(self) -> Any:
+        return self.fetchone_result
+
+    def fetchall(self) -> Any:
+        return self.fetchall_result
+
+    def __enter__(self) -> '_FakeCursor':
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+
+@pytest.fixture
+def _init_settings(vault_address: HexAddress, data_dir: Path) -> None:
+    settings.set(vault=vault_address, vault_dir=data_dir / 'vault', network=HOODI)
+
+
+@pytest.mark.usefixtures('_init_settings')
+class TestKeyPairsCrud:
+    def test_get_keypairs_count_is_vault_scoped(self, vault_address: HexAddress):
+        cursor = _FakeCursor(fetchone_result=(0,))
+        crud = KeyPairsCrud(db_connection=_FakeConnection(cursor))
+
+        crud.get_keypairs_count()
+
+        assert 'WHERE vault = %s' in cursor.executed_sql
+        assert cursor.executed_params == (vault_address,)
+
+    def test_get_first_keypair_is_vault_scoped(self, vault_address: HexAddress):
+        cursor = _FakeCursor(fetchone_result=None)
+        crud = KeyPairsCrud(db_connection=_FakeConnection(cursor))
+
+        crud.get_first_keypair()
+
+        assert 'WHERE vault = %s' in cursor.executed_sql
+        assert cursor.executed_params == (vault_address,)
+
+    def test_get_keypairs_is_vault_scoped(self, vault_address: HexAddress):
+        cursor = _FakeCursor(fetchall_result=[])
+        crud = KeyPairsCrud(db_connection=_FakeConnection(cursor))
+
+        crud.get_keypairs()
+
+        assert 'WHERE vault = %(vault)s' in cursor.executed_sql
+        assert 'ORDER BY public_key' in cursor.executed_sql
+        assert cursor.executed_params == {'vault': vault_address}
+
+    def test_remove_keypairs_without_args_is_vault_scoped(self, vault_address: HexAddress):
+        cursor = _FakeCursor()
+        crud = KeyPairsCrud(db_connection=_FakeConnection(cursor))
+
+        crud.remove_keypairs()
+
+        assert 'WHERE vault = %(vault)s' in cursor.executed_sql
+        assert 'DELETE FROM' in cursor.executed_sql
+        assert cursor.executed_params == {'vault': vault_address}
+
+    def test_remove_keypairs_with_public_keys_is_vault_scoped(self, vault_address: HexAddress):
+        cursor = _FakeCursor()
+        crud = KeyPairsCrud(db_connection=_FakeConnection(cursor))
+
+        crud.remove_keypairs(in_public_keys={'0x1'})
+
+        assert 'vault = %(vault)s' in cursor.executed_sql
+        assert 'public_key IN %(in_public_keys)s' in cursor.executed_sql
+        assert cursor.executed_params['vault'] == vault_address
+        assert cursor.executed_params['in_public_keys'] == ('0x1',)
+
+    def test_upload_keypairs_arity_and_vault_scoping(self, vault_address: HexAddress):
+        cursor = _FakeCursor()
+        crud = KeyPairsCrud(db_connection=_FakeConnection(cursor))
+        keypairs = [
+            RemoteDatabaseKeyPair(public_key='0xpub1', private_key='0xpriv1', nonce='0xnonce1'),
+            RemoteDatabaseKeyPair(public_key='0xpub2', private_key='0xpriv2', nonce='0xnonce2'),
+        ]
+
+        crud.upload_keypairs(keypairs)
+
+        assert cursor.executemany_sql.count('%s') == 4
+        assert 'vault' in cursor.executemany_sql
+        assert 'public_key' in cursor.executemany_sql
+        assert 'private_key' in cursor.executemany_sql
+        assert 'nonce' in cursor.executemany_sql
+
+        assert cursor.executemany_params is not None
+        for param_tuple, keypair in zip(cursor.executemany_params, keypairs):
+            assert len(param_tuple) == 4
+            assert param_tuple[0] == vault_address
+            assert param_tuple == (
+                vault_address,
+                keypair.public_key,
+                keypair.private_key,
+                keypair.nonce,
+            )
+
+    def test_create_table_includes_vault_column_and_migration(self):
+        cursor = _FakeCursor()
+        crud = KeyPairsCrud(db_connection=_FakeConnection(cursor))
+
+        # create_table issues two separate execute calls: the CREATE TABLE and
+        # the forward-migration ALTER. Track both by wrapping execute.
+        executed_statements: list[str] = []
+        original_execute = cursor.execute
+
+        def _tracking_execute(sql: str, params: Any = None) -> None:
+            executed_statements.append(sql)
+            original_execute(sql, params)
+
+        cursor.execute = _tracking_execute  # type: ignore[method-assign]
+
+        crud.create_table()
+
+        assert len(executed_statements) == 2
+        create_sql, alter_sql = executed_statements
+        assert 'CREATE TABLE IF NOT EXISTS' in create_sql
+        assert 'vault' in create_sql
+        assert 'UNIQUE (vault, public_key)' in create_sql
+        assert 'ALTER TABLE' in alter_sql
+        assert 'ADD COLUMN IF NOT EXISTS vault' in alter_sql


### PR DESCRIPTION
## Description

### Scope remote-db keypairs by vault

`KeyPairsCrud` filtered the `{network}_keypairs` table only by network, never by vault, even though the CLI is invoked per vault. When two vaults share one remote Postgres database, one vault's process could read, decrypt, and export another vault's validator private keys, and `remote-db cleanup` deleted every vault's rows at once.

Every query is now scoped to `settings.vault`:

- `create_table` restores the `vault` column with a `UNIQUE (vault, public_key)` constraint (previously a global per-column `UNIQUE`), plus an idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS vault` so an existing table without the column is upgraded in place rather than crashing on the new queries.
- `get_keypairs_count`, `get_first_keypair`, and `get_keypairs` filter `WHERE vault = ...`, so key export and the encryption-key check operate only on the current vault's rows.
- `remove_keypairs` always filters by vault, so `cleanup` removes only the current vault's keys.
- `upload_keypairs` inserts the `vault` column. This also corrects the INSERT, which named three columns but supplied four `%s` placeholders and three-tuple rows — it raised on any real insert, so `remote-db upload-keypairs` had been non-functional.

`RemoteDatabaseKeyPair` is unchanged: the vault is process context, supplied directly in SQL. The previous tests mocked the database connection wholesale, so the SQL was never exercised; the new `test_database.py` drives `KeyPairsCrud` with a fake cursor that records the emitted SQL and parameters, asserting vault-scoping on every read/delete and the INSERT column/placeholder arity.