### PR TITLE
Add exit signatures checkpoint to network config

### DIFF
--- a/src/config/networks.py
+++ b/src/config/networks.py
@@ -73,6 +73,11 @@ class CheckpointsConfig:
     # events up to `VAULT_VALIDATORS_LAST_BLOCK`. 72-byte records.
     VAULT_VALIDATORS_IPFS_HASH: str
     VAULT_VALIDATORS_LAST_BLOCK: BlockNumber
+    # Starting point for scanning `ExitSignaturesUpdated` events, and the last event
+    # block to assume before it. None deliberately: older events (legacy rotations)
+    # are long finalized and synced by oracles, so they don't gate a new rotation.
+    EXIT_SIGNATURES_LAST_EVENT_BLOCK: BlockNumber | None
+    EXIT_SIGNATURES_CHECKPOINT_BLOCK: BlockNumber
 
 
 @dataclass
@@ -133,6 +138,8 @@ NETWORKS: dict[str, NetworkConfig] = {
                 'bafybeigywptyz3lo7pb4rby2gwagdamyeahw2yklijupwfxqjjzfuqebpm'
             ),
             VAULT_VALIDATORS_LAST_BLOCK=BlockNumber(25934000),
+            EXIT_SIGNATURES_LAST_EVENT_BLOCK=None,
+            EXIT_SIGNATURES_CHECKPOINT_BLOCK=BlockNumber(25934000),
         ),
         OS_TOKEN_REDEEMER_GENESIS_BLOCK=BlockNumber(24923158),
         MAX_FEE_PER_GAS_GWEI=Gwei(10),
@@ -191,6 +198,8 @@ NETWORKS: dict[str, NetworkConfig] = {
                 'bafkreihalltsgohglgsphglrbmbcnvbuohgwfqa5r5wnnsgiic53zpkliy'
             ),
             VAULT_VALIDATORS_LAST_BLOCK=BlockNumber(3584000),
+            EXIT_SIGNATURES_LAST_EVENT_BLOCK=None,
+            EXIT_SIGNATURES_CHECKPOINT_BLOCK=BlockNumber(3584000),
         ),
         OS_TOKEN_REDEEMER_GENESIS_BLOCK=BlockNumber(2657589),
         MAX_FEE_PER_GAS_GWEI=Gwei(10),
@@ -251,6 +260,8 @@ NETWORKS: dict[str, NetworkConfig] = {
                 'bafybeicl67j5kcvn5lzhydi5pmp5wjnot23topveijwggodb2ueay2qk5a'
             ),
             VAULT_VALIDATORS_LAST_BLOCK=BlockNumber(48148000),
+            EXIT_SIGNATURES_LAST_EVENT_BLOCK=None,
+            EXIT_SIGNATURES_CHECKPOINT_BLOCK=BlockNumber(48148000),
         ),
         OS_TOKEN_REDEEMER_GENESIS_BLOCK=BlockNumber(45773287),
         MAX_FEE_PER_GAS_GWEI=Gwei(2),

--- a/src/exits/tasks.py
+++ b/src/exits/tasks.py
@@ -114,13 +114,16 @@ async def _fetch_last_update_block() -> BlockNumber | None:
     app_state = AppState()
     update_cache = app_state.exit_signature_update_cache
 
-    from_block: BlockNumber | None = None
-    if (checkpoint_block := update_cache.checkpoint_block) is not None:
-        from_block = BlockNumber(checkpoint_block + 1)
+    if update_cache.checkpoint_block is None:
+        # Cold cache: start from the release checkpoint instead of the keeper genesis block.
+        checkpoints = settings.network_config.CHECKPOINTS
+        update_cache.checkpoint_block = checkpoints.EXIT_SIGNATURES_CHECKPOINT_BLOCK
+        update_cache.last_event_block = checkpoints.EXIT_SIGNATURES_LAST_EVENT_BLOCK
 
+    from_block = BlockNumber(update_cache.checkpoint_block + 1)
     to_block = await execution_client.eth.get_block_number()
 
-    if from_block is not None and from_block > to_block:
+    if from_block > to_block:
         return update_cache.last_event_block
 
     last_event = await keeper_contract.get_exit_signatures_updated_event(

--- a/src/exits/tests/test_tasks.py
+++ b/src/exits/tests/test_tasks.py
@@ -9,6 +9,7 @@ import pytest
 from eth_typing import ChecksumAddress
 from sw_utils.typings import ConsensusFork, ProtocolConfig
 
+from src.common.app_state import AppState, ExitSignatureUpdateCache
 from src.common.utils import get_current_timestamp
 from src.config.settings import settings
 from src.exits.tasks import _fetch_last_update_block, _get_oracles_request
@@ -90,7 +91,18 @@ class TestFetchLastExitSignatureUpdateBlock:
     async def test_normal(self):
         get_event_func = 'src.exits.tasks.keeper_contract.get_exit_signatures_updated_event'
         vault_address = settings.vault
-        # no events, checkpoint moved from None to 8
+        # node is behind the checkpoint, no scan
+        with (
+            mock.patch(get_event_func, return_value=None) as get_event_mock,
+            patch_latest_block(5),
+            patch_checkpoints(checkpoint_block=6),
+        ):
+            last_update_block = await _fetch_last_update_block()
+
+        assert last_update_block is None
+        get_event_mock.assert_not_called()
+
+        # no events, checkpoint moved from 6 to 8
         with (
             mock.patch(get_event_func, return_value=None) as get_event_mock,
             patch_latest_block(8),
@@ -98,7 +110,7 @@ class TestFetchLastExitSignatureUpdateBlock:
             last_update_block = await _fetch_last_update_block()
 
         assert last_update_block is None
-        get_event_mock.assert_called_once_with(vault=vault_address, from_block=None, to_block=8)
+        get_event_mock.assert_called_once_with(vault=vault_address, from_block=7, to_block=8)
 
         # no events, checkpoint moved to 9
         with (
@@ -129,6 +141,31 @@ class TestFetchLastExitSignatureUpdateBlock:
 
         assert last_update_block == 11
         get_event_mock.assert_called_once_with(vault=vault_address, from_block=16, to_block=20)
+
+    async def test_cold_cache_uses_checkpoint_last_event(self):
+        get_event_func = 'src.exits.tasks.keeper_contract.get_exit_signatures_updated_event'
+        with (
+            mock.patch(get_event_func, return_value=None) as get_event_mock,
+            patch_latest_block(20),
+            patch_checkpoints(checkpoint_block=10, last_event_block=7),
+        ):
+            last_update_block = await _fetch_last_update_block()
+
+        assert last_update_block == 7
+        get_event_mock.assert_called_once_with(vault=settings.vault, from_block=11, to_block=20)
+
+
+@pytest.fixture(autouse=True)
+def reset_exit_signature_update_cache():
+    AppState().exit_signature_update_cache = ExitSignatureUpdateCache()
+
+
+def patch_checkpoints(checkpoint_block: int, last_event_block: int | None = None):
+    return mock.patch.multiple(
+        settings.network_config.CHECKPOINTS,
+        EXIT_SIGNATURES_CHECKPOINT_BLOCK=checkpoint_block,
+        EXIT_SIGNATURES_LAST_EVENT_BLOCK=last_event_block,
+    )
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Narrows the `ExitSignaturesUpdated` event scan range for operators. Previously, on a cold cache, `_fetch_last_update_block` scanned from `KEEPER_GENESIS_BLOCK` to the chain head.

## Changes

- Add `EXIT_SIGNATURES_LAST_EVENT_BLOCK` and `EXIT_SIGNATURES_CHECKPOINT_BLOCK` to `CheckpointsConfig`. The checkpoint block equals `CONFIG_UPDATE_CHECKPOINT_BLOCK` on all networks.
- `_fetch_last_update_block` seeds its cache from these checkpoints and scans from `EXIT_SIGNATURES_CHECKPOINT_BLOCK + 1`.
- Update tests for `_fetch_last_update_block`.

## Why `EXIT_SIGNATURES_LAST_EVENT_BLOCK` is `None`

A full scan found only legacy events from 2–3 years ago. The last update block only gates rotation on finality and oracle sync, and these old events are long finalized and already synced by oracles. Treating them as absent doesn't change behaviour.
