### PR TITLE
Add iter_validators_by_ids

### DIFF
--- a/src/commands/recover.py
+++ b/src/commands/recover.py
@@ -7,12 +7,7 @@ from eth_typing import BlockNumber, ChecksumAddress, HexStr
 from eth_utils import add_0x_prefix
 from sw_utils.consensus import EXITED_STATUSES, ValidatorStatus
 
-from src.common.clients import (
-    close_clients,
-    consensus_client,
-    execution_client,
-    setup_clients,
-)
+from src.common.clients import close_clients, execution_client, setup_clients
 from src.common.contracts import VaultContract
 from src.common.credentials import CredentialManager
 from src.common.logging import LOG_LEVELS, setup_logging
@@ -22,6 +17,7 @@ from src.common.validators import validate_eth_address, validate_mnemonic
 from src.config.config import OperatorConfig
 from src.config.networks import AVAILABLE_NETWORKS
 from src.config.settings import DEFAULT_NETWORK, settings
+from src.validators.consensus import iter_validators_by_ids
 
 
 @click.command(help='Recover config data directory and keystores.')
@@ -241,13 +237,8 @@ async def _fetch_registered_validators(
     validator_statuses: dict[HexStr, ValidatorStatus | None] = {
         public_key: None for public_key in public_keys
     }
-    for i in range(0, len(public_keys), settings.validators_fetch_chunk_size):
-        validators = await consensus_client.get_validators_by_ids(
-            public_keys[i : i + settings.validators_fetch_chunk_size]
-        )
-        for beacon_validator in validators['data']:
-            public_key = add_0x_prefix(beacon_validator['validator']['pubkey'])
-            validator_statuses[public_key] = ValidatorStatus(beacon_validator['status'])
+    async for validator in iter_validators_by_ids(public_keys):
+        validator_statuses[validator.public_key] = validator.status
     click.secho('Fetched statuses for registered validators', bold=True)
 
     return validator_statuses

--- a/src/common/tests/utils.py
+++ b/src/common/tests/utils.py
@@ -1,4 +1,7 @@
+from contextlib import contextmanager
 from decimal import Decimal
+from typing import Generator
+from unittest.mock import AsyncMock, patch
 
 from web3 import Web3
 from web3.types import Gwei, Wei
@@ -20,3 +23,13 @@ def parse_wei(value: str | list | dict) -> Wei:
         return {key: parse_wei(value) for key, value in value.items()}
 
     raise ValueError(f'Unsupported type for parse_wei: {type(value)}')
+
+
+@contextmanager
+def patch_consensus_client(
+    consensus_client: AsyncMock | None = None,
+) -> Generator[AsyncMock, None, None]:
+    """Patches the consensus client used by `src.validators.consensus`."""
+    consensus_client = consensus_client or AsyncMock()
+    with patch('src.validators.consensus.default_consensus_client', consensus_client):
+        yield consensus_client

--- a/src/exits/consensus.py
+++ b/src/exits/consensus.py
@@ -2,8 +2,7 @@ import logging
 
 from web3.types import HexStr
 
-from src.common.clients import consensus_client
-from src.config.settings import settings
+from src.validators.consensus import iter_validators_by_ids
 
 logger = logging.getLogger(__name__)
 
@@ -12,20 +11,14 @@ async def get_validator_public_keys(validator_indexes: list[int]) -> dict[int, H
     """Fetches validators public keys."""
     indexes = [str(index) for index in validator_indexes]
     result: dict[int, HexStr] = {}
-    for i in range(0, len(indexes), settings.validators_fetch_chunk_size):
-        validators = await consensus_client.get_validators_by_ids(
-            indexes[i : i + settings.validators_fetch_chunk_size],
-            state_id='finalized',
-        )
-        for beacon_validator in validators['data']:
-            index = int(beacon_validator['index'])
-            if index not in validator_indexes:
-                logger.warning(
-                    'Consensus client returned validator index %d that was not requested; '
-                    'skipping it',
-                    index,
-                )
-                continue
-            result[index] = beacon_validator['validator']['pubkey']
+    async for validator in iter_validators_by_ids(indexes, state_id='finalized'):
+        if validator.index not in validator_indexes:
+            logger.warning(
+                'Consensus client returned validator index %d that was not requested; '
+                'skipping it',
+                validator.index,
+            )
+            continue
+        result[validator.index] = validator.public_key
 
     return result

--- a/src/exits/tests/test_consensus.py
+++ b/src/exits/tests/test_consensus.py
@@ -13,13 +13,30 @@ class TestGetValidatorPublicKeys:
         # the unrequested record must not end up in the index-to-public-key mapping.
         response = {
             'data': [
-                {'index': '10', 'validator': {'pubkey': '0xaa'}},
-                {'index': '999', 'validator': {'pubkey': '0xbb'}},
+                _beacon_validator(index='10', pubkey='0xaa'),
+                _beacon_validator(index='999', pubkey='0xbb'),
             ]
         }
-        with mock.patch('src.exits.consensus.consensus_client', new=AsyncMock()) as consensus_mock:
+        with mock.patch(
+            'src.validators.consensus.consensus_client', new=AsyncMock()
+        ) as consensus_mock:
             consensus_mock.get_validators_by_ids.return_value = response
             result = await get_validator_public_keys([10])
 
         assert result == {10: '0xaa'}
-        consensus_mock.get_validators_by_ids.assert_called_once_with(['10'], state_id='finalized')
+        consensus_mock.get_validators_by_ids.assert_called_once_with(
+            validator_ids=('10',), state_id='finalized'
+        )
+
+
+def _beacon_validator(index: str, pubkey: str) -> dict:
+    return {
+        'index': index,
+        'balance': '32000000000',
+        'status': 'active_ongoing',
+        'validator': {
+            'pubkey': pubkey,
+            'withdrawal_credentials': '0x01',
+            'activation_epoch': '0',
+        },
+    }

--- a/src/exits/tests/test_consensus.py
+++ b/src/exits/tests/test_consensus.py
@@ -1,8 +1,6 @@
-from unittest import mock
-from unittest.mock import AsyncMock
-
 import pytest
 
+from src.common.tests.utils import patch_consensus_client
 from src.exits.consensus import get_validator_public_keys
 
 
@@ -17,9 +15,7 @@ class TestGetValidatorPublicKeys:
                 _beacon_validator(index='999', pubkey='0xbb'),
             ]
         }
-        with mock.patch(
-            'src.validators.consensus.consensus_client', new=AsyncMock()
-        ) as consensus_mock:
+        with patch_consensus_client() as consensus_mock:
             consensus_mock.get_validators_by_ids.return_value = response
             result = await get_validator_public_keys([10])
 

--- a/src/nodewise/status.py
+++ b/src/nodewise/status.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from eth_typing import BlockNumber
 from sw_utils import ExtendedAsyncBeacon
-from sw_utils.consensus import ACTIVE_STATUSES, ValidatorStatus
+from sw_utils.consensus import ACTIVE_STATUSES
 from web3 import AsyncWeb3
 from web3.types import BlockData, Timestamp
 
@@ -25,6 +25,7 @@ from src.nodewise.typings import (
     StatusHistoryRecord,
     SyncStageProgress,
 )
+from src.validators.consensus import iter_validators_by_ids
 from src.validators.keystores.local import LocalKeystore
 
 logger = logging.getLogger(__name__)
@@ -135,18 +136,16 @@ async def _get_number_of_active_validators(
     if not public_keys:
         return 0
 
+    active_count = 0
     try:
-        validators = (await consensus_client.get_validators_by_ids(public_keys))['data']
+        async for validator in iter_validators_by_ids(
+            public_keys, consensus_client=consensus_client
+        ):
+            if validator.status in ACTIVE_STATUSES:
+                active_count += 1
     except Exception as e:
         warning_verbose('Error fetching validators: %s', format_error(e))
         return 0
-
-    active_count = 0
-
-    for validator in validators:
-        status = ValidatorStatus(validator['status'])
-        if status in ACTIVE_STATUSES:
-            active_count += 1
 
     return active_count
 

--- a/src/redemptions/commands/tests/test_process_redeemer.py
+++ b/src/redemptions/commands/tests/test_process_redeemer.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -347,7 +347,7 @@ class TestProcess:
 
 
 @contextmanager
-def _mock_startup_checks() -> Iterator[None]:
+def _mock_startup_checks() -> Generator[None, None, None]:
     """Patch the execution-node, network and wallet-balance checks run by _startup_check,
     leaving the Position Manager role check under test."""
     with (
@@ -366,7 +366,7 @@ def _mock_redeem_positions(
     submit_results: list[bool] | None = None,
     ltv_exceeded: bool = False,
     minted_shares: Wei | list[Wei] | None = None,
-) -> Iterator[dict[str, MagicMock]]:
+) -> Generator[dict[str, MagicMock], None, None]:
     """Mock setup for redeem_positions tests.
 
     ``withdrawable`` may be a constant Wei value (returned on every call) or an
@@ -443,7 +443,7 @@ def _submitted_position(mocks: dict[str, MagicMock], index: int = 0) -> OsTokenP
 @contextmanager
 def _mock_process(
     positions: list[OsTokenPosition] | None = None,
-) -> Iterator[dict[str, MagicMock]]:
+) -> Generator[dict[str, MagicMock], None, None]:
     """Common mock setup for process() tests."""
     positions = positions or []
     mock_client = MagicMock()

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from dataclasses import replace
 from itertools import batched
-from typing import Collection, cast
+from typing import AsyncIterator, Collection, Sequence, cast
 
 from eth_typing import HexStr
 from sw_utils import ChainHead, ValidatorStatus
@@ -238,12 +238,17 @@ async def apply_pending_deposits(
 async def fetch_consensus_validators(
     validator_ids: list[HexStr] | list[str], slot: str = 'head'
 ) -> list[ConsensusValidator]:
-    validators = []
-    for chunk_keys in batched(validator_ids, settings.validators_fetch_chunk_size):
-        beacon_validators = await consensus_client.get_validators_by_ids(
-            validator_ids=chunk_keys, state_id=slot
-        )
-        for beacon_validator in beacon_validators['data']:
-            validators.append(ConsensusValidator.from_consensus_data(beacon_validator))
+    return [validator async for validator in iter_validators_by_ids(validator_ids, state_id=slot)]
 
-    return validators
+
+async def iter_validators_by_ids(
+    validator_ids: Sequence[str] | Sequence[HexStr],
+    state_id: str = 'head',
+) -> AsyncIterator[ConsensusValidator]:
+    """Yields the consensus validators for the given ids, fetching them in chunks."""
+    for chunk in batched(validator_ids, settings.validators_fetch_chunk_size):
+        response = await consensus_client.get_validators_by_ids(
+            validator_ids=chunk, state_id=state_id
+        )
+        for beacon_validator in response['data']:
+            yield ConsensusValidator.from_consensus_data(beacon_validator)

--- a/src/validators/consensus.py
+++ b/src/validators/consensus.py
@@ -5,11 +5,11 @@ from itertools import batched
 from typing import AsyncIterator, Collection, Sequence, cast
 
 from eth_typing import HexStr
-from sw_utils import ChainHead, ValidatorStatus
+from sw_utils import ChainHead, ExtendedAsyncBeacon, ValidatorStatus
 from sw_utils.consensus import EXITED_STATUSES
 from web3.types import Gwei
 
-from src.common.clients import consensus_client
+from src.common.clients import consensus_client as default_consensus_client
 from src.common.consensus import get_chain_latest_head
 from src.common.consolidations import get_pending_consolidations
 from src.common.typings import PendingConsolidation
@@ -200,7 +200,7 @@ async def apply_pending_deposits(
     pending_balances: dict[HexStr, Gwei] = defaultdict(lambda: Gwei(0))
     new_credentials: dict[HexStr, HexStr] = {}
 
-    for deposit in await consensus_client.get_pending_deposits(slot):
+    for deposit in await default_consensus_client.get_pending_deposits(slot):
         public_key: HexStr = deposit['pubkey']
         if public_key not in public_keys:
             continue
@@ -244,8 +244,10 @@ async def fetch_consensus_validators(
 async def iter_validators_by_ids(
     validator_ids: Sequence[str] | Sequence[HexStr],
     state_id: str = 'head',
+    consensus_client: ExtendedAsyncBeacon | None = None,
 ) -> AsyncIterator[ConsensusValidator]:
     """Yields the consensus validators for the given ids, fetching them in chunks."""
+    consensus_client = consensus_client or default_consensus_client
     for chunk in batched(validator_ids, settings.validators_fetch_chunk_size):
         response = await consensus_client.get_validators_by_ids(
             validator_ids=chunk, state_id=state_id

--- a/src/validators/tests/test_consensus.py
+++ b/src/validators/tests/test_consensus.py
@@ -7,7 +7,7 @@ from sw_utils.tests import faker
 from web3.types import Gwei
 
 from src.common.tests.factories import create_chain_head
-from src.common.tests.utils import ether_to_gwei
+from src.common.tests.utils import ether_to_gwei, patch_consensus_client
 from src.common.typings import PendingConsolidation
 from src.validators.consensus import (
     UNKNOWN_VALIDATOR_INDEX,
@@ -456,7 +456,7 @@ def patch_funding_dependencies(
             new_callable=AsyncMock,
             return_value=pending_consolidations or [],
         ) as mock_consolidations,
-        patch('src.validators.consensus.consensus_client', mock_consensus),
+        patch_consensus_client(mock_consensus),
     ):
         yield {
             'chain_head': mock_chain_head,

--- a/src/validators/tests/test_tasks.py
+++ b/src/validators/tests/test_tasks.py
@@ -10,7 +10,7 @@ from web3 import Web3
 from web3.types import Gwei, Wei
 
 from src.common.tests.factories import create_chain_head
-from src.common.tests.utils import ether_to_gwei
+from src.common.tests.utils import ether_to_gwei, patch_consensus_client
 from src.common.typings import ValidatorType
 from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI, settings
 from src.validators.exceptions import FundingException
@@ -440,7 +440,7 @@ class TestProcessFunding:
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
@@ -515,7 +515,7 @@ class TestProcessFunding:
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
@@ -571,7 +571,7 @@ class TestProcessFunding:
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
@@ -642,7 +642,7 @@ class TestProcessFunding:
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
@@ -684,7 +684,7 @@ class TestProcessFunding:
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
@@ -747,7 +747,7 @@ class TestProcessFunding:
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
@@ -783,7 +783,7 @@ class TestProcessFunding:
         with (
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(None) as mock_fund,
         ):
@@ -845,7 +845,7 @@ class TestProcessFunding:
             patch_max_validator_balance(ether_to_gwei(64)),
             self.patch_get_latest_vault_v2_validator_public_keys(),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):
@@ -888,7 +888,7 @@ class TestProcessFunding:
         with (
             self.patch_get_latest_vault_v2_validator_public_keys({pub_key}),
             self.patch_chain_head_and_consolidations(),
-            patch('src.validators.consensus.consensus_client', mock_consensus),
+            patch_consensus_client(mock_consensus),
             self.patch_is_funding_interval_passed(True),
             self.patch_fund_validators_chunk(HexStr('0xabc')) as mock_fund,
         ):


### PR DESCRIPTION
## Summary

Adds `iter_validators_by_ids` in `src/validators/consensus.py` — an async generator that fetches beacon validators in chunks of `settings.validators_fetch_chunk_size` and yields flat `ConsensusValidator` instances. Callers no longer deal with batching or with the raw beacon dict.

```python
async def iter_validators_by_ids(
    validator_ids: Sequence[str] | Sequence[HexStr],
    state_id: str = 'head',
    consensus_client: ExtendedAsyncBeacon | None = None,
) -> AsyncIterator[ConsensusValidator]
```

`consensus_client` defaults to the shared singleton, imported as `default_consensus_client`. It is overridable because `node-status` deliberately builds its own non-retry, 10s-timeout client to fail fast.

## Changes

- **`src/validators/consensus.py`** — new `iter_validators_by_ids`; `fetch_consensus_validators` becomes a one-line async comprehension over it.
- **`src/exits/consensus.py`** — replaces manual `range()` slicing; `int(beacon_validator['index'])` and the raw pubkey lookup become `validator.index` / `validator.public_key`.
- **`src/commands/recover.py`** — replaces manual `range()` slicing; the pubkey/status normalization collapses to `validator_statuses[validator.public_key] = validator.status`.
- **`src/nodewise/status.py`** — `_get_number_of_active_validators` now iterates instead of issuing one unbatched request for every keystore public key, passing its own fail-fast client.

Normalization (0x-prefixing the pubkey, `int()` on the index, `ValidatorStatus(...)` on the status) now happens in one place: `ConsensusValidator.from_consensus_data`.

## Behavior notes

- `get_validator_public_keys` in `src/exits/consensus.py` now returns 0x-prefixed public keys, consistent with the rest of the codebase.
- `nodewise` validator activity stats are now batched. Previously all keystore public keys went out in a single request, which could exceed request-size limits on a large keystore directory.

## Tests

- New `patch_consensus_client` helper in `src/common/tests/utils.py` replaces 11 copies of the same `patch('src.validators.consensus...')` string across three test files.
- `@contextmanager` functions annotated `-> Iterator[...]` are deprecated in typeshed; switched to `Generator[..., None, None]` in the touched test files.
