### PR TITLE
Pass chain_id to complex_protocol_list request

### DIFF
--- a/src/common/clients.py
+++ b/src/common/clients.py
@@ -149,8 +149,9 @@ def build_ipfs_upload_clients() -> IpfsMultiUploadClient:
 
     if not clients:
         raise ValueError(
-            'No IPFS client settings configured. '
-            'Please provide IPFS_LOCAL_CLIENT_ENDPOINT or third party IPFS services settings.'
+            'IPFS upload client is not configured. '
+            'Set IPFS_LOCAL_CLIENT_ENDPOINT to upload via a local IPFS node, '
+            'or set both IPFS_PINATA_API_KEY and IPFS_PINATA_SECRET_KEY to upload via Pinata.'
         )
     return IpfsMultiUploadClient(clients)
 

--- a/src/redemptions/api_client.py
+++ b/src/redemptions/api_client.py
@@ -52,6 +52,7 @@ class APIClient:
         url = urljoin(self.base_url, 'v1/user/complex_protocol_list')
         params = {
             'id': address,
+            'chain_id': self.api_chain,
         }
 
         protocol_data = await self._fetch_json(url, params=params)


### PR DESCRIPTION
## Description

- Pass `chain_id` in the `v1/user/complex_protocol_list` request so the API returns positions only for the configured network instead of all chains.
- Clarify the error raised when no IPFS upload client is configured: it now names the exact env vars for each option (local IPFS node or Pinata).