### PR TITLE
Normalize validator public keys

### DIFF
--- a/src/common/tests/test_validators.py
+++ b/src/common/tests/test_validators.py
@@ -131,6 +131,23 @@ def test_validate_public_keys_file():
             validate_public_keys_file(None, None, 'mock_file_path')
 
 
+def test_validate_public_keys_normalization():
+    """Upper case and unprefixed keys are accepted and reduced to the canonical form."""
+    public_key = faker.validator_public_key()
+    variants = [
+        public_key.upper().replace('0X', '0x'),
+        public_key[2:],
+        public_key[2:].upper(),
+    ]
+
+    for variant in variants:
+        assert validate_public_key(None, None, variant) == public_key
+        assert validate_public_keys(None, None, variant) == [public_key]
+
+        with patch('builtins.open', mock_open(read_data=variant + '\n')):
+            assert validate_public_keys_file(None, None, 'mock_file_path') == 'mock_file_path'
+
+
 def test_is_public_key():
     # returns_true_for_valid_public_key
     result = _is_public_key('0x' + 'a' * 96)

--- a/src/common/typings.py
+++ b/src/common/typings.py
@@ -1,9 +1,15 @@
 from dataclasses import dataclass
 from enum import Enum
 
+from eth_typing import HexStr
+from eth_utils import add_0x_prefix
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.types import ChecksumAddress, Gwei, Wei
+
+
+def normalize_public_key(public_key: str) -> HexStr:
+    return add_0x_prefix(HexStr(public_key.lower()))
 
 
 @dataclass

--- a/src/common/validators.py
+++ b/src/common/validators.py
@@ -7,6 +7,7 @@ from eth_utils import is_address, is_hexstr, to_checksum_address
 from web3 import Web3
 
 from src.common.language import validate_mnemonic as verify_mnemonic
+from src.common.typings import normalize_public_key
 from src.config.settings import (
     MAX_EFFECTIVE_BALANCE,
     MAX_EFFECTIVE_BALANCE_GWEI,
@@ -73,10 +74,11 @@ def validate_dappnode_execution_endpoints(
 def validate_public_key(ctx: click.Context, param: click.Parameter, value: str) -> str | None:
     if not value:
         return None
-    if not _is_public_key(value):
+    public_key = normalize_public_key(value)
+    if not _is_public_key(public_key):
         raise click.BadParameter('Invalid validator public key')
 
-    return value
+    return public_key
 
 
 def validate_public_keys(
@@ -84,11 +86,12 @@ def validate_public_keys(
 ) -> list[HexStr] | None:
     if not value:
         return None
-    for key in value.split(','):
-        if not _is_public_key(key):
+    public_keys = [normalize_public_key(key) for key in value.split(',')]
+    for public_key in public_keys:
+        if not _is_public_key(public_key):
             raise click.BadParameter('Invalid validator public key')
 
-    return [HexStr(address) for address in value.split(',')]
+    return public_keys
 
 
 def validate_public_keys_file(ctx: click.Context, param: click.Parameter, value: str) -> str | None:
@@ -97,7 +100,7 @@ def validate_public_keys_file(ctx: click.Context, param: click.Parameter, value:
     with open(value, 'r', encoding='utf-8') as f:
         for line in f:
             key = line.strip()
-            if not _is_public_key(key):
+            if not _is_public_key(normalize_public_key(key)):
                 raise click.BadParameter(f'Invalid validator public key: {key}')
 
     return value

--- a/src/validators/commands/consolidate.py
+++ b/src/validators/commands/consolidate.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import click
 from eth_typing import BlockNumber, ChecksumAddress, HexStr
-from eth_utils import add_0x_prefix
 from sw_utils import ChainHead
 from web3 import Web3
 from web3.types import Gwei, Wei
@@ -20,6 +19,7 @@ from src.common.execution import check_gas_price
 from src.common.logging import LOG_LEVELS, setup_logging
 from src.common.protocol_config import get_protocol_config
 from src.common.startup_check import check_validators_manager
+from src.common.typings import normalize_public_key
 from src.common.utils import log_verbose
 from src.common.validators import (
     validate_eth_address,
@@ -446,7 +446,7 @@ def _encode_validators(target_source_public_keys: list[tuple[HexStr, HexStr]]) -
 def _load_public_keys(public_keys_file: Path) -> list[HexStr]:
     """Loads public keys from file."""
     with open(public_keys_file, 'r', encoding='utf-8') as f:
-        public_keys = [add_0x_prefix(HexStr(line.rstrip())) for line in f]
+        public_keys = [normalize_public_key(line.rstrip()) for line in f]
 
     return public_keys
 

--- a/src/validators/keystores/hashi_vault.py
+++ b/src/validators/keystores/hashi_vault.py
@@ -9,9 +9,9 @@ from typing import Iterable
 import milagro_bls_binding as bls
 from aiohttp import ClientSession, ClientTimeout
 from eth_typing import HexStr
-from eth_utils import add_0x_prefix
 from web3 import Web3
 
+from src.common.typings import normalize_public_key
 from src.config.settings import HASHI_VAULT_TIMEOUT, settings
 from src.validators.keystores.local import Keys, LocalKeystore
 from src.validators.typings import BLSPrivkey
@@ -161,10 +161,10 @@ class HashiVaultBundledKeysLoader(HashiVaultKeysLoader):
             # mismatched label/secret pair must be rejected rather than loaded silently.
             if bls.SkToPk(sk_bytes) != Web3.to_bytes(hexstr=pk):
                 raise RuntimeError(
-                    f'Public key {add_0x_prefix(HexStr(pk))} does not match the derived '
+                    f'Public key {normalize_public_key(pk)} does not match the derived '
                     f'public key of its private key at {secret_url}'
                 )
-            keys.append((add_0x_prefix(HexStr(pk)), BLSPrivkey(sk_bytes)))
+            keys.append((normalize_public_key(pk), BLSPrivkey(sk_bytes)))
         validator_keys = Keys(dict(keys))
 
         logger.info('Loaded %d keys from %s', len(validator_keys), secret_url)
@@ -250,7 +250,7 @@ class HashiVaultPrefixedKeysLoader(HashiVaultKeysLoader):
                 logger.error('hashi vault error: %s', error)
             raise RuntimeError('Can not retrieve validator signing keys from hashi vault')
         # Last chunk of URL is a public key
-        pk = add_0x_prefix(HexStr(secret_url.strip('/').split('/')[-1]))
+        pk = normalize_public_key(secret_url.strip('/').split('/')[-1])
         if len(key_data['data']['data']) > 1:
             raise RuntimeError(
                 f'Invalid multi-value secret at path {secret_url}, '

--- a/src/validators/keystores/local.py
+++ b/src/validators/keystores/local.py
@@ -7,13 +7,13 @@ from typing import NewType
 
 import milagro_bls_binding as bls
 from eth_typing import BLSPrivateKey, BLSSignature, HexStr
-from eth_utils import add_0x_prefix
 from staking_deposit.key_handling.keystore import ScryptKeystore
 from sw_utils.signing import get_exit_message_signing_root
 from sw_utils.typings import ConsensusFork
 from web3 import Web3
 
 from src.common.credentials import CredentialManager
+from src.common.typings import normalize_public_key
 from src.config.settings import settings
 from src.validators.exceptions import KeystoreException
 from src.validators.keystores.base import BaseKeystore
@@ -179,6 +179,6 @@ class LocalKeystore(BaseKeystore):
 
         # extract index from path: m/12381/3600/<index>/0/0
         key_index = int(keystore.path.split('/')[-3])
-        public_key = add_0x_prefix(HexStr(keystore.pubkey))
+        public_key = normalize_public_key(keystore.pubkey)
 
         return key_index, public_key

--- a/src/validators/keystores/remote.py
+++ b/src/validators/keystores/remote.py
@@ -15,6 +15,7 @@ from sw_utils.signing import compute_deposit_domain, compute_signing_root
 from sw_utils.typings import ConsensusFork
 from web3 import Web3
 
+from src.common.typings import normalize_public_key
 from src.config.networks import NETWORKS
 from src.config.settings import REMOTE_SIGNER_TIMEOUT, settings
 from src.validators.keystores.base import BaseKeystore
@@ -158,7 +159,7 @@ class RemoteSignerKeystore(BaseKeystore):
             response = await session.get(signer_url)
 
             response.raise_for_status()
-            return await response.json()
+            return [normalize_public_key(public_key) for public_key in await response.json()]
 
     @staticmethod
     async def _sign_exit_request(

--- a/src/validators/keystores/tests/test_fixtures/hashi_vault.py
+++ b/src/validators/keystores/tests/test_fixtures/hashi_vault.py
@@ -52,6 +52,12 @@ def mocked_hashi_vault(
         HashiVaultStub.bundled_pk_1: HashiVaultStub.bundled_sk_2,
     }
 
+    # Same key as bundled_pk_1, labeled without the 0x prefix and in upper case.
+    # Exercises public key normalization on load.
+    _hashi_vault_uppercase_pk_sk_mapping = {
+        HashiVaultStub.bundled_pk_1[2:].upper(): HashiVaultStub.bundled_sk_1,
+    }
+
     _hashi_vault_prefixed_pk_sk_mapping1 = {
         HashiVaultStub.prefixed_pk_1: HashiVaultStub.prefixed_sk_1,
         HashiVaultStub.prefixed_pk_2: HashiVaultStub.prefixed_sk_2,
@@ -101,6 +107,11 @@ def mocked_hashi_vault(
         m.get(
             f'{hashi_vault_url}/v1/secret/data/ethereum/signing/same/keystores',
             callback=partial(_mocked_secret_path, _hashi_vault_pk_sk_mapping_1),
+            repeat=True,
+        )
+        m.get(
+            f'{hashi_vault_url}/v1/secret/data/ethereum/signing/uppercase/keystores',
+            callback=partial(_mocked_secret_path, _hashi_vault_uppercase_pk_sk_mapping),
             repeat=True,
         )
         m.get(

--- a/src/validators/keystores/tests/test_normalization.py
+++ b/src/validators/keystores/tests/test_normalization.py
@@ -1,0 +1,72 @@
+import json
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from src.common.typings import normalize_public_key
+from src.config.settings import settings
+from src.validators.keystores.hashi_vault import HashiVaultKeystore
+from src.validators.keystores.remote import RemoteSignerKeystore
+from src.validators.keystores.tests.test_fixtures.hashi_vault import HashiVaultStub
+
+PUBLIC_KEY = (
+    '0xb79b844a8e2d2b9a1b3b0dbbedca4a1a1a8e8ed13e5cbb2d0b90bbb2d99b0be8'
+    '00d2d3b4c1b6b3e0b1c2d3e4f5061728'
+)
+
+
+class TestNormalizePublicKey:
+    @pytest.mark.parametrize(
+        'public_key',
+        [
+            PUBLIC_KEY,
+            PUBLIC_KEY.upper().replace('0X', '0x'),
+            PUBLIC_KEY[2:],
+            PUBLIC_KEY[2:].upper(),
+        ],
+    )
+    def test_normalize_public_key(self, public_key):
+        """Prefixed, unprefixed and upper case keys all collapse to the same form."""
+        assert normalize_public_key(public_key) == PUBLIC_KEY
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestRemoteSignerNormalization:
+    async def test_load_normalizes_public_keys(self, remote_signer_url):
+        """Remote signer keys are normalized, so lookups by the canonical form match."""
+        settings.remote_signer_url = remote_signer_url
+        settings.remote_signer_public_keys_url = None
+
+        # Web3Signer returns 0x-prefixed lower case keys, but that is not guaranteed
+        # by the keymanager API.
+        signer_public_keys = [PUBLIC_KEY[2:].upper(), PUBLIC_KEY.upper().replace('0X', '0x')]
+
+        with aioresponses() as mocked:
+            mocked.get(
+                f'{remote_signer_url}/api/v1/eth2/publicKeys',
+                callback=lambda url, **kwargs: CallbackResult(
+                    status=200, body=json.dumps(signer_public_keys)
+                ),
+            )
+            keystore = await RemoteSignerKeystore.load()
+
+        assert keystore.public_keys == [PUBLIC_KEY, PUBLIC_KEY]
+        assert PUBLIC_KEY in keystore
+
+
+class TestHashiVaultNormalization:
+    @pytest.mark.usefixtures('mocked_hashi_vault')
+    async def test_load_normalizes_public_keys(self, hashi_vault_url):
+        """A key labeled in upper case without the 0x prefix is still found by its
+        canonical form."""
+        settings.hashi_vault_url = hashi_vault_url
+        settings.hashi_vault_engine_name = 'secret'
+        settings.hashi_vault_token = 'Secret'
+        settings.hashi_vault_key_paths = ['ethereum/signing/uppercase/keystores']
+        settings.hashi_vault_key_prefixes = []
+        settings.hashi_vault_parallelism = 1
+
+        keystore = await HashiVaultKeystore.load()
+
+        assert keystore.public_keys == [HashiVaultStub.bundled_pk_1]
+        assert HashiVaultStub.bundled_pk_1 in keystore

--- a/src/validators/relayer.py
+++ b/src/validators/relayer.py
@@ -10,6 +10,7 @@ from web3 import Web3
 from web3.types import Gwei
 
 from src.common.clients import OPERATOR_USER_AGENT
+from src.common.typings import normalize_public_key
 from src.config.settings import settings
 from src.validators.event_processors import get_validators_start_index
 from src.validators.typings import (
@@ -190,7 +191,7 @@ def _parse_validator(v: dict) -> Validator:
         else None
     )
     return Validator(
-        public_key=add_0x_prefix(v['public_key']),
+        public_key=normalize_public_key(v['public_key']),
         amount=v['amount'],
         deposit_signature=_to_hex_or_none(v.get('deposit_signature')),
         exit_signature=_to_bls_signature_or_none(v.get('exit_signature')),

--- a/src/validators/typings.py
+++ b/src/validators/typings.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass
 from typing import NewType
 
 from eth_typing import BlockNumber, BLSSignature, ChecksumAddress, HexStr
-from eth_utils import add_0x_prefix
 from sw_utils import ValidatorStatus
 from web3 import Web3
 from web3.types import Gwei, Wei
 
+from src.common.typings import normalize_public_key
 from src.config.settings import MIN_ACTIVATION_BALANCE_GWEI, settings
 
 BLSPrivkey = NewType('BLSPrivkey', bytes)
@@ -96,7 +96,7 @@ class ConsensusValidator:
     def from_consensus_data(beacon_validator: dict) -> 'ConsensusValidator':
         return ConsensusValidator(
             index=int(beacon_validator['index']),
-            public_key=add_0x_prefix(beacon_validator['validator']['pubkey']),
+            public_key=normalize_public_key(beacon_validator['validator']['pubkey']),
             balance=Gwei(int(beacon_validator['balance'])),
             withdrawal_credentials=beacon_validator['validator']['withdrawal_credentials'],
             status=ValidatorStatus(beacon_validator['status']),


### PR DESCRIPTION
## Summary

Validator public keys are compared as plain strings — `public_key in keystore`, `self.keys[public_key]`, set membership — but keys entering the app from external sources were not reduced to a common form. Most call sites added the `0x` prefix; none handled case. A key that arrived upper case, or without the prefix, would silently fail to match the 0x-lowercase keys the rest of the codebase produces (beacon API, subgraph, contract events).

Adds `normalize_public_key` in `src/common/typings.py` and applies it wherever a public key enters the app:

```python
def normalize_public_key(public_key: str) -> HexStr:
    return add_0x_prefix(HexStr(public_key.lower()))
```

## Entry points covered

| Location | Source of the key | Previously |
| --- | --- | --- |
| `keystores/remote.py` | remote signer `publicKeys` response | no normalization at all |
| `keystores/hashi_vault.py` | vault secret labels and URL path segments | prefix only |
| `keystores/local.py` `parse_keystore_file` | keystore JSON `pubkey` field | prefix only |
| `validators/typings.py` `from_consensus_data` | beacon API | prefix only |
| `common/validators.py` | `--target-public-key`, `--source-public-keys` CLI args | returned verbatim |
| `commands/consolidate.py` `_load_public_keys` | `--source-public-keys-file`, `--exclude-public-keys-file` | prefix only |
| `validators/relayer.py` `_parse_validator` | relayer service response | prefix only |

`LocalKeystore.load()` is left alone: it derives the key with `Web3.to_hex(bls.SkToPk(...))`, which is already 0x-lowercase by construction.

## Impact

- `HashiKeys.__setitem__` raises on duplicate keys to prevent slashing, but the check was case sensitive: the same key stored under `0xAB…` and `0xab…` in two vault paths was not flagged. The identity check right above it uses `Web3.to_bytes(hexstr=pk)`, which is case insensitive, so a mixed-case label passed validation and then entered the dict unnormalized.
- `exclude_public_keys` is used as a set for exclusion in `consolidate`. An upper case key in that file would silently fail to exclude a validator the operator meant to skip.
- `public_key in keystore` in `exits/tasks.py` would put the validator into `failed_indexes`, so its exit signature would never rotate.

## Behavior change

In `common/validators.py` normalization now runs **before** `_is_public_key`, which checks `len(value) == 98` and so assumes the `0x` prefix. Unprefixed keys passed on the command line are therefore accepted now, where they were previously rejected as invalid. This matches `_load_public_keys`, which already prefixed whatever the file contained. The error message for an invalid key in a file still shows the raw line as typed.

## Tests

- New `src/validators/keystores/tests/test_normalization.py`: the helper itself, remote signer load, and a Hashi Vault key labeled upper case without the prefix (new stub endpoint in the shared fixture).
- New `test_validate_public_keys_normalization` covers the three CLI validators against upper case, unprefixed, and unprefixed upper case input.

Both were verified to fail without the corresponding fix.
