### PR TITLE
Add oracle config checkpoints

### DIFF
--- a/src/commands/start/startup_check.py
+++ b/src/commands/start/startup_check.py
@@ -69,7 +69,7 @@ async def startup_checks() -> None:
         logger.info('Checking graph nodes %s...', settings.graph_endpoint)
         await wait_for_graph_node_sync_to_chain_head()
 
-    logger.info('Checking oracles config...')
+    logger.info('Checking event logs...')
     await check_events_logs()
 
     logger.info('Checking vault address %s...', settings.vault)

--- a/src/common/protocol_config.py
+++ b/src/common/protocol_config.py
@@ -4,6 +4,7 @@ from typing import cast
 from eth_typing import BlockNumber
 from sw_utils import ProtocolConfig, build_protocol_config
 from web3 import Web3
+from web3.types import EventData
 
 from src.common.app_state import AppState, OraclesCache
 from src.common.clients import execution_client, ipfs_fetch_client
@@ -33,24 +34,27 @@ async def update_oracles_cache() -> None:
     app_state = AppState()
     oracles_cache = app_state.oracles_cache
 
-    # Find the latest block for which oracle config is cached
-    if oracles_cache:
-        from_block = BlockNumber(oracles_cache.checkpoint_block + 1)
-    else:
-        from_block = settings.network_config.KEEPER_GENESIS_BLOCK
-
     to_block = await execution_client.eth.get_block_number()
 
-    if from_block > to_block:
-        return
+    if oracles_cache:
+        # Warm cache: only scan blocks added since the last checkpoint.
+        if oracles_cache.checkpoint_block >= to_block:
+            return
 
-    logger.debug('update_oracles_cache: get logs from block %s to block %s', from_block, to_block)
-    event = await keeper_contract.get_config_updated_event(from_block=from_block, to_block=to_block)
-    if event:
-        ipfs_hash = event['args']['configIpfsHash']
-        config = cast(dict, await ipfs_fetch_client.fetch_json(ipfs_hash))
+        from_block = BlockNumber(oracles_cache.checkpoint_block + 1)
+        logger.debug(
+            'update_oracles_cache: get logs from block %s to block %s', from_block, to_block
+        )
+        event = await keeper_contract.get_config_updated_event(
+            from_block=from_block, to_block=to_block
+        )
+        config = await _fetch_config(event) if event else oracles_cache.config
     else:
-        config = oracles_cache.config  # type: ignore
+        # Cold cache: start from the release checkpoint instead of the keeper genesis block.
+        event = await _get_config_updated_event_since_checkpoint(to_block=to_block)
+        if not event:
+            raise ValueError('Failed to fetch IPFS hash of oracles config')
+        config = await _fetch_config(event)
 
     rewards_threshold_call = keeper_contract.encode_abi(fn_name='rewardsMinOracles', args=[])
     validators_threshold_call = keeper_contract.encode_abi(fn_name='validatorsMinOracles', args=[])
@@ -70,3 +74,31 @@ async def update_oracles_cache() -> None:
         rewards_threshold=rewards_threshold,
         checkpoint_block=to_block,
     )
+
+
+async def _get_config_updated_event_since_checkpoint(to_block: BlockNumber) -> EventData | None:
+    """
+    Cold cache lookup. Scans from the checkpoint to avoid re-scanning the whole
+    history, and falls back to the last known event block when nothing is newer.
+    """
+    network_config = settings.network_config
+    from_block = BlockNumber(network_config.CONFIG_UPDATE_CHECKPOINT_BLOCK + 1)
+
+    if from_block <= to_block:
+        logger.debug(
+            'update_oracles_cache: get logs from block %s to block %s', from_block, to_block
+        )
+        event = await keeper_contract.get_config_updated_event(
+            from_block=from_block, to_block=to_block
+        )
+        if event:
+            return event
+
+    last_event_block = network_config.CONFIG_UPDATE_LAST_EVENT_BLOCK
+    return await keeper_contract.get_config_updated_event(
+        from_block=last_event_block, to_block=last_event_block
+    )
+
+
+async def _fetch_config(event: EventData) -> dict:
+    return cast(dict, await ipfs_fetch_client.fetch_json(event['args']['configIpfsHash']))

--- a/src/common/startup_check.py
+++ b/src/common/startup_check.py
@@ -25,11 +25,7 @@ from web3.exceptions import BadFunctionCallOutput
 import src
 from src.common.clients import OPERATOR_USER_AGENT
 from src.common.clients import execution_client as default_execution_client
-from src.common.contracts import (
-    VaultContract,
-    keeper_contract,
-    validators_registry_contract,
-)
+from src.common.contracts import VaultContract, validators_registry_contract
 from src.common.execution import get_finalized_block_number
 from src.common.harvest import get_harvest_params
 from src.common.protocol_config import get_protocol_config
@@ -425,15 +421,6 @@ async def check_operator_version() -> None:
 
 async def check_events_logs() -> None:
     """Check that EL client didn't prune logs"""
-    events = await keeper_contract.events.ConfigUpdated.get_logs(
-        from_block=settings.network_config.CONFIG_UPDATE_EVENT_BLOCK,
-        to_block=settings.network_config.CONFIG_UPDATE_EVENT_BLOCK,
-    )
-    if not events:
-        raise ValueError(
-            "Can't find oracle config. Please, ensure that EL client didn't prune event logs."
-        )
-
     events = await validators_registry_contract.events.DepositEvent.get_logs(
         from_block=settings.network_config.GENESIS_VALIDATORS_LAST_BLOCK,
         to_block=settings.network_config.GENESIS_VALIDATORS_LAST_BLOCK,

--- a/src/common/tests/test_protocol_config.py
+++ b/src/common/tests/test_protocol_config.py
@@ -1,0 +1,206 @@
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from eth_typing import BlockNumber
+from web3.types import EventData
+
+from src.common.app_state import AppState, OraclesCache
+from src.common.protocol_config import (
+    _get_config_updated_event_since_checkpoint,
+    update_oracles_cache,
+)
+from src.config.settings import settings
+
+
+@pytest.mark.usefixtures('fake_settings')
+class TestGetConfigUpdatedEventSinceCheckpoint:
+    async def test_returns_recent_event(self):
+        """An event after the checkpoint is returned without the fallback query."""
+        expected_event = _config_event('hash1')
+
+        with patch(
+            'src.common.protocol_config.keeper_contract.get_config_updated_event',
+            new_callable=AsyncMock,
+            return_value=expected_event,
+        ) as mock_event, _mock_checkpoints():
+            result = await _get_config_updated_event_since_checkpoint(to_block=BlockNumber(100000))
+
+        assert result is expected_event
+        mock_event.assert_awaited_once_with(
+            from_block=BlockNumber(90001), to_block=BlockNumber(100000)
+        )
+
+    async def test_falls_back_to_last_event_block(self):
+        """With no event since the checkpoint, the last known event block is queried."""
+        last_event = _config_event('last')
+
+        with patch(
+            'src.common.protocol_config.keeper_contract.get_config_updated_event',
+            new_callable=AsyncMock,
+            side_effect=[None, last_event],
+        ) as mock_event, _mock_checkpoints():
+            result = await _get_config_updated_event_since_checkpoint(to_block=BlockNumber(100000))
+
+        assert result is last_event
+        assert mock_event.await_args_list == [
+            call(from_block=BlockNumber(90001), to_block=BlockNumber(100000)),
+            call(from_block=BlockNumber(80000), to_block=BlockNumber(80000)),
+        ]
+
+    async def test_node_behind_checkpoint_skips_scan(self):
+        """Node lagging behind the checkpoint queries the last event block only."""
+        last_event = _config_event('last')
+
+        with patch(
+            'src.common.protocol_config.keeper_contract.get_config_updated_event',
+            new_callable=AsyncMock,
+            return_value=last_event,
+        ) as mock_event, _mock_checkpoints():
+            result = await _get_config_updated_event_since_checkpoint(to_block=BlockNumber(85000))
+
+        assert result is last_event
+        mock_event.assert_awaited_once_with(
+            from_block=BlockNumber(80000), to_block=BlockNumber(80000)
+        )
+
+
+@pytest.mark.usefixtures('fake_settings', 'setup_test_clients')
+class TestUpdateOraclesCache:
+    def setup_method(self) -> None:
+        # AppState is a process-wide singleton; reset the cache between tests.
+        AppState().oracles_cache = None
+
+    async def test_cold_cache_fetches_and_populates(self):
+        with _mock_block_number(BlockNumber(100)), patch(
+            'src.common.protocol_config._get_config_updated_event_since_checkpoint',
+            new_callable=AsyncMock,
+            return_value=_config_event('hash1'),
+        ) as mock_event, patch(
+            'src.common.protocol_config.ipfs_fetch_client.fetch_json',
+            new_callable=AsyncMock,
+            return_value={'k': 'v1'},
+        ) as mock_fetch, self._mock_thresholds():
+            await update_oracles_cache()
+
+        # Cold path: delegates to the checkpoint-aware lookup.
+        mock_event.assert_awaited_once_with(to_block=BlockNumber(100))
+        mock_fetch.assert_awaited_once_with('hash1')
+
+        oracles_cache = AppState().oracles_cache
+        assert oracles_cache.checkpoint_block == BlockNumber(100)
+        assert oracles_cache.config == {'k': 'v1'}
+        assert oracles_cache.rewards_threshold == 3
+        assert oracles_cache.validators_threshold == 5
+
+    async def test_cold_cache_no_event_raises(self):
+        with _mock_block_number(BlockNumber(100)), patch(
+            'src.common.protocol_config._get_config_updated_event_since_checkpoint',
+            new_callable=AsyncMock,
+            return_value=None,
+        ), pytest.raises(ValueError, match='Failed to fetch IPFS hash of oracles config'):
+            await update_oracles_cache()
+
+    async def test_warm_cache_no_new_event_reuses_config(self):
+        AppState().oracles_cache = OraclesCache(
+            checkpoint_block=BlockNumber(100),
+            config={'k': 'cached'},
+            validators_threshold=5,
+            rewards_threshold=3,
+        )
+
+        with _mock_block_number(BlockNumber(105)), patch(
+            'src.common.protocol_config.keeper_contract.get_config_updated_event',
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_event, patch(
+            'src.common.protocol_config.ipfs_fetch_client.fetch_json', new_callable=AsyncMock
+        ) as mock_fetch, self._mock_thresholds():
+            await update_oracles_cache()
+
+        # Warm path: incremental scan only, no IPFS fetch when nothing changed.
+        mock_event.assert_awaited_once_with(from_block=BlockNumber(101), to_block=BlockNumber(105))
+        mock_fetch.assert_not_awaited()
+
+        oracles_cache = AppState().oracles_cache
+        assert oracles_cache.checkpoint_block == BlockNumber(105)
+        assert oracles_cache.config == {'k': 'cached'}
+
+    async def test_warm_cache_new_event_refetches(self):
+        AppState().oracles_cache = OraclesCache(
+            checkpoint_block=BlockNumber(100),
+            config={'k': 'old'},
+            validators_threshold=5,
+            rewards_threshold=3,
+        )
+
+        with _mock_block_number(BlockNumber(110)), patch(
+            'src.common.protocol_config.keeper_contract.get_config_updated_event',
+            new_callable=AsyncMock,
+            return_value=_config_event('hash2'),
+        ) as mock_event, patch(
+            'src.common.protocol_config.ipfs_fetch_client.fetch_json',
+            new_callable=AsyncMock,
+            return_value={'k': 'new'},
+        ) as mock_fetch, self._mock_thresholds():
+            await update_oracles_cache()
+
+        mock_event.assert_awaited_once_with(from_block=BlockNumber(101), to_block=BlockNumber(110))
+        mock_fetch.assert_awaited_once_with('hash2')
+
+        oracles_cache = AppState().oracles_cache
+        assert oracles_cache.checkpoint_block == BlockNumber(110)
+        assert oracles_cache.config == {'k': 'new'}
+
+    async def test_warm_cache_no_new_block_skips_scan(self):
+        AppState().oracles_cache = OraclesCache(
+            checkpoint_block=BlockNumber(100),
+            config={'k': 'cached'},
+            validators_threshold=5,
+            rewards_threshold=3,
+        )
+
+        with _mock_block_number(BlockNumber(100)), patch(
+            'src.common.protocol_config.keeper_contract.get_config_updated_event',
+            new_callable=AsyncMock,
+        ) as mock_event, patch(
+            'src.common.protocol_config.ipfs_fetch_client.fetch_json', new_callable=AsyncMock
+        ) as mock_fetch, self._mock_thresholds():
+            await update_oracles_cache()
+
+        mock_event.assert_not_awaited()
+        mock_fetch.assert_not_awaited()
+
+        oracles_cache = AppState().oracles_cache
+        assert oracles_cache.checkpoint_block == BlockNumber(100)
+        assert oracles_cache.config == {'k': 'cached'}
+
+    @staticmethod
+    def _mock_thresholds():
+        return patch(
+            'src.common.protocol_config.multicall_contract.aggregate',
+            new_callable=AsyncMock,
+            return_value=(None, [(3).to_bytes(32, 'big'), (5).to_bytes(32, 'big')]),
+        )
+
+
+def _config_event(ipfs_hash: str) -> EventData:
+    return EventData(
+        event='ConfigUpdated',
+        args={'configIpfsHash': ipfs_hash},
+        blockNumber=BlockNumber(0),
+    )
+
+
+def _mock_block_number(block_number: BlockNumber):
+    client = MagicMock()
+    client.eth.get_block_number = AsyncMock(return_value=block_number)
+    return patch('src.common.protocol_config.execution_client', client)
+
+
+def _mock_checkpoints():
+    """Pins the checkpoint / last event blocks of the network config."""
+    return patch.multiple(
+        settings.network_config,
+        CONFIG_UPDATE_CHECKPOINT_BLOCK=BlockNumber(90000),
+        CONFIG_UPDATE_LAST_EVENT_BLOCK=BlockNumber(80000),
+    )

--- a/src/config/networks.py
+++ b/src/config/networks.py
@@ -40,7 +40,9 @@ class NetworkConfig(BaseNetworkConfig):
     STAKEWISE_REST_API_URL: str
     STAKEWISE_GRAPH_ENDPOINT: str
     RATED_API_URL: str
-    CONFIG_UPDATE_EVENT_BLOCK: BlockNumber
+    # Newest known `ConfigUpdated` event, and a block with no newer event up to it.
+    CONFIG_UPDATE_LAST_EVENT_BLOCK: BlockNumber
+    CONFIG_UPDATE_CHECKPOINT_BLOCK: BlockNumber
     OS_TOKEN_REDEEMER_GENESIS_BLOCK: BlockNumber
     MAX_FEE_PER_GAS_GWEI: Gwei
     MAX_VALIDATOR_BALANCE_GWEI: Gwei
@@ -111,7 +113,8 @@ NETWORKS: dict[str, NetworkConfig] = {
             'https://graphs.stakewise.io/mainnet/subgraphs/name/stakewise/prod'
         ),
         RATED_API_URL='https://api.rated.network',
-        CONFIG_UPDATE_EVENT_BLOCK=BlockNumber(21471524),
+        CONFIG_UPDATE_LAST_EVENT_BLOCK=BlockNumber(25093055),
+        CONFIG_UPDATE_CHECKPOINT_BLOCK=BlockNumber(25934000),
         OS_TOKEN_REDEEMER_GENESIS_BLOCK=BlockNumber(24923158),
         MAX_FEE_PER_GAS_GWEI=Gwei(10),
         MAX_VALIDATOR_BALANCE_GWEI=Gwei(int(Web3.from_wei(Web3.to_wei(300, 'ether'), 'gwei'))),
@@ -162,7 +165,8 @@ NETWORKS: dict[str, NetworkConfig] = {
         STAKEWISE_REST_API_URL='https://hoodi-api.stakewise.io',
         STAKEWISE_GRAPH_ENDPOINT='https://graphs.stakewise.io/hoodi/subgraphs/name/stakewise/prod',
         RATED_API_URL='https://api.rated.network',
-        CONFIG_UPDATE_EVENT_BLOCK=BlockNumber(94090),
+        CONFIG_UPDATE_LAST_EVENT_BLOCK=BlockNumber(1279009),
+        CONFIG_UPDATE_CHECKPOINT_BLOCK=BlockNumber(3584000),
         OS_TOKEN_REDEEMER_GENESIS_BLOCK=BlockNumber(2657589),
         MAX_FEE_PER_GAS_GWEI=Gwei(10),
         MAX_VALIDATOR_BALANCE_GWEI=Gwei(int(Web3.from_wei(Web3.to_wei(300, 'ether'), 'gwei'))),
@@ -215,7 +219,8 @@ NETWORKS: dict[str, NetworkConfig] = {
             'https://graphs.stakewise.io/gnosis/subgraphs/name/stakewise/prod'
         ),
         RATED_API_URL='https://api.rated.network',
-        CONFIG_UPDATE_EVENT_BLOCK=BlockNumber(37640206),
+        CONFIG_UPDATE_LAST_EVENT_BLOCK=BlockNumber(42392284),
+        CONFIG_UPDATE_CHECKPOINT_BLOCK=BlockNumber(48148000),
         OS_TOKEN_REDEEMER_GENESIS_BLOCK=BlockNumber(45773287),
         MAX_FEE_PER_GAS_GWEI=Gwei(2),
         MAX_VALIDATOR_BALANCE_GWEI=Gwei(int(Web3.from_wei(Web3.to_wei(1800, 'ether'), 'gwei'))),


### PR DESCRIPTION
Speeds up the cold-start lookup of the oracles config and stops forcing operators to keep ancient event logs.

## Oracle config checkpoints

`NetworkConfig` gets two new fields, mirroring [v3-keeper](https://github.com/stakewise/v3-keeper):

- `CONFIG_UPDATE_LAST_EVENT_BLOCK` — the newest known `ConfigUpdated` event block
- `CONFIG_UPDATE_CHECKPOINT_BLOCK` — a block with no newer `ConfigUpdated` event up to it

| network | last event | checkpoint |
| --- | --- | --- |
| mainnet | 25093055 | 25934000 |
| hoodi | 1279009 | 3584000 |
| gnosis | 42392284 | 48148000 |

The last-event blocks were verified on-chain with the repo's own backward scanner (`keeper_contract.get_config_updated_event`) against each network's finalized head.

## `update_oracles_cache`

The cold-cache path now starts from the checkpoint instead of `KEEPER_GENESIS_BLOCK`: it scans `CONFIG_UPDATE_CHECKPOINT_BLOCK + 1 → head`, and when nothing newer turns up (the normal case) reads the single `CONFIG_UPDATE_LAST_EVENT_BLOCK`. On mainnet that replaces a ~7.5M-block scan with ~840k blocks plus one single-block query. If the node is behind the checkpoint, the scan is skipped and only the last-event block is queried.

Missing config now raises `ValueError('Failed to fetch IPFS hash of oracles config')`; previously that path dereferenced a `None` cache and died with an `AttributeError`.

The warm-cache path is unchanged: incremental scan from `checkpoint_block + 1`, early return when the head has not advanced.

## Removed legacy `CONFIG_UPDATE_EVENT_BLOCK`

The `ConfigUpdated` half of `check_events_logs()` is gone, along with the `CONFIG_UPDATE_EVENT_BLOCK` field. `ConfigUpdated` is a rare event, so the check required operators to retain logs from an arbitrarily old block. The `DepositEvent` half of the check stays.
