### PR TITLE
Harden keystore and exit-signature rotation checks

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -38,6 +38,7 @@ from src.validators.keystores.tests.test_fixtures.hashi_vault import (
 )
 from src.validators.keystores.tests.test_fixtures.remote_signer import (
     mocked_remote_signer,
+    mocked_remote_signer_partial_import,
     remote_signer_url,
 )
 from src.validators.signing.tests.oracle_functions import OracleCommittee

--- a/src/exits/consensus.py
+++ b/src/exits/consensus.py
@@ -1,18 +1,31 @@
+import logging
+
 from web3.types import HexStr
 
 from src.common.clients import consensus_client
 from src.config.settings import settings
 
+logger = logging.getLogger(__name__)
+
 
 async def get_validator_public_keys(validator_indexes: list[int]) -> dict[int, HexStr]:
     """Fetches validators public keys."""
     indexes = [str(index) for index in validator_indexes]
-    result = {}
+    result: dict[int, HexStr] = {}
     for i in range(0, len(indexes), settings.validators_fetch_chunk_size):
         validators = await consensus_client.get_validators_by_ids(
-            indexes[i : i + settings.validators_fetch_chunk_size]
+            indexes[i : i + settings.validators_fetch_chunk_size],
+            state_id='finalized',
         )
         for beacon_validator in validators['data']:
-            result[int(beacon_validator['index'])] = beacon_validator['validator']['pubkey']
+            index = int(beacon_validator['index'])
+            if index not in validator_indexes:
+                logger.warning(
+                    'Consensus client returned validator index %d that was not requested; '
+                    'skipping it',
+                    index,
+                )
+                continue
+            result[index] = beacon_validator['validator']['pubkey']
 
     return result

--- a/src/exits/tests/test_consensus.py
+++ b/src/exits/tests/test_consensus.py
@@ -1,0 +1,25 @@
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.exits.consensus import get_validator_public_keys
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestGetValidatorPublicKeys:
+    async def test_keeps_only_requested_indexes(self):
+        # The consensus client returns a requested index (10) plus an unrequested one (999);
+        # the unrequested record must not end up in the index-to-public-key mapping.
+        response = {
+            'data': [
+                {'index': '10', 'validator': {'pubkey': '0xaa'}},
+                {'index': '999', 'validator': {'pubkey': '0xbb'}},
+            ]
+        }
+        with mock.patch('src.exits.consensus.consensus_client', new=AsyncMock()) as consensus_mock:
+            consensus_mock.get_validators_by_ids.return_value = response
+            result = await get_validator_public_keys([10])
+
+        assert result == {10: '0xaa'}
+        consensus_mock.get_validators_by_ids.assert_called_once_with(['10'], state_id='finalized')

--- a/src/validators/commands/setup_remote_signer.py
+++ b/src/validators/commands/setup_remote_signer.py
@@ -26,7 +26,7 @@ from src.config.settings import (
     REMOTE_SIGNER_UPLOAD_CHUNK_SIZE,
     settings,
 )
-from src.validators.keystores.local import LocalKeystore
+from src.validators.keystores.local import KeystoreFile, LocalKeystore
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +214,9 @@ async def process(vault: ChecksumAddress | None) -> None:
                     f' - status code {resp.status}, body: {await resp.text()}'
                 )
 
+            results = (await resp.json()).get('data') or []
+            _ensure_keystores_imported(keystore_files_chunk, results)
+
     click.echo(
         f'Successfully imported {len(keystore_files)} keys into remote signer.',
     )
@@ -239,3 +242,24 @@ async def process(vault: ChecksumAddress | None) -> None:
         f' Successfully configured operator to use remote signer'
         f' for {len(keystore_files)} public key(s)!',
     )
+
+
+def _ensure_keystores_imported(
+    keystore_files_chunk: tuple[KeystoreFile, ...], results: list[dict]
+) -> None:
+    """Verify the remote signer imported every keystore in the chunk.
+
+    A 200 response can still be a partial import: the keymanager API reports per-keystore
+    outcomes in the body, so each one must be checked before the local keystores are
+    considered safe to delete.
+    """
+    if len(results) != len(keystore_files_chunk):
+        raise RuntimeError(f'Unexpected import response from remote signer: {results}')
+
+    for keystore_file, result in zip(keystore_files_chunk, results):
+        if result.get('status') not in ('imported', 'duplicate'):
+            raise click.ClickException(
+                f'Keystore {keystore_file.name} failed to import into the remote '
+                f"signer ({result.get('status')} - {result.get('message', '')}); "
+                'local keystores were NOT removed.'
+            )

--- a/src/validators/commands/tests/test_setup_remote_signer.py
+++ b/src/validators/commands/tests/test_setup_remote_signer.py
@@ -103,3 +103,33 @@ class TestOperatorRemoteSignerSetup:
                 f'Done. Successfully configured operator to use remote signer for {key_count} public key(s)'
                 in result.output
             )
+
+    @pytest.mark.usefixtures(
+        '_init_config',
+        '_create_keys',
+        'fake_settings',
+        'mocked_remote_signer_partial_import',
+        'setup_test_clients',
+    )
+    def test_partial_import_preserves_local_keystores(
+        self,
+        vault_address: HexAddress,
+        data_dir: Path,
+        vault_dir: Path,
+        keystores_dir: Path,
+        remote_signer_url: str,
+        runner: CliRunner,
+    ):
+        args = [
+            '--remote-signer-url',
+            remote_signer_url,
+            '--vault',
+            str(vault_address),
+            '--data-dir',
+            str(data_dir),
+        ]
+
+        result = runner.invoke(setup_remote_signer, args, input='y')
+        assert result.exit_code != 0
+        assert 'were NOT removed' in result.output
+        assert keystores_dir.exists() is True

--- a/src/validators/keystores/hashi_vault.py
+++ b/src/validators/keystores/hashi_vault.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from itertools import batched
 from typing import Iterable
 
+import milagro_bls_binding as bls
 from aiohttp import ClientSession, ClientTimeout
 from eth_typing import HexStr
 from eth_utils import add_0x_prefix
@@ -155,6 +156,14 @@ class HashiVaultBundledKeysLoader(HashiVaultKeysLoader):
             if not sk:
                 continue
             sk_bytes = Web3.to_bytes(hexstr=sk)
+            # The label is otherwise trusted as the key's identity and feeds the
+            # anti-double-registration and duplicate-key safety checks, so a
+            # mismatched label/secret pair must be rejected rather than loaded silently.
+            if bls.SkToPk(sk_bytes) != Web3.to_bytes(hexstr=pk):
+                raise RuntimeError(
+                    f'Public key {add_0x_prefix(HexStr(pk))} does not match the derived '
+                    f'public key of its private key at {secret_url}'
+                )
             keys.append((add_0x_prefix(HexStr(pk)), BLSPrivkey(sk_bytes)))
         validator_keys = Keys(dict(keys))
 
@@ -249,6 +258,12 @@ class HashiVaultPrefixedKeysLoader(HashiVaultKeysLoader):
             )
         sk = list(key_data['data']['data'].values())[0]
         sk_bytes = Web3.to_bytes(hexstr=sk)
+        # Same identity check as in the bundled loader.
+        if bls.SkToPk(sk_bytes) != Web3.to_bytes(hexstr=pk):
+            raise RuntimeError(
+                f'Public key {pk} does not match the derived '
+                f'public key of its private key at {secret_url}'
+            )
         return Keys({pk: BLSPrivkey(sk_bytes)})
 
 

--- a/src/validators/keystores/tests/test_fixtures/hashi_vault.py
+++ b/src/validators/keystores/tests/test_fixtures/hashi_vault.py
@@ -2,6 +2,7 @@ import json
 from functools import partial
 from typing import Generator
 
+import milagro_bls_binding as bls
 import pytest
 from aioresponses import CallbackResult, aioresponses
 from sw_utils.tests import faker
@@ -13,30 +14,24 @@ def hashi_vault_url() -> str:
     return 'http://vault:8200'
 
 
+def _generate_key_pair() -> tuple[str, str]:
+    """Generate a private key and the public key derived from it, the same way
+    HashiVaultKeystore verifies loaded keys against their label."""
+    sk = Web3.to_hex(faker.private_key())
+    pk = Web3.to_hex(bls.SkToPk(Web3.to_bytes(hexstr=sk)))
+    return pk, sk
+
+
 class HashiVaultStub:
-    bundled_pk_1 = faker.validator_public_key()
-    bundled_sk_1 = Web3.to_hex(faker.private_key())
+    bundled_pk_1, bundled_sk_1 = _generate_key_pair()
+    bundled_pk_2, bundled_sk_2 = _generate_key_pair()
+    bundled_pk_3, bundled_sk_3 = _generate_key_pair()
+    bundled_pk_4, bundled_sk_4 = _generate_key_pair()
 
-    bundled_pk_2 = faker.validator_public_key()
-    bundled_sk_2 = Web3.to_hex(faker.private_key())
-
-    bundled_pk_3 = faker.validator_public_key()
-    bundled_sk_3 = Web3.to_hex(faker.private_key())
-
-    bundled_pk_4 = faker.validator_public_key()
-    bundled_sk_4 = Web3.to_hex(faker.private_key())
-
-    prefixed_pk_1 = faker.validator_public_key()
-    prefixed_sk_1 = Web3.to_hex(faker.private_key())
-
-    prefixed_pk_2 = faker.validator_public_key()
-    prefixed_sk_2 = Web3.to_hex(faker.private_key())
-
-    prefixed_pk_3 = faker.validator_public_key()
-    prefixed_sk_3 = Web3.to_hex(faker.private_key())
-
-    prefixed_pk_4 = faker.validator_public_key()
-    prefixed_sk_4 = Web3.to_hex(faker.private_key())
+    prefixed_pk_1, prefixed_sk_1 = _generate_key_pair()
+    prefixed_pk_2, prefixed_sk_2 = _generate_key_pair()
+    prefixed_pk_3, prefixed_sk_3 = _generate_key_pair()
+    prefixed_pk_4, prefixed_sk_4 = _generate_key_pair()
 
 
 @pytest.fixture
@@ -50,6 +45,11 @@ def mocked_hashi_vault(
     _hashi_vault_pk_sk_mapping_2 = {
         HashiVaultStub.bundled_pk_3: HashiVaultStub.bundled_sk_3,
         HashiVaultStub.bundled_pk_4: HashiVaultStub.bundled_sk_4,
+    }
+    # Label pubkey (bundled_pk_1) does not match the secret's derived pubkey
+    # (bundled_sk_2 belongs to bundled_pk_2), simulating a mislabeled entry.
+    _hashi_vault_pk_sk_mismatched_mapping = {
+        HashiVaultStub.bundled_pk_1: HashiVaultStub.bundled_sk_2,
     }
 
     _hashi_vault_prefixed_pk_sk_mapping1 = {
@@ -149,6 +149,12 @@ def mocked_hashi_vault(
         m.get(
             f'{hashi_vault_url}/v1/secret/data/ethereum/inaccessible/keystores',
             callback=_mocked_error_path,
+            repeat=True,
+        )
+        # Mocked bundled signing keys endpoint with a mislabeled key
+        m.get(
+            f'{hashi_vault_url}/v1/secret/data/ethereum/signing/mismatched/keystores',
+            callback=partial(_mocked_secret_path, _hashi_vault_pk_sk_mismatched_mapping),
             repeat=True,
         )
         yield

--- a/src/validators/keystores/tests/test_fixtures/remote_signer.py
+++ b/src/validators/keystores/tests/test_fixtures/remote_signer.py
@@ -117,3 +117,76 @@ def mocked_remote_signer(
             repeat=True,
         )
         yield
+
+
+@pytest.fixture
+def mocked_remote_signer_partial_import(
+    remote_signer_url: str,
+) -> Generator:
+    """Same as ``mocked_remote_signer``, except the import endpoint reports the first
+    submitted keystore as failed, simulating a partial import from the remote signer."""
+    _remote_signer_pubkey_privkey_mapping: dict[HexStr, BLSPrivkey] = {}
+
+    def _mocked_keymanager_import_endpoint(url, **kwargs) -> CallbackResult:
+        data = kwargs['json']
+        keystores = [Keystore.from_json(json.loads(keystore)) for keystore in data['keystores']]
+        passwords = data['passwords']
+
+        results = []
+        for index, (keystore, password) in enumerate(zip(keystores, passwords)):
+            if index == 0:
+                results.append({'status': 'error', 'message': 'invalid keystore'})
+                continue
+
+            priv_key = BLSPrivkey(keystore.decrypt(password))
+            pubkey = Web3.to_hex(bls.SkToPk(priv_key))
+            _remote_signer_pubkey_privkey_mapping[pubkey] = priv_key
+            results.append({'status': 'imported'})
+
+        return CallbackResult(status=200, payload={'data': results})
+
+    def _mocked_keymanager_delete_endpoint(url, **kwargs) -> CallbackResult:
+        data = kwargs['json']
+        pubkeys = data['pubkeys']
+
+        for pubkey in pubkeys:
+            _remote_signer_pubkey_privkey_mapping.pop(pubkey)
+
+        return CallbackResult(
+            status=200, payload={'data': [{'status': 'deleted'} for _ in pubkeys]}
+        )
+
+    def _mocked_keymanager_list_endpoint(url, **kwargs) -> CallbackResult:
+        return CallbackResult(
+            status=200,
+            payload={
+                'data': [
+                    {'validating_pubkey': pubkey}
+                    for pubkey in _remote_signer_pubkey_privkey_mapping.keys()
+                ]
+            },
+        )
+
+    with aioresponses() as m:
+        # Mocked keymanager list keys endpoint
+        m.get(
+            f'{remote_signer_url}/eth/v1/keystores',
+            callback=_mocked_keymanager_list_endpoint,
+            repeat=True,
+        )
+
+        # Mocked keymanager import keystores endpoint
+        m.post(
+            f'{remote_signer_url}/eth/v1/keystores',
+            callback=_mocked_keymanager_import_endpoint,
+            repeat=True,
+        )
+
+        # Mocked keymanager delete keys endpoint
+        m.delete(
+            f'{remote_signer_url}/eth/v1/keystores',
+            callback=_mocked_keymanager_delete_endpoint,
+            repeat=True,
+        )
+
+        yield

--- a/src/validators/keystores/tests/test_hashi_vault.py
+++ b/src/validators/keystores/tests/test_hashi_vault.py
@@ -186,3 +186,18 @@ class TestHashiVault:
         assert HashiVaultStub.prefixed_pk_2 in keystore
         assert HashiVaultStub.prefixed_pk_3 in keystore
         assert HashiVaultStub.prefixed_pk_4 in keystore
+
+    @pytest.mark.usefixtures('mocked_hashi_vault')
+    async def test_hashi_vault_rejects_mismatched_public_key(
+        self,
+        hashi_vault_url: str,
+    ):
+        settings.hashi_vault_url = hashi_vault_url
+        settings.hashi_vault_engine_name = 'secret'
+        settings.hashi_vault_token = 'Secret'
+        settings.hashi_vault_key_paths = ['ethereum/signing/mismatched/keystores']
+        settings.hashi_vault_key_prefixes = []
+        settings.hashi_vault_parallelism = 1
+
+        with pytest.raises(RuntimeError, match='does not match'):
+            await HashiVaultKeystore.load()


### PR DESCRIPTION
## Description

### Verify Hashi Vault key labels against private keys

Both HashiCorp Vault key loaders trusted the supplied label (bundled path) or URL path segment (prefixed path) as the validator's public-key identity and never checked it against the public key derived from the loaded private key. A mislabeled entry — a label claiming validator A mapped to validator B's private key — was loaded silently under the wrong identity. Because that label is what flows into the anti-double-registration filter and the `HashiKeys` duplicate guard, a mislabeled or duplicated secret could evade the checks that exist to prevent slashing.

Both loaders now derive the public key from each private key and reject any entry whose label does not match, using the same byte comparison already used in `src/remote_db/tasks.py`. The existing test fixtures generated each public key and private key independently, so their labels never matched their secrets; they are regenerated to derive each label from its private key the same way the loader now verifies. A new test points a bundled key path at a deliberately mislabeled entry and asserts the load raises.

### Check per-key results before deleting local keystores

`operator-remote-signer-setup` imported the local keystores to the remote signer's keymanager API and treated any HTTP 200 as full success, then prompted to delete the local keystores. But the keymanager endpoint returns 200 even on a partial import, reporting per-keystore outcomes in the body. Keys that silently failed to import were therefore deleted locally and never reached the signer, leaving them unrecoverable.

The command now checks each per-key status (`imported` and `duplicate` are treated as success) and raises before the deletion step if any keystore failed to import, so the local keystores are preserved. A new test simulates a partial import and asserts the keystores directory still exists.

### Reject unrequested consensus indexes in exit rotation

During exit-signature rotation, `get_validator_public_keys` built the index-to-public-key mapping directly from the consensus response without checking that the returned indexes were the ones requested. A misbehaving or malicious consensus endpoint could bind an unrequested index into the mapping that decides which key an exit signature is generated for, corrupting a validator's fallback exit material.

The function now keeps only records whose index is one of the requested indexes (logging and skipping any others) and queries the finalized state. A new test asserts an unrequested index returned by the consensus client is dropped and that the finalized state is used. Note: fully authenticating that a returned public key genuinely owns a requested index still relies on the oracle/keeper verification, since the operator has no independent index-to-key source.
