### PR TITLE
Verify remote signer deposit signatures

### DIFF
--- a/src/validators/keystores/remote.py
+++ b/src/validators/keystores/remote.py
@@ -99,8 +99,9 @@ class RemoteSignerKeystore(BaseKeystore):
     ) -> dict:
         fork_version = NETWORKS[settings.network].GENESIS_FORK_VERSION
         withdrawal_credentials = get_withdrawal_credentials()
+        public_key_bytes = BLSPubkey(Web3.to_bytes(hexstr=public_key))
         signing_root = self._get_deposit_signing_root(
-            public_key=BLSPubkey(Web3.to_bytes(hexstr=public_key)),
+            public_key=public_key_bytes,
             withdrawal_credentials=withdrawal_credentials,
             amount=amount,
             fork_version=fork_version,
@@ -112,7 +113,9 @@ class RemoteSignerKeystore(BaseKeystore):
             signing_root=signing_root,
             fork_version=fork_version,
         )
-        public_key_bytes = Web3.to_bytes(hexstr=public_key)
+        if not bls.Verify(public_key_bytes, signing_root, signature):
+            raise RuntimeError(f'Deposit signature verification failed for public_key={public_key}')
+
         deposit_data = SerializableDepositData(
             pubkey=public_key_bytes,
             withdrawal_credentials=withdrawal_credentials,

--- a/src/validators/keystores/tests/test_remote.py
+++ b/src/validators/keystores/tests/test_remote.py
@@ -1,0 +1,68 @@
+import re
+from typing import Callable
+
+import milagro_bls_binding as bls
+import pytest
+from aioresponses import CallbackResult, aioresponses
+from eth_typing import BLSPubkey
+from web3 import Web3
+
+from src.config.networks import NETWORKS
+from src.config.settings import settings
+from src.validators.keystores.remote import RemoteSignerKeystore
+from src.validators.utils import get_withdrawal_credentials
+
+
+class TestRemoteSignerGetDepositData:
+    @pytest.mark.usefixtures('fake_settings')
+    async def test_get_deposit_data(
+        self,
+        remote_signer_keystore: RemoteSignerKeystore,
+    ):
+        public_key = remote_signer_keystore.public_keys[0]
+        amount = 32_000_000_000
+
+        deposit_data = await remote_signer_keystore.get_deposit_data(
+            public_key=public_key, amount=amount
+        )
+
+        public_key_bytes = BLSPubkey(Web3.to_bytes(hexstr=public_key))
+        signing_root = remote_signer_keystore._get_deposit_signing_root(
+            public_key=public_key_bytes,
+            withdrawal_credentials=get_withdrawal_credentials(),
+            amount=amount,
+            fork_version=NETWORKS[settings.network].GENESIS_FORK_VERSION,
+        )
+
+        assert deposit_data['pubkey'] == public_key_bytes
+        assert bls.Verify(public_key_bytes, signing_root, deposit_data['signature'])
+
+    @pytest.mark.usefixtures('fake_settings')
+    async def test_get_deposit_data_wrong_signature(
+        self,
+        remote_signer_url: str,
+        create_validator_keypair: Callable,
+    ):
+        _, public_key = create_validator_keypair()
+        wrong_private_key, wrong_public_key = create_validator_keypair()
+        # create_validator_keypair draws a random index from a fixed mnemonic
+        assert wrong_public_key != public_key
+
+        def _mocked_sign_endpoint(url, **kwargs) -> CallbackResult:
+            signature = bls.Sign(
+                wrong_private_key, Web3.to_bytes(hexstr=kwargs['json']['signing_root'])
+            )
+            return CallbackResult(payload={'signature': f'0x{signature.hex()}'})
+
+        settings.remote_signer_url = remote_signer_url
+        keystore = RemoteSignerKeystore([public_key])
+
+        with aioresponses() as mocked_responses:
+            mocked_responses.post(
+                re.compile(f'^{remote_signer_url}/api/v1/eth2/sign/\\w{{98}}$'),
+                callback=_mocked_sign_endpoint,
+                repeat=True,
+            )
+
+            with pytest.raises(RuntimeError, match='Deposit signature verification failed'):
+                await keystore.get_deposit_data(public_key=public_key, amount=32_000_000_000)


### PR DESCRIPTION
## Description

`RemoteSignerKeystore.get_deposit_data` used the deposit signature returned by the remote signer without checking it. A wrong-key or malformed signature would be embedded into the deposit data and submitted for oracle approval, where it is rejected, stalling validator registration.

The signature is now verified with `bls.Verify` against the locally computed deposit signing root before the deposit data is built, and a `RuntimeError` is raised on mismatch. This mirrors the existing check in `get_exit_signature`.