### PR TITLE
Remove stale web3signer key files on export; fix disable-validators env var names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,9 +78,11 @@ CONSENSUS_ENDPOINTS=http://localhost:3500
 # FEE_SPLITTER_INTERVAL=86400
 # FEE_SPLITTER_MIN_ASSETS=1000000000000000
 
-# Disable new validator registrations and funding for registered validators.
-# Default is False
-# DISABLE_VALIDATOR_REGISTRATIONS=false
+# Disable registration of new validators. Default is False
+# DISABLE_VALIDATORS_REGISTRATION=false
+
+# Disable funding of existing 0x02 (compounding) validators. Default is False
+# DISABLE_VALIDATORS_FUNDING=false
 
 # Disable submitting validator withdrawals through the vault contract.
 # Default is False

--- a/src/remote_db/tasks.py
+++ b/src/remote_db/tasks.py
@@ -99,6 +99,11 @@ def setup_web3signer(db_url: str, b64_encrypt_key: str, output_dir: Path) -> Non
     if not output_dir.exists():
         output_dir.mkdir(parents=True, exist_ok=True)
 
+    # Remove key files from a previous, larger export before writing the current set -
+    # otherwise Web3Signer would keep loading keys the operator believes were removed.
+    for filepath in output_dir.glob('key_*.yaml'):
+        filepath.unlink()
+
     sorted_private_keys = sorted(list(private_keys))
     for index, private_key in enumerate(sorted_private_keys):
         filename = f'key_{index}.yaml'

--- a/src/remote_db/tests/test_commands.py
+++ b/src/remote_db/tests/test_commands.py
@@ -199,6 +199,60 @@ class TestRemoteDbSetupWeb3Signer:
             output = 'Successfully retrieved web3signer private keys from the database.\n'
             assert output.strip() in result.output.strip()
 
+    def test_setup_web3signer_removes_stale_keys_on_shrink(
+        self,
+        data_dir: Path,
+        vault_address: HexAddress,
+        runner: CliRunner,
+        execution_endpoints: str,
+    ):
+        db_url = 'postgresql://user:password@localhost:5432/dbname'
+        encryption_key = '43ueY4nqsiajWHTnkdqrc3OWj2W+t0bbdBISJFjZ3Ck='
+
+        args = [
+            '--db-url',
+            db_url,
+            '--vault',
+            vault_address,
+            '--data-dir',
+            str(data_dir),
+            'setup-web3signer',
+            '--output-dir',
+            './web3signer',
+            '--encrypt-key',
+            encryption_key,
+        ]
+        keypairs = _get_remote_db_keypairs(base64.b64decode(encryption_key), total_validators=3)
+
+        with (
+            runner.isolated_filesystem(),
+            mock.patch.object(KeyPairsCrud, 'get_first_keypair', return_value=keypairs[0]),
+            mock.patch.object(KeyPairsCrud, 'get_keypairs', return_value=keypairs),
+        ):
+            result = runner.invoke(remote_db_group, args)
+            assert result.exit_code == 0
+
+            web3signer_dir = Path('./web3signer')
+            assert (web3signer_dir / 'key_0.yaml').exists()
+            assert (web3signer_dir / 'key_1.yaml').exists()
+            assert (web3signer_dir / 'key_2.yaml').exists()
+
+            other_filepath = web3signer_dir / 'other.txt'
+            other_filepath.write_text('unrelated file')
+
+            with (
+                mock.patch.object(KeyPairsCrud, 'get_first_keypair', return_value=keypairs[0]),
+                mock.patch.object(KeyPairsCrud, 'get_keypairs', return_value=keypairs[:1]),
+            ):
+                result = runner.invoke(remote_db_group, args)
+                assert result.exit_code == 0
+
+            assert (web3signer_dir / 'key_0.yaml').exists()
+            assert not (web3signer_dir / 'key_1.yaml').exists()
+            assert not (web3signer_dir / 'key_2.yaml').exists()
+            assert sorted(web3signer_dir.glob('key_*.yaml')) == [web3signer_dir / 'key_0.yaml']
+            assert other_filepath.exists()
+
 
 @pytest.mark.usefixtures(
     '_patch_check_db_connection',


### PR DESCRIPTION
## Description

### Remove stale web3signer key files on export

`setup-web3signer` wrote the decrypted keys as positional files `key_0.yaml`, `key_1.yaml`, ... but never removed files from an earlier, larger export. If the key set shrank, the leftover `key_N.yaml` files stayed on disk and Web3Signer kept loading and signing with keys the operator believed were removed. The command now deletes the existing `key_*.yaml` files before writing the current set, so the output directory holds exactly the current keys (unrelated files in the directory are left untouched).

### Fix disable-validators env var names in example

`.env.example` documented `DISABLE_VALIDATOR_REGISTRATIONS`, a name the code never reads (the option's env var is `DISABLE_VALIDATORS_REGISTRATION`), under a comment that also claimed the single switch covered funding. An operator following the example could believe registration was paused when it was not. The example now lists both real, correctly spelled variables with accurate descriptions: `DISABLE_VALIDATORS_REGISTRATION` and the previously undocumented `DISABLE_VALIDATORS_FUNDING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)